### PR TITLE
Make get_antioch_version static

### DIFF
--- a/src/utilities/include/antioch/antioch_version.h.in
+++ b/src/utilities/include/antioch/antioch_version.h.in
@@ -51,38 +51,7 @@
 
 namespace Antioch
 {
-  void antioch_version_stdout();
-  int  get_antioch_version();
-
-  template< typename CharT, typename Traits >
-  std::basic_ostream<CharT,Traits>&
-  antioch_version(std::basic_ostream<CharT,Traits> &os)
-  {
-    // A little automatic C-style string concatenation goes a long way.
-    // It also lets using strings(1) on a binary show something useful.
-    return
-    os << "--------------------------------------------------------\n"
-          "antioch Package: Version = " ANTIOCH_LIB_VERSION " ("
-       << get_antioch_version() << ")\n"
-          "\n"
-          ANTIOCH_LIB_RELEASE "\n"
-          "\n"
-          "Build Date   = " ANTIOCH_BUILD_DATE     "\n"
-          "Build Host   = " ANTIOCH_BUILD_HOST     "\n"
-          "Build User   = " ANTIOCH_BUILD_USER     "\n"
-          "Build Arch   = " ANTIOCH_BUILD_ARCH     "\n"
-          "Build Rev    = " ANTIOCH_BUILD_VERSION  "\n"
-          "\n"
-          "C++ Config   = " ANTIOCH_CXX " " ANTIOCH_CXXFLAGS "\n"
-          "--------------------------------------------------------\n";
-  }
-
-  void antioch_version_stdout()
-  {
-    antioch_version(std::cout).flush();
-  }
-
-  int get_antioch_version()
+  static int get_antioch_version()
   {
     /* Note: return format follows the versioning convention xx.yy.zz where
 
@@ -112,6 +81,34 @@ namespace Antioch
 #endif
 
     return major_version*10000 + minor_version*100 + micro_version;
+  }
+
+  template< typename CharT, typename Traits >
+  std::basic_ostream<CharT,Traits>&
+  antioch_version(std::basic_ostream<CharT,Traits> &os)
+  {
+    // A little automatic C-style string concatenation goes a long way.
+    // It also lets using strings(1) on a binary show something useful.
+    return
+    os << "--------------------------------------------------------\n"
+          "antioch Package: Version = " ANTIOCH_LIB_VERSION " ("
+       << get_antioch_version() << ")\n"
+          "\n"
+          ANTIOCH_LIB_RELEASE "\n"
+          "\n"
+          "Build Date   = " ANTIOCH_BUILD_DATE     "\n"
+          "Build Host   = " ANTIOCH_BUILD_HOST     "\n"
+          "Build User   = " ANTIOCH_BUILD_USER     "\n"
+          "Build Arch   = " ANTIOCH_BUILD_ARCH     "\n"
+          "Build Rev    = " ANTIOCH_BUILD_VERSION  "\n"
+          "\n"
+          "C++ Config   = " ANTIOCH_CXX " " ANTIOCH_CXXFLAGS "\n"
+          "--------------------------------------------------------\n";
+  }
+
+  inline void antioch_version_stdout()
+  {
+    antioch_version(std::cout).flush();
   }
 } // end namespace Antioch
 


### PR DESCRIPTION
Also makes antioch_version_stdout inline to avoid -Wunused warnings.
Reorders methods to remove the need for forward declarations.
Closes #35 on private testing.
