### PR TITLE
bugfix for memory leak

### DIFF
--- a/src/kinetics/include/antioch/reaction_set.h
+++ b/src/kinetics/include/antioch/reaction_set.h
@@ -70,6 +70,9 @@ namespace Antioch
     unsigned int n_reactions() const;
      
     //! Add a reaction to the system.
+    //
+    // The ownership is transfered to the ReactionSet
+    // object, they are deleted in the desctructor.
     void add_reaction(Reaction<CoeffType>* reaction);
 
     //!


### PR DESCRIPTION
I have no idea why it does not start deleting from the first reaction_rate, it gives a memory leak.

If there is a reason, please tell me. If not, I'll merge it sometimes before next week.
