### PR TITLE
Add a draft .yml for Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: cpp
+compiler:
+  - gcc
+  - clang
+before_script:
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq libeigen3-dev
+script: ./bootstrap && ./configure && make && make check || (cat test-suite.log && false)


### PR DESCRIPTION
This should be a sane default configuration for Travis-CI if you guys want to enable it.  The funky cat test-suite && false bit is to get output from the Automake parallel test runner.
