### PR TITLE
C++11 and git compatibility

### DIFF
--- a/m4/common/config_environment.m4
+++ b/m4/common/config_environment.m4
@@ -6,7 +6,7 @@
 #
 # DESCRIPTION
 #
-#   Queries compile environment and SVN revision for use in configure summary 
+#   Queries compile environment and SVN revision for use in configure summary
 #   and pre-processing macros.
 #
 # LAST MODIFICATION
@@ -31,29 +31,32 @@ BUILD_ARCH=${host}
 BUILD_HOST=${ac_hostname}
 BUILD_DATE=`date +'%F %H:%M'`
 
-# Determine method for querying Source code revisioning (assumes SVN)
+# Determine method for querying Source code revisioning (assumes git)
 
-AC_PATH_PROG(svnquery,svnversion)
+AC_PATH_PROG(gitquery,git)
 
-# svnversion 1.7.x changed the return value for unversioned directories
-if test "x${svnquery}" = "x" || test "`${svnquery} -n $srcdir`" = "exported" || test "`${svnquery} -n $srcdir`" = "Unversioned directory"; then
-   SVN_REVISION="cat $srcdir/dist_version"
-   SVN_CHECKOUT=false
+if (test "x${gitquery}" = "x" -o ! -d $srcdir/.git) ; then
+   GIT_REVISION="external" #"cat $srcdir/dist_version"
+   GIT_CHECKOUT=false
    BUILD_DEVSTATUS="External Release"
 else
-   SVN_REVISION="${svnquery} -n $srcdir"
-   SVN_CHECKOUT=true
+
+   #echo "git revision=`cd $srcdir ; ${gitquery} rev-parse HEAD`"
+   #echo "git branch=`cd $srcdir ; ${gitquery} branch | awk '/^\\* / { print $2 }'`"
+
+   GIT_REVISION="`cd $srcdir ; ${gitquery} rev-parse HEAD`"
+   GIT_CHECKOUT=true
    BUILD_DEVSTATUS="Development Build"
 fi
 
 
-AC_SUBST(SVN_REVISION)
+AC_SUBST(GIT_REVISION)
 AC_SUBST(BUILD_DEVSTATUS)
-AM_CONDITIONAL(SVN_CHECKOUT,test x${SVN_CHECKOUT} = xtrue )
+AM_CONDITIONAL(GIT_CHECKOUT,test x${GIT_CHECKOUT} = xtrue )
 
 # Query current version.
 
-BUILD_VERSION=`${SVN_REVISION}`
+BUILD_VERSION=${GIT_REVISION}
 
 # Versioning info - check local developer version (if checked out)
 
@@ -62,12 +65,12 @@ AC_DEFINE_UNQUOTED([BUILD_ARCH],     "${BUILD_ARCH}",     [Architecture of the b
 AC_DEFINE_UNQUOTED([BUILD_HOST],     "${BUILD_HOST}",     [Build host name])
 AC_DEFINE_UNQUOTED([BUILD_VERSION],  "${BUILD_VERSION}",  [SVN revision])
 AC_DEFINE_UNQUOTED([BUILD_DEVSTATUS],"${BUILD_DEVSTATUS}",[Dev/Release build])
-AC_DEFINE(         [BUILD_DATE],     __DATE__" "__TIME__, [Build date])
+AC_DEFINE(         [BUILD_DATE],     __DATE__ " " __TIME__, [Build date])
 
 AC_SUBST(BUILD_USER)
 AC_SUBST(BUILD_ARCH)
 AC_SUBST(BUILD_HOST)
-AC_SUBST(BUILD_DATE)
+#AC_SUBST(BUILD_DATE)
 AC_SUBST(BUILD_VERSION)
 
 ])

--- a/m4/config_summary.m4
+++ b/m4/config_summary.m4
@@ -28,7 +28,7 @@ echo Build user.................... : $USER
 echo Build host.................... : $BUILD_HOST
 echo Configure date................ : $BUILD_DATE
 echo Build architecture............ : $BUILD_ARCH
-echo SVN revision number........... : $BUILD_VERSION
+echo Revision id................... : $BUILD_VERSION
 echo
 echo Testing Options:
 echo '  'Number of tuples............ : $n_tuples


### PR DESCRIPTION
This is the config_environment from libMesh, modified by Ben Kirk to
query git revision id and by me to avoid a C++11 -Wliteral-suffix
warning
