### PR TITLE
Bugfixes:

### DIFF
--- a/src/units/include/antioch/unit_store.h
+++ b/src/units/include/antioch/unit_store.h
@@ -60,101 +60,113 @@ namespace Antioch{
 
 namespace UnitBaseConstant{
 
-template <typename T = double>
-class UnitBaseStore{
-  public:
-        ~UnitBaseStore(){}
-        UnitBaseStore()
-{
-/* base UnitBase, 
- * UnitBase<T>(string symbol, string name, 
- * double a, double b, 
- * int m, int kg = 0, int s = 0, int A = 0, int K = 0, int mol = 0, int cd = 0, int rad = 0)
- */
-store.push_back(UnitBase<T>("m",  "meter",   1.0L,0.,1));
-store.push_back(UnitBase<T>("kg", "kilogram",1.0L,0.,0,1));
-store.push_back(UnitBase<T>("s",  "second",  1.0L,0.,0,0,1));
-store.push_back(UnitBase<T>("A",  "ampere",  1.0L,0.,0,0,0,1));
-store.push_back(UnitBase<T>("K",  "kelvin",  1.0L,0.,0,0,0,0,1));
-store.push_back(UnitBase<T>("mol","mole",    1.0L,0.,0,0,0,0,0,1));
-store.push_back(UnitBase<T>("cd", "candela", 1.0L,0.,0,0,0,0,0,0,1));
-store.push_back(UnitBase<T>("rad","radian",  1.0L,0.,0,0,0,0,0,0,0,1));
-/* others known Units using constructor 
- * UnitBase<T>(string symbol, string name, 
- * double a, double b, 
- * int m, int kg=0, int s=0, int A=0, int K=0, int mol=0, int cd=0, int rad=0)
- */
-//length
-store.push_back(UnitBase<T>("in", "inch",             0.0254L,          0.,1));
-store.push_back(UnitBase<T>("ft", "foot",             0.3048L,          0.,1));
-store.push_back(UnitBase<T>("ua", "astronomical unit",1.49597870700e11L,0.,1)); //~ Sun-Earth distance, BIPM symbol
-store.push_back(UnitBase<T>("ang","angstrom",         1e-10L,           0.,1)); 
-//mass
-store.push_back(UnitBase<T>("Da","dalton",             1.660538921e-27L,0.,0,1));
-store.push_back(UnitBase<T>("u", "unified atomic mass",1.660538921e-27L,0.,0,1));
-//Time
-store.push_back(UnitBase<T>("min", "minute",60.0L,  0.,0,0,1));
-store.push_back(UnitBase<T>("hour","hour",  3600.0L,0.,0,0,1));
-//Current
-//Temperature
-store.push_back(UnitBase<T>("degC","degree Celsius",  1.L,    273.15L,          0,0,0,0,1));
-store.push_back(UnitBase<T>("degF","degree Farenheit",5.L/9.L,459.57L*5.0L/9.0L,0,0,0,0,1));
-//angle
-store.push_back(UnitBase<T>("deg", "degree",    Constants::pi<T>()/180.0L,              0.,0,0,0,0,0,0,0,1));
-store.push_back(UnitBase<T>("\'",  "Arcminute", Constants::pi<T>()/(180.0L*60.0L),      0.,0,0,0,0,0,0,0,1));
-store.push_back(UnitBase<T>("\'\'","Arcsecond", Constants::pi<T>()/(180.0L*60.0L*60.0L),0.,0,0,0,0,0,0,0,1));
-//volume
-store.push_back(UnitBase<T>("l","litre",1e-3L,0.,3));
-store.push_back(UnitBase<T>("L","litre",1e-3L,0.,3));
-//Force m.kg.s-2
-store.push_back(UnitBase<T>("N",  "newton",1.0L, 0.,1,1,-2));
-store.push_back(UnitBase<T>("dyn","dyne",  1e-5L,0.,1,1,-2));
-//Pressure N.m-2 (m-1.kg.s-2)
-store.push_back(UnitBase<T>("Pa",  "pascal",               1.0L,            0.,-1,1,-2));
-store.push_back(UnitBase<T>("bar", "bar",                  1e5L,            0.,-1,1,-2));
-store.push_back(UnitBase<T>("at",  "technical atmosphere", 9.80665e4L,      0.,-1,1,-2));
-store.push_back(UnitBase<T>("atm", "atmosphere",           1.01325e5L,      0.,-1,1,-2));
-store.push_back(UnitBase<T>("Torr","Torr",                 101325.0L/760.0L,0.,-1,1,-2)); // 1 atm / 760 by def
-store.push_back(UnitBase<T>("psi", "pound per square inch",6.895e3L,        0.,-1,1,-2));
-store.push_back(UnitBase<T>("mmHg","millimeter of mercury",133.322387415L,  0.,-1,1,-2));
-//viscosity Pa.s (m-1.kg.s-1)
-store.push_back(UnitBase<T>("P","poise",0.1L,0.,-1,1,-1));
-//Power W (m2.kg.s-3)
-store.push_back(UnitBase<T>("W","watt" ,1.0L,0.,2 ,1,-3));
-//Energy N.m (m2.kg.s-2)
-store.push_back(UnitBase<T>("J",    "joule",       1.0L,            0.,2,1,-2));
-store.push_back(UnitBase<T>("cal",  "calorie",     4.1868L,         0.,2,1,-2));//International table
-store.push_back(UnitBase<T>("calth","calorie thermodynamic", 4.184L,0.,2,1,-2));//thermodynamics
-store.push_back(UnitBase<T>("eV",   "electronVolt",1.602176565e-19L,0.,2,1,-2));
-store.push_back(UnitBase<T>("erg",  "erg",         1.e-7L,          0.,2,1,-2));
-store.push_back(UnitBase<T>("Ha",   "hartree",     4.35974434e-18L, 0.,2,1,-2));
-//Electric charge A.s
-store.push_back(UnitBase<T>("C","coulomb",1.0L,0.,0,0,1,1));
-//Frequency s-1
-store.push_back(UnitBase<T>("Hz","herzt",    1.0L,   0.,0,0,-1));
-store.push_back(UnitBase<T>("Ci","curie",    3.7e10L,0.,0,0,-1));
-store.push_back(UnitBase<T>("Bq","becquerel",1.0L,   0.,0,0,-1));
-//no unit
-store.push_back(UnitBase<T>("molecule","molecule",1.0L,0.,0,0,0,0,0,0));
-store.push_back(UnitBase<T>("photon",  "photon",  1.0L,0.,0,0,0,0,0,0));
+  template <typename T = double>
+  class UnitBaseStore{
+        public:
+    ~UnitBaseStore(){}
+    UnitBaseStore()
+    {
+    /* base UnitBase, 
+     * UnitBase<T>(string symbol, string name, 
+     * double a, double b, 
+     * int m, int kg = 0, int s = 0, int A = 0, int K = 0, int mol = 0, int cd = 0, int rad = 0)
+     */
+    store.push_back(UnitBase<T>("m",  "meter",   1.0L,0.,1));
+    store.push_back(UnitBase<T>("kg", "kilogram",1.0L,0.,0,1));
+    store.push_back(UnitBase<T>("s",  "second",  1.0L,0.,0,0,1));
+    store.push_back(UnitBase<T>("A",  "ampere",  1.0L,0.,0,0,0,1));
+    store.push_back(UnitBase<T>("K",  "kelvin",  1.0L,0.,0,0,0,0,1));
+    store.push_back(UnitBase<T>("mol","mole",    1.0L,0.,0,0,0,0,0,1));
+    store.push_back(UnitBase<T>("cd", "candela", 1.0L,0.,0,0,0,0,0,0,1));
+    store.push_back(UnitBase<T>("rad","radian",  1.0L,0.,0,0,0,0,0,0,0,1));
+    /* others known Units using constructor 
+     * UnitBase<T>(string symbol, string name, 
+     * double a, double b, 
+     * int m, int kg=0, int s=0, int A=0, int K=0, int mol=0, int cd=0, int rad=0)
+     */
+    //length
+    store.push_back(UnitBase<T>("in", "inch",             0.0254L,          0.,1));
+    store.push_back(UnitBase<T>("ft", "foot",             0.3048L,          0.,1));
+    store.push_back(UnitBase<T>("ua", "astronomical unit",1.49597870700e11L,0.,1)); //~ Sun-Earth distance, BIPM symbol
+    store.push_back(UnitBase<T>("ang","angstrom",         1e-10L,           0.,1)); 
+    //mass
+    store.push_back(UnitBase<T>("Da","dalton",             1.660538921e-27L,0.,0,1));
+    store.push_back(UnitBase<T>("u", "unified atomic mass",1.660538921e-27L,0.,0,1));
+    //Time
+    store.push_back(UnitBase<T>("min", "minute",60.0L,  0.,0,0,1));
+    store.push_back(UnitBase<T>("hour","hour",  3600.0L,0.,0,0,1));
+    //Current
+    //Temperature
+    store.push_back(UnitBase<T>("degC","degree Celsius",  1.L,    273.15L,          0,0,0,0,1));
+    store.push_back(UnitBase<T>("degF","degree Farenheit",5.L/9.L,459.57L*5.0L/9.0L,0,0,0,0,1));
+    //angle
+    store.push_back(UnitBase<T>("deg", "degree",    Constants::pi<T>()/180.0L,              0.,0,0,0,0,0,0,0,1));
+    store.push_back(UnitBase<T>("\'",  "Arcminute", Constants::pi<T>()/(180.0L*60.0L),      0.,0,0,0,0,0,0,0,1));
+    store.push_back(UnitBase<T>("\'\'","Arcsecond", Constants::pi<T>()/(180.0L*60.0L*60.0L),0.,0,0,0,0,0,0,0,1));
+    //volume
+    store.push_back(UnitBase<T>("l","litre",1e-3L,0.,3));
+    store.push_back(UnitBase<T>("L","litre",1e-3L,0.,3));
+    //Force m.kg.s-2
+    store.push_back(UnitBase<T>("N",  "newton",1.0L, 0.,1,1,-2));
+    store.push_back(UnitBase<T>("dyn","dyne",  1e-5L,0.,1,1,-2));
+    //Pressure N.m-2 (m-1.kg.s-2)
+    store.push_back(UnitBase<T>("Pa",  "pascal",               1.0L,            0.,-1,1,-2));
+    store.push_back(UnitBase<T>("bar", "bar",                  1e5L,            0.,-1,1,-2));
+    store.push_back(UnitBase<T>("at",  "technical atmosphere", 9.80665e4L,      0.,-1,1,-2));
+    store.push_back(UnitBase<T>("atm", "atmosphere",           1.01325e5L,      0.,-1,1,-2));
+    store.push_back(UnitBase<T>("Torr","Torr",                 101325.0L/760.0L,0.,-1,1,-2)); // 1 atm / 760 by def
+    store.push_back(UnitBase<T>("psi", "pound per square inch",6.895e3L,        0.,-1,1,-2));
+    store.push_back(UnitBase<T>("mmHg","millimeter of mercury",133.322387415L,  0.,-1,1,-2));
+    //viscosity Pa.s (m-1.kg.s-1)
+    store.push_back(UnitBase<T>("P","poise",0.1L,0.,-1,1,-1));
+    //Power W (m2.kg.s-3)
+    store.push_back(UnitBase<T>("W","watt" ,1.0L,0.,2 ,1,-3));
+    //Energy N.m (m2.kg.s-2)
+    store.push_back(UnitBase<T>("J",    "joule",       1.0L,            0.,2,1,-2));
+    store.push_back(UnitBase<T>("cal",  "calorie",     4.1868L,         0.,2,1,-2));//International table
+    store.push_back(UnitBase<T>("calth","calorie thermodynamic", 4.184L,0.,2,1,-2));//thermodynamics
+    store.push_back(UnitBase<T>("eV",   "electronVolt",1.602176565e-19L,0.,2,1,-2));
+    store.push_back(UnitBase<T>("erg",  "erg",         1.e-7L,          0.,2,1,-2));
+    store.push_back(UnitBase<T>("Ha",   "hartree",     4.35974434e-18L, 0.,2,1,-2));
+    //Electric charge A.s
+    store.push_back(UnitBase<T>("C","coulomb",1.0L,0.,0,0,1,1));
+    //Frequency s-1
+    store.push_back(UnitBase<T>("Hz","herzt",    1.0L,   0.,0,0,-1));
+    store.push_back(UnitBase<T>("Ci","curie",    3.7e10L,0.,0,0,-1));
+    store.push_back(UnitBase<T>("Bq","becquerel",1.0L,   0.,0,0,-1));
+    //no unit
+    store.push_back(UnitBase<T>("molecule","molecule",1.0L,0.,0,0,0,0,0,0));
+    store.push_back(UnitBase<T>("photon",  "photon",  1.0L,0.,0,0,0,0,0,0));
+    
+    _n_known_units = store.size();
+    
+      for(int i = 0; i < (int)store.size(); i++)
+      {
+        map_store[store[i].symbol()] = i;
+      }
+    }
+    
+    int stored_index(const std::string &symb)  const 
+    {
+      return (symb == "g")?map_store.at("kg"): //special case for gram
+                                              (map_store.count(symb))?map_store.at(symb):-1;
+    }
+    
+    const UnitBase<T> stored(const int &iunit) const
+    {
+      return store[iunit];
+    }
+    
+    int n_known_units() const 
+    {
+      return _n_known_units;
+    }
 
-_n_known_units = store.size();
-
-  for(int i = 0; i < (int)store.size(); i++)
-  {
-      map_store[store[i].symbol()] = i;
-  }
-}
-
-int stored_index(const std::string &symb)    const {return (map_store.find(symb) == map_store.end())?-1:map_store.at(symb);}
-const UnitBase<T> stored(const int &iunit) const {return store[iunit];}
-int n_known_units()                          const {return _n_known_units;}
-
-  private:
-   std::map<std::string,unsigned int> map_store;
-   std::vector<UnitBase<T> > store;
-   unsigned int _n_known_units;
-};
+        private:
+    std::map<std::string,unsigned int> map_store;
+    std::vector<UnitBase<T> > store;
+    unsigned int _n_known_units;
+  };
 
 
 /*!Prefixes, SI
@@ -186,44 +198,55 @@ class SIPrefixeStore{
    public:
      ~SIPrefixeStore(){}
      SIPrefixeStore(){
-store.push_back(SIPrefixes<T>("y", "yocto",1e-24L));
-store.push_back(SIPrefixes<T>("z", "zepto",1e-21L));
-store.push_back(SIPrefixes<T>("a", "atto", 1e-18L));
-store.push_back(SIPrefixes<T>("f", "femto",1e-15L));
-store.push_back(SIPrefixes<T>("p", "pico", 1e-12L));
-store.push_back(SIPrefixes<T>("n", "nano", 1e-9L));
-store.push_back(SIPrefixes<T>("mu","micro",1e-6L));
-store.push_back(SIPrefixes<T>("m", "milli",1e-3L));
-store.push_back(SIPrefixes<T>("c", "centi",1e-2L));
-store.push_back(SIPrefixes<T>("d", "deci", 1e-1L));
-store.push_back(SIPrefixes<T>("da","deca", 1e1L));
-store.push_back(SIPrefixes<T>("h", "hecto",1e2L));
-store.push_back(SIPrefixes<T>("k", "kilo", 1e3L));
-store.push_back(SIPrefixes<T>("M", "mega", 1e6L));
-store.push_back(SIPrefixes<T>("G", "giga", 1e9L));
-store.push_back(SIPrefixes<T>("T", "tera", 1e12L));
-store.push_back(SIPrefixes<T>("P", "peta", 1e15L));
-store.push_back(SIPrefixes<T>("E", "exa",  1e18L));
-store.push_back(SIPrefixes<T>("Z", "zetta",1e21L));
-store.push_back(SIPrefixes<T>("Y", "yotta",1e24L));
+     store.push_back(SIPrefixes<T>("y", "yocto",1e-24L));
+     store.push_back(SIPrefixes<T>("z", "zepto",1e-21L));
+     store.push_back(SIPrefixes<T>("a", "atto", 1e-18L));
+     store.push_back(SIPrefixes<T>("f", "femto",1e-15L));
+     store.push_back(SIPrefixes<T>("p", "pico", 1e-12L));
+     store.push_back(SIPrefixes<T>("n", "nano", 1e-9L));
+     store.push_back(SIPrefixes<T>("mu","micro",1e-6L));
+     store.push_back(SIPrefixes<T>("m", "milli",1e-3L));
+     store.push_back(SIPrefixes<T>("c", "centi",1e-2L));
+     store.push_back(SIPrefixes<T>("d", "deci", 1e-1L));
+     store.push_back(SIPrefixes<T>("da","deca", 1e1L));
+     store.push_back(SIPrefixes<T>("h", "hecto",1e2L));
+     store.push_back(SIPrefixes<T>("k", "kilo", 1e3L));
+     store.push_back(SIPrefixes<T>("M", "mega", 1e6L));
+     store.push_back(SIPrefixes<T>("G", "giga", 1e9L));
+     store.push_back(SIPrefixes<T>("T", "tera", 1e12L));
+     store.push_back(SIPrefixes<T>("P", "peta", 1e15L));
+     store.push_back(SIPrefixes<T>("E", "exa",  1e18L));
+     store.push_back(SIPrefixes<T>("Z", "zetta",1e21L));
+     store.push_back(SIPrefixes<T>("Y", "yotta",1e24L));
+     
+     _n_prefixes = store.size();
+     
+       for(int i = 0; i < (int)store.size(); i++)
+       {
+           map_store[store[i].symbol()] = i;
+       }
+     }
+     
+     int stored_index(const std::string &symb) const 
+     {
+        return (map_store.count(symb))?map_store.at(symb):-1;
+     }
 
-_n_prefixes = store.size();
+     const SIPrefixes<T> stored(const int &ipre) const
+     {
+        return store[ipre];
+     }
 
-  for(int i = 0; i < (int)store.size(); i++)
-  {
-      map_store[store[i].symbol()] = i;
-  }
-}
-
-int stored_index(const std::string &symb)     const {return (map_store.find(symb) == map_store.end())?-1:map_store.at(symb);}
-const SIPrefixes<T> stored(const int &ipre) const {return store[ipre];}
-int n_known_prefixes()                        const {return _n_prefixes;}
-
-   private:
-     std::map<std::string, int> map_store;
-     std::vector<SIPrefixes<T> > store;
-     unsigned int _n_prefixes;
-};
+     int n_known_prefixes() const 
+     {
+        return _n_prefixes;
+     }
+  
+     private:
+       std::map<std::string, int> map_store;
+       std::vector<SIPrefixes<T> > store;
+       unsigned int _n_prefixes;
+  };
 
 
 }//end namespace UnitBase

--- a/src/units/include/antioch/units.h
+++ b/src/units/include/antioch/units.h
@@ -585,7 +585,6 @@ Units<T>::Units(const std::string &sym, const std::string &na):  //constructors 
        symbol(sym),
        name(na)
 {
-  develop_symbol(symbol);
   fill_in_power(true);
 }
 
@@ -596,7 +595,6 @@ Units<T>::Units(const std::string &sym, const Converter<T> &conv, const std::str
        name(na),
        toSI(conv)
 {
-  develop_symbol(symbol);
   fill_in_power(false);
 }
 
@@ -604,6 +602,8 @@ template <typename T>
 void Units<T>::fill_in_power(bool doConv)
 {
   if(symbol.empty())return; // no unity
+  develop_symbol(symbol);
+
   std::string tmp(""),symboltmp(symbol);
   int signe(1),istart(0);
 
@@ -767,6 +767,7 @@ template <typename T>
 void Units<T>::parse_prefix_unit(int &iUnit,int &iPre,const std::string& unit) const
 {
   iPre = -1;
+
   iUnit = UnitBaseStorage::known_units().stored_index(unit);
 //prefix, if exists, is one or two character
    if(iUnit == -1 && unit.size() > 1)
@@ -801,7 +802,7 @@ bool Units<T>::parse_single_unit(int signe,std::string unit,bool doConv)
 
   T pre = 1.;
   if(iPre != -1)pre = UnitBaseStorage::known_prefixes().stored(iPre).value<T>();
-  if(UnitBaseStorage::known_units().stored(iUnit).symbol() == "kg")pre *= 1e-3;
+  if(UnitBaseStorage::known_units().stored(iUnit).symbol() == "kg")pre *= 1e-3; //rescale
   InSI powerTmp = UnitBaseStorage::known_units().stored(iUnit).power_array();
   power += (powerTmp * signe * ipower);
   if(doConv)
@@ -1121,7 +1122,6 @@ template <typename T>
 void Units<T>::set_unit(const std::string &sym, std::string na)
 {
   symbol = sym;
-  develop_symbol(symbol);
   name = na;
   toSI.clear();
   power.clear();

--- a/test/units_unit.C
+++ b/test/units_unit.C
@@ -30,6 +30,7 @@
  *      - addition
  *      - substraction
  *      - multiplication
+ *      - multiple combinations with parenthesises
  */
 
 // C++
@@ -64,14 +65,14 @@ int test_factor(int nAddition)
   using std::abs;
 
 
-  const T tol = std::numeric_limits<T>::epsilon() * 100;
+  const T tol = std::numeric_limits<T>::epsilon() * 2.;
   const T unity = 1.L;
 
 // testing SI derived
   Antioch::Units<T> test("W");
   if(abs((test.get_SI_factor()-unity)/unity) > tol)
   {
-    std::cout << std::scientific << std::setprecision(16)
+    std::cerr << std::scientific << std::setprecision(16)
               << "mismatch in unit SI description, unity is not found" << std::endl
               << "factor = " << test.get_SI_factor() << std::endl;
     return 1;
@@ -79,7 +80,7 @@ int test_factor(int nAddition)
   test.set_unit("J");
   if(abs((test.get_SI_factor()-unity)/unity) > tol)
   {
-    std::cout << std::scientific << std::setprecision(16)
+    std::cerr << std::scientific << std::setprecision(16)
               << "mismatch in unit SI description, unity is not found" << std::endl
               << "factor = " << test.get_SI_factor() << std::endl;
     return 1;
@@ -87,7 +88,7 @@ int test_factor(int nAddition)
   test.set_unit("Hz");
   if(abs((test.get_SI_factor()-unity)/unity) > tol)
   {
-    std::cout << std::scientific << std::setprecision(16)
+    std::cerr << std::scientific << std::setprecision(16)
               << "mismatch in unit SI description, unity is not found" << std::endl
               << "factor = " << test.get_SI_factor() << std::endl;
     return 1;
@@ -95,7 +96,7 @@ int test_factor(int nAddition)
   test.set_unit("N");
   if(abs((test.get_SI_factor()-unity)/unity) > tol)
   {
-    std::cout << std::scientific << std::setprecision(16)
+    std::cerr << std::scientific << std::setprecision(16)
               << "mismatch in unit SI description, unity is not found" << std::endl
               << "factor = " << test.get_SI_factor() << std::endl;
     return 1;
@@ -103,7 +104,7 @@ int test_factor(int nAddition)
   test.set_unit("Pa");
   if(abs((test.get_SI_factor()-unity)/unity) > tol)
   {
-    std::cout << std::scientific << std::setprecision(16)
+    std::cerr << std::scientific << std::setprecision(16)
               << "mismatch in unit SI description, unity is not found" << std::endl
               << "factor = " << test.get_SI_factor() << std::endl;
     return 1;
@@ -111,7 +112,7 @@ int test_factor(int nAddition)
   test.set_unit("C");
   if(abs((test.get_SI_factor()-unity)/unity) > tol)
   {
-    std::cout << std::scientific << std::setprecision(16)
+    std::cerr << std::scientific << std::setprecision(16)
               << "mismatch in unit SI description, unity is not found" << std::endl
               << "factor = " << test.get_SI_factor() << std::endl;
     return 1;
@@ -119,7 +120,7 @@ int test_factor(int nAddition)
   test.set_unit("Bq");
   if(abs((test.get_SI_factor()-unity)/unity) > tol)
   {
-    std::cout << std::scientific << std::setprecision(16)
+    std::cerr << std::scientific << std::setprecision(16)
               << "mismatch in unit SI description, unity is not found" << std::endl
               << "factor = " << test.get_SI_factor() << std::endl;
     return 1;
@@ -164,7 +165,7 @@ int test_factor(int nAddition)
   test.set_unit(uu);
   if(abs((test.get_SI_factor()-unity)/unity) > tol)
   {
-    std::cout << std::scientific << std::setprecision(16)
+    std::cerr << std::scientific << std::setprecision(16)
               << "mismatch in unit combination, unity is not found" << std::endl
               << "factor = " << test.get_SI_factor() << std::endl;
     return 1;
@@ -182,7 +183,7 @@ int test_factor(int nAddition)
   T Rcalc = RJ * test.factor_to_some_unit("cal/mol/K");
   if(abs((Rcalc - Rcal)/Rcal) > tol && abs((Rcalc - Rcal)/Rcal) > abs(Runc/Rcal))
   {
-    std::cout << std::scientific << std::setprecision(16)
+    std::cerr << std::scientific << std::setprecision(16)
               << "mismatch in R calculation" << std::endl
               << "Rtheo = " << Rcal  << " cal/mol/K" << std::endl
               << "Rcal  = " << Rcalc << " cal/mol/K" << std::endl
@@ -193,6 +194,18 @@ int test_factor(int nAddition)
   }
 
   std::cout << "R calculation passed" << std::endl;
+
+  // now combining with parenthesises E = m * c * c, [E] = [m] + [c] + [c]
+  Antioch::Units<T> m("g"), c("m/s");
+  Antioch::Units<T> E = m + c + c;
+
+  if(!E.is_homogeneous("J"))
+  {
+     std::cerr << "E = m * c *c failed, output unit is " << E.get_symbol() << std::endl;
+     return 1;
+  }
+
+  std::cout << "E = m * c * c calculation passed" << std::endl;
 
   return 0;
 }


### PR DESCRIPTION
- unit_store: the "g" case is properly taken into account
- units: fill_in_power uses develop_symbol before calculations 
      => no more develop_symbol needed before calling it
- units: some cleaning: indexUnit no more needed
- unit_unit: added the test [E] = [m] + [c] + [c] has to be homogeneous to Joules

It looks big, but the changes are small, most of the changes are spaces and line returns added for readability purposes.

The changes are:
unit_store.h line 151

```
return (symb == "g")?map_store.at("kg"): //special case for gram
                                (map_store.count(symb))?map_store.at(symb):-1;
```

the case of the gram unit is taken care of here instead of units.h, in units.h line 805 is the rescaling in response of the fact that the kilo prefixes is counted anyway so it has to be deleted.

Then line151 and 232 changes are the `count()` method instead of a `find()` method to test if the requested element is indeed in the map.

units.h and unit_unit.C comments are pretty explicit, with `std::cerr` used instead of `std::cout` when proper.
