### PR TITLE
Install specific version of fglrx on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ compiler:
   - clang
 before_script:
   - sudo apt-get update -qq
-  - sudo apt-get install -qq libeigen3-dev fglrx opencl-headers libboost-chrono1.48-dev libboost-date-time1.48-dev libboost-filesystem1.48-dev libboost-system1.48-dev libboost-thread1.48-dev libboost-program-options1.48-dev libboost-test1.48-dev
+  - sudo apt-get install -qq libeigen3-dev fglrx=2:8.960-0ubuntu1 opencl-headers libboost-chrono1.48-dev libboost-date-time1.48-dev libboost-filesystem1.48-dev libboost-system1.48-dev libboost-thread1.48-dev libboost-program-options1.48-dev libboost-test1.48-dev
 script:
   - git clone https://github.com/ddemidov/vexcl
   - ./bootstrap && ./configure --with-vexcl=${PWD}/vexcl


### PR DESCRIPTION
The current version that gets installed automatically is broken in the
sense that it does not work on a CPU in the absence of a GPU (e.g. see
https://travis-ci.org/ddemidov/vexcl/jobs/18265418#L276).

This installs version 2:8.960-0ubuntu1 which does work.
