### PR TITLE
Forgotten Tref() method definition in VantHoffRate

### DIFF
--- a/src/kinetics/include/antioch/vanthoff_rate.h
+++ b/src/kinetics/include/antioch/vanthoff_rate.h
@@ -236,6 +236,11 @@ namespace Antioch
 
   template<typename CoeffType>
   inline
+  CoeffType VantHoffRate<CoeffType>::Tref() const
+  { return _Tref; }
+
+  template<typename CoeffType>
+  inline
   CoeffType VantHoffRate<CoeffType>::rscale() const
   { return _rscale; }
 


### PR DESCRIPTION
A forgotten method definition, here's the patch.

If no one says anything before next week, I'll rebase then merge, this is pretty minor.
