### PR TITLE
Conditions reac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -192,7 +192,6 @@ AC_CONFIG_FILES(test/kinetics_vec_unit_air_5sp.sh,       [chmod +x test/kinetics
 AC_CONFIG_FILES(test/kinetics_regression_air_5sp.sh,     [chmod +x test/kinetics_regression_air_5sp.sh])
 AC_CONFIG_FILES(test/kinetics_regression_vec_air_5sp.sh, [chmod +x test/kinetics_regression_vec_air_5sp.sh])
 AC_CONFIG_FILES(test/photochemical_rate_unit.sh,         [chmod +x test/photochemical_rate_unit.sh])
-AC_CONFIG_FILES(test/sigma_bin_converter_unit.sh,        [chmod +x test/sigma_bin_converter_unit.sh])
 AC_CONFIG_FILES(test/parsing_xml.sh,                     [chmod +x test/parsing_xml.sh])
 AC_CONFIG_FILES(test/kinetics_reactive_scheme_unit.sh,   [chmod +x test/kinetics_reactive_scheme_unit.sh])
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -13,7 +13,6 @@ pkginclude_HEADERS  =
 # core
 pkginclude_HEADERS += core/include/antioch/chemical_species.h
 pkginclude_HEADERS += core/include/antioch/chemical_mixture.h
-pkginclude_HEADERS += core/include/antioch/species_enum.h
 pkginclude_HEADERS += core/include/antioch/kinetics_conditions.h
 
 # unit

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -13,6 +13,8 @@ pkginclude_HEADERS  =
 # core
 pkginclude_HEADERS += core/include/antioch/chemical_species.h
 pkginclude_HEADERS += core/include/antioch/chemical_mixture.h
+pkginclude_HEADERS += core/include/antioch/species_enum.h
+pkginclude_HEADERS += core/include/antioch/kinetics_conditions.h
 
 # unit
 pkginclude_HEADERS += units/include/antioch/converter.h

--- a/src/core/include/antioch/kinetics_conditions.h
+++ b/src/core/include/antioch/kinetics_conditions.h
@@ -1,0 +1,131 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//-----------------------------------------------------------------------el-
+
+#ifndef ANTIOCH_KINETICS_CONDITIONS_H
+#define ANTIOCH_KINETICS_CONDITIONS_H
+
+// Antioch
+#include "antioch/antioch_asserts.h"
+#include "antioch/particle_flux.h"
+
+// C++
+#include <vector>
+#include <map>
+
+namespace Antioch{
+
+  /*! This class contains the conditions of the chemistry
+
+      Conditions are:
+        - Temperature(s)
+        - particle flux
+        - any other not yet implemented conditions (catalysis for instance)
+
+      Pressure is given by the molecular composition of the mixture,
+      we are in a gaz phase, so the state equation will give pressure (typically
+      ideal gas).
+
+      The idea is to avoid any copy of anything as much as we can, 
+      we store pointers but deal only with references. Nothing
+      belongs to this object, if there is any cleaning to do,
+      it must be done elsewhere.
+
+      Might be interesting to see about the "double" case
+      for temperature: faster to copy instead of copying
+      the reference, and it's expected to be the classic
+      case.
+   */
+  template <typename StateType, 
+            typename VectorStateType = std::vector<StateType> >
+  class KineticsConditions
+  {
+        public:
+
+          KineticsConditions();
+          KineticsConditions(const StateType & temperature);
+          ~KineticsConditions();
+
+          void add_particle_flux(const ParticleFlux<VectorStateType> & pf, unsigned int nr);
+
+          void change_temperature(const StateType & temperature);
+
+          void change_particle_flux(const ParticleFlux<VectorStateType> & pf, unsigned int nr);
+
+          const StateType & T() const;
+
+          const ParticleFlux<VectorStateType> & particle_flux(int nr) const;
+
+        private:
+        // pointer's not const, temperature is
+          StateType const * _temperature; 
+        // pointer's not const, particle flux is
+          std::map<unsigned int,ParticleFlux<VectorStateType> const * > _map_pf; 
+
+  };
+
+  template <typename StateType, typename VectorStateType>
+  inline
+  KineticsConditions<StateType,VectorStateType>::KineticsConditions():
+        _temperature(NULL)
+  {
+    return;
+  }
+
+  template <typename StateType, typename VectorStateType>
+  inline
+  KineticsConditions<StateType,VectorStateType>::KineticsConditions(const StateType & temperature):
+        _temperature(&temperature)
+  {
+    return;
+  }
+
+  template <typename StateType, typename VectorStateType>
+  inline
+  KineticsConditions<StateType,VectorStateType>::~KineticsConditions()
+  {
+    return;
+  }
+
+  template <typename StateType, typename VectorStateType>
+  inline
+  void KineticsConditions<StateType,VectorStateType>::add_particle_flux(const ParticleFlux<VectorStateType> & pf, unsigned int nr)
+  {
+     _map_pf.insert(std::make_pair(nr, &pf));
+  }
+
+  template <typename StateType, typename VectorStateType>
+  inline
+  void KineticsConditions<StateType,VectorStateType>::change_temperature(const StateType & temperature)
+  {
+      _temperature = &temperature;
+  }
+
+  template <typename StateType, typename VectorStateType>
+  inline
+  void KineticsConditions<StateType,VectorStateType>::change_particle_flux(const ParticleFlux<VectorStateType> & pf, unsigned int nr)
+  {
+     antioch_assert(_map_pf.count(nr));
+     _map_pf[nr] = &pf;
+  }
+
+  template <typename StateType, typename VectorStateType>
+  inline
+  const StateType & KineticsConditions<StateType,VectorStateType>::T() const
+  {
+     antioch_assert(_temperature);
+     return *_temperature;
+  }
+
+  template <typename StateType, typename VectorStateType>
+  inline
+  const ParticleFlux<VectorStateType> & KineticsConditions<StateType,VectorStateType>::particle_flux(int nr) const
+  {
+     antioch_assert(_map_pf.count(nr));
+     return *(_map_pf.at(nr));
+  }
+
+
+} //end namespace Antioch
+
+#endif

--- a/src/core/include/antioch/kinetics_conditions.h
+++ b/src/core/include/antioch/kinetics_conditions.h
@@ -68,23 +68,17 @@ namespace Antioch{
 
           void add_particle_flux(const ParticleFlux<VectorStateType> & pf, unsigned int nr);
 
-          void change_temperature(const StateType & temperature);
-
-          void change_particle_flux(const ParticleFlux<VectorStateType> & pf, unsigned int nr);
-
           const StateType & T() const;
 
           const ParticleFlux<VectorStateType> & particle_flux(int nr) const;
 
-          const std::map<unsigned int, ParticleFlux<VectorStateType> const *> & map_pf() const;
-
         private:
 
           KineticsConditions();
-        // pointer's not const, temperature is
-          StateType const * _temperature; 
+        // const temperature is
+          const StateType & _temperature; 
         // pointer's not const, particle flux is
-          std::map<unsigned int,ParticleFlux<VectorStateType> const * > _map_pf; 
+          std::map<unsigned int,ParticleFlux<VectorStateType> const * const > _map_pf; 
 
   };
 
@@ -92,7 +86,7 @@ namespace Antioch{
   template <typename StateType, typename VectorStateType>
   inline
   KineticsConditions<StateType,VectorStateType>::KineticsConditions(const StateType & temperature):
-        _temperature(&temperature)
+        _temperature(temperature)
   {
     return;
   }
@@ -113,32 +107,9 @@ namespace Antioch{
 
   template <typename StateType, typename VectorStateType>
   inline
-  void KineticsConditions<StateType,VectorStateType>::change_temperature(const StateType & temperature)
-  {
-      _temperature = &temperature;
-  }
-
-  template <typename StateType, typename VectorStateType>
-  inline
-  void KineticsConditions<StateType,VectorStateType>::change_particle_flux(const ParticleFlux<VectorStateType> & pf, unsigned int nr)
-  {
-     antioch_assert(_map_pf.count(nr));
-     _map_pf[nr] = &pf;
-  }
-
-  template <typename StateType, typename VectorStateType>
-  inline
   const StateType & KineticsConditions<StateType,VectorStateType>::T() const
   {
-     antioch_assert(_temperature);
-     return *_temperature;
-  }
-
-  template <typename StateType, typename VectorStateType>
-  inline
-  const std::map<unsigned int, ParticleFlux<VectorStateType> const *> & KineticsConditions<StateType,VectorStateType>::map_pf() const
-  {
-      return _map_pf;
+     return _temperature;
   }
 
   template <typename StateType, typename VectorStateType>

--- a/src/core/include/antioch/kinetics_conditions.h
+++ b/src/core/include/antioch/kinetics_conditions.h
@@ -63,7 +63,6 @@ namespace Antioch{
   {
         public:
 
-          KineticsConditions();
           KineticsConditions(const KineticsConditions<StateType,VectorStateType>& rhs);
           KineticsConditions(const StateType & temperature);
           ~KineticsConditions();
@@ -81,6 +80,8 @@ namespace Antioch{
           const std::map<unsigned int, ParticleFlux<VectorStateType> const *> & map_pf() const;
 
         private:
+
+          KineticsConditions();
         // pointer's not const, temperature is
           StateType const * _temperature; 
         // pointer's not const, particle flux is
@@ -88,13 +89,6 @@ namespace Antioch{
 
   };
 
-  template <typename StateType, typename VectorStateType>
-  inline
-  KineticsConditions<StateType,VectorStateType>::KineticsConditions():
-        _temperature(NULL)
-  {
-    return;
-  }
 
   template <typename StateType, typename VectorStateType>
   inline

--- a/src/core/include/antioch/kinetics_conditions.h
+++ b/src/core/include/antioch/kinetics_conditions.h
@@ -62,6 +62,7 @@ namespace Antioch{
         public:
 
           KineticsConditions();
+          KineticsConditions(const KineticsConditions<StateType,VectorStateType>& rhs);
           KineticsConditions(const StateType & temperature);
           ~KineticsConditions();
 
@@ -74,6 +75,8 @@ namespace Antioch{
           const StateType & T() const;
 
           const ParticleFlux<VectorStateType> & particle_flux(int nr) const;
+
+          const std::map<unsigned int, ParticleFlux<VectorStateType> const *> & map_pf() const;
 
         private:
         // pointer's not const, temperature is
@@ -97,6 +100,19 @@ namespace Antioch{
         _temperature(&temperature)
   {
     return;
+  }
+
+  template <typename StateType, typename VectorStateType>
+  inline
+  KineticsConditions<StateType,VectorStateType>::KineticsConditions(const KineticsConditions<StateType,VectorStateType>& rhs)
+  {
+     if(this != &rhs)
+     {
+        _temperature = &rhs.T();
+        _map_pf      = rhs.map_pf();
+     }
+
+     return;
   }
 
   template <typename StateType, typename VectorStateType>
@@ -134,6 +150,13 @@ namespace Antioch{
   {
      antioch_assert(_temperature);
      return *_temperature;
+  }
+
+  template <typename StateType, typename VectorStateType>
+  inline
+  const std::map<unsigned int, ParticleFlux<VectorStateType> const *> & KineticsConditions<StateType,VectorStateType>::map_pf() const
+  {
+      return _map_pf;
   }
 
   template <typename StateType, typename VectorStateType>

--- a/src/core/include/antioch/kinetics_conditions.h
+++ b/src/core/include/antioch/kinetics_conditions.h
@@ -1,5 +1,24 @@
 //-----------------------------------------------------------------------bl-
 //--------------------------------------------------------------------------
+//
+// Antioch - A Gas Dynamics Thermochemistry Library
+//
+// Copyright (C) 2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
 //-----------------------------------------------------------------------el-
 
 #ifndef ANTIOCH_KINETICS_CONDITIONS_H

--- a/src/core/include/antioch/kinetics_conditions.h
+++ b/src/core/include/antioch/kinetics_conditions.h
@@ -63,7 +63,6 @@ namespace Antioch{
   {
         public:
 
-          KineticsConditions(const KineticsConditions<StateType,VectorStateType>& rhs);
           KineticsConditions(const StateType & temperature);
           ~KineticsConditions();
 
@@ -96,19 +95,6 @@ namespace Antioch{
         _temperature(&temperature)
   {
     return;
-  }
-
-  template <typename StateType, typename VectorStateType>
-  inline
-  KineticsConditions<StateType,VectorStateType>::KineticsConditions(const KineticsConditions<StateType,VectorStateType>& rhs)
-  {
-     if(this != &rhs)
-     {
-        _temperature = &rhs.T();
-        _map_pf      = rhs.map_pf();
-     }
-
-     return;
   }
 
   template <typename StateType, typename VectorStateType>

--- a/src/core/include/antioch/kinetics_conditions.h
+++ b/src/core/include/antioch/kinetics_conditions.h
@@ -3,6 +3,8 @@
 //
 // Antioch - A Gas Dynamics Thermochemistry Library
 //
+// Copyright (C) 2014 Paul T. Bauman, Benjamin S. Kirk, Sylvain Plessis,
+//                    Roy H. Stonger
 // Copyright (C) 2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/kinetics/include/antioch/duplicate_reaction.h
+++ b/src/kinetics/include/antioch/duplicate_reaction.h
@@ -135,8 +135,8 @@ namespace Antioch
       VectorStateType& dkfwd_dX) const
   {
     //dk_dT = sum_p dalpha_p_dT
-    StateType kfwd_tmp = Antioch::zero_clone(conditions);
-    StateType dkfwd_dT_tmp = Antioch::zero_clone(conditions);
+    StateType kfwd_tmp = Antioch::zero_clone(conditions.T());
+    StateType dkfwd_dT_tmp = Antioch::zero_clone(conditions.T());
 
     this->_forward_rate[0]->compute_rate_and_derivative(conditions,kfwd,dkfwd_dT);
 

--- a/src/kinetics/include/antioch/duplicate_reaction.h
+++ b/src/kinetics/include/antioch/duplicate_reaction.h
@@ -28,6 +28,7 @@
 
 // Antioch
 #include "antioch/reaction.h"
+#include "antioch/kinetics_conditions.h"
 
 //C++
 #include <string>
@@ -74,12 +75,12 @@ namespace Antioch
     //!
     template <typename StateType, typename VectorStateType>
     StateType compute_forward_rate_coefficient( const VectorStateType& molar_densities,
-                                                const StateType& T ) const;
+                                                const KineticsConditions<StateType,VectorStateType>& conditions ) const;
     
     //!
     template <typename StateType, typename VectorStateType>
     void compute_forward_rate_coefficient_and_derivatives( const VectorStateType& molar_densities,
-                                                           const StateType& T, 
+                                                           const KineticsConditions<StateType,VectorStateType>& conditions,
                                                            StateType& kfwd,  
                                                            StateType& dkfwd_dT, 
                                                            VectorStateType& dkfwd_dX) const;
@@ -112,12 +113,12 @@ namespace Antioch
   inline
   StateType DuplicateReaction<CoeffType>::compute_forward_rate_coefficient
     ( const VectorStateType& /* molar_densities */,
-      const StateType& T  ) const
+      const KineticsConditions<StateType,VectorStateType>& conditions) const
   {
-    StateType kfwd = (*this->_forward_rate[0])(T);
+    StateType kfwd = (*this->_forward_rate[0])(conditions);
     for(unsigned int ir = 1; ir < this->_forward_rate.size(); ir++)
       {
-        kfwd += (*this->_forward_rate[ir])(T);
+        kfwd += (*this->_forward_rate[ir])(conditions);
       }
 
     return kfwd;
@@ -128,20 +129,20 @@ namespace Antioch
   inline
   void DuplicateReaction<CoeffType>::compute_forward_rate_coefficient_and_derivatives
     ( const VectorStateType& /* molar_densities */,
-      const StateType& T,
+      const KineticsConditions<StateType,VectorStateType>& conditions,
       StateType& kfwd,
       StateType& dkfwd_dT,
       VectorStateType& dkfwd_dX) const
   {
     //dk_dT = sum_p dalpha_p_dT
-    StateType kfwd_tmp = Antioch::zero_clone(T);
-    StateType dkfwd_dT_tmp = Antioch::zero_clone(T);
+    StateType kfwd_tmp = Antioch::zero_clone(conditions);
+    StateType dkfwd_dT_tmp = Antioch::zero_clone(conditions);
 
-    this->_forward_rate[0]->compute_rate_and_derivative(T,kfwd,dkfwd_dT);
+    this->_forward_rate[0]->compute_rate_and_derivative(conditions,kfwd,dkfwd_dT);
 
     for(unsigned int ir = 1; ir < Reaction<CoeffType>::_forward_rate.size(); ir++)
       {
-        this->_forward_rate[ir]->compute_rate_and_derivative(T,kfwd_tmp,dkfwd_dT_tmp);
+        this->_forward_rate[ir]->compute_rate_and_derivative(conditions,kfwd_tmp,dkfwd_dT_tmp);
         kfwd += kfwd_tmp;
         dkfwd_dT += dkfwd_dT_tmp;
       }

--- a/src/kinetics/include/antioch/elementary_reaction.h
+++ b/src/kinetics/include/antioch/elementary_reaction.h
@@ -28,6 +28,7 @@
 
 // Antioch
 #include "antioch/reaction.h"
+#include "antioch/kinetics_conditions.h"
 
 //C++
 #include <string>
@@ -74,12 +75,12 @@ namespace Antioch
     //!
     template <typename StateType, typename VectorStateType>
     StateType compute_forward_rate_coefficient( const VectorStateType& molar_densities,
-                                                const StateType& T ) const; 
+                                                const KineticsConditions<StateType,VectorStateType>& conditions ) const; 
     
     //!
     template <typename StateType, typename VectorStateType>
     void compute_forward_rate_coefficient_and_derivatives( const VectorStateType& molar_densities,
-                                                           const StateType& T, 
+                                                           const KineticsConditions<StateType,VectorStateType>& conditions, 
                                                            StateType& kfwd,  
                                                            StateType& dkfwd_dT, 
                                                            VectorStateType& dkfwd_dX) const;
@@ -115,12 +116,12 @@ namespace Antioch
   inline
   StateType ElementaryReaction<CoeffType>::compute_forward_rate_coefficient
     ( const VectorStateType& /* molar_densities */,
-      const StateType& T) const
+      const KineticsConditions<StateType,VectorStateType>& conditions) const
   {
     antioch_assert_equal_to(1, Reaction<CoeffType>::_forward_rate.size());
 
     //k(T,[M]) = alpha(T)
-    return (*this->_forward_rate[0])(T);
+    return (*this->_forward_rate[0])(conditions);
   }
 
   template<typename CoeffType>
@@ -128,13 +129,13 @@ namespace Antioch
   inline
   void ElementaryReaction<CoeffType>::compute_forward_rate_coefficient_and_derivatives
     ( const VectorStateType& /* molar_densities */,
-      const StateType& T,
+      const KineticsConditions<StateType,VectorStateType>& conditions,
       StateType& kfwd,
       StateType& dkfwd_dT,
       VectorStateType& dkfwd_dX) const
   {
     //dk_dT = dalpha_dT(T)
-    this->_forward_rate[0]->compute_rate_and_derivative(T,kfwd,dkfwd_dT);
+    this->_forward_rate[0]->compute_rate_and_derivative(conditions,kfwd,dkfwd_dT);
 
     //dk_dCi = 0.
     antioch_assert_equal_to(dkfwd_dX.size(),this->n_species());

--- a/src/kinetics/include/antioch/kinetics_evaluator.h
+++ b/src/kinetics/include/antioch/kinetics_evaluator.h
@@ -67,8 +67,8 @@ namespace Antioch
 
     //! Compute species production/destruction rates per unit volume
     /*! \f$ \left(kg/sec/m^3\right)\f$ */
-    template <typename VectorStateType>
-    void compute_mass_sources( const KineticsConditions<StateType,VectorStateType>& conditions,
+    template <typename VectorStateType, typename KC>
+    void compute_mass_sources( const KC& conditions,
                                const VectorStateType& molar_densities,
                                const VectorStateType& h_RT_minus_s_R,
                                VectorStateType& mass_sources );
@@ -76,8 +76,8 @@ namespace Antioch
     //! Compute species production/destruction rate derivatives
     /*! In mass units, e.g. \f$ \frac{\partial \dot{\omega}}{dT}
       [\left(kg/sec/m^3/K\right)]\f$ */
-    template <typename VectorStateType>
-    void compute_mass_sources_and_derivs( const KineticsConditions<StateType,VectorStateType>& conditions,
+    template <typename VectorStateType, typename KC>
+    void compute_mass_sources_and_derivs( const KC& conditions,
                                           const VectorStateType& molar_densities,
                                           const VectorStateType& h_RT_minus_s_R,
                                           const VectorStateType& dh_RT_minus_s_R_dT,
@@ -87,8 +87,8 @@ namespace Antioch
 
     //! Compute species molar production/destruction rates per unit volume
     /*! \f$ \left(mole/sec/m^3\right)\f$ */
-    template <typename VectorStateType>
-    void compute_mole_sources( const KineticsConditions<StateType,VectorStateType>& conditions,
+    template <typename VectorStateType, typename KC>
+    void compute_mole_sources( const KC& conditions,
                                const VectorStateType& molar_densities,
                                const VectorStateType& h_RT_minus_s_R,
                                VectorStateType& mole_sources );
@@ -96,8 +96,8 @@ namespace Antioch
     //! Compute species production/destruction rate derivatives
     /*! In mass units, e.g. \f$ \frac{\partial \dot{\omega}}{dT}
       [\left(mole/sec/m^3/K\right)]\f$ */
-    template <typename VectorStateType>
-    void compute_mole_sources_and_derivs( const KineticsConditions<StateType,VectorStateType>& conditions,
+    template <typename VectorStateType, typename KC>
+    void compute_mole_sources_and_derivs( const KC& conditions,
                                           const VectorStateType& molar_densities,
                                           const VectorStateType& h_RT_minus_s_R,
                                           const VectorStateType& dh_RT_minus_s_R_dT,
@@ -174,9 +174,9 @@ namespace Antioch
   }
 
   template<typename CoeffType, typename StateType>
-  template<typename VectorStateType>
+  template<typename VectorStateType, typename KC>
   inline
-  void KineticsEvaluator<CoeffType,StateType>::compute_mole_sources( const KineticsConditions<StateType,VectorStateType>& conditions,
+  void KineticsEvaluator<CoeffType,StateType>::compute_mole_sources( const KC& conditions,
                                                                      const VectorStateType& molar_densities,
                                                                      const VectorStateType& h_RT_minus_s_R,
                                                                      VectorStateType& mole_sources )
@@ -192,8 +192,10 @@ namespace Antioch
 
     Antioch::set_zero(mole_sources);
 
+    typename constructor_or_reference<const KineticsConditions<StateType,VectorStateType>, const KC>::type  //either (KineticsConditions<> &) or (KineticsConditions<>)
+                kinetics_conditions(conditions);
     // compute the requisite reaction rates
-    this->_reaction_set.compute_reaction_rates( conditions, molar_densities,
+    this->_reaction_set.compute_reaction_rates( kinetics_conditions, molar_densities,
                                                 h_RT_minus_s_R, _net_reaction_rates );
 
     // compute the actual mole sources in kmol/sec/m^3
@@ -226,9 +228,9 @@ namespace Antioch
 
 
   template<typename CoeffType, typename StateType>
-  template<typename VectorStateType>
+  template<typename VectorStateType, typename KC>
   inline
-  void KineticsEvaluator<CoeffType,StateType>::compute_mass_sources( const KineticsConditions<StateType,VectorStateType>& conditions,
+  void KineticsEvaluator<CoeffType,StateType>::compute_mass_sources( const KC& conditions,
                                                                      const VectorStateType& molar_densities,
                                                                      const VectorStateType& h_RT_minus_s_R,
                                                                      VectorStateType& mass_sources )
@@ -246,9 +248,9 @@ namespace Antioch
   }
 
   template<typename CoeffType, typename StateType>
-  template<typename VectorStateType>
+  template<typename VectorStateType, typename KC>
   inline
-  void KineticsEvaluator<CoeffType,StateType>::compute_mole_sources_and_derivs( const KineticsConditions<StateType,VectorStateType>& conditions,
+  void KineticsEvaluator<CoeffType,StateType>::compute_mole_sources_and_derivs( const KC& conditions,
                                                                                 const VectorStateType& molar_densities,
                                                                                 const VectorStateType& h_RT_minus_s_R,
                                                                                 const VectorStateType& dh_RT_minus_s_R_dT,
@@ -289,8 +291,10 @@ namespace Antioch
         Antioch::set_zero(_dnet_rate_dX_s[rxn]);
       }
 
+    typename constructor_or_reference<const KineticsConditions<StateType,VectorStateType>, const KC>::type  //either (KineticsConditions<> &) or (KineticsConditions<>)
+                                        kinetics_conditions(conditions);
     // compute the requisite reaction rates
-    this->_reaction_set.compute_reaction_rates_and_derivs( conditions, molar_densities, 
+    this->_reaction_set.compute_reaction_rates_and_derivs( kinetics_conditions, molar_densities, 
                                                            h_RT_minus_s_R, dh_RT_minus_s_R_dT,
                                                            _net_reaction_rates,
                                                            _dnet_rate_dT, 
@@ -348,9 +352,9 @@ namespace Antioch
 
 
   template<typename CoeffType, typename StateType>
-  template <typename VectorStateType>
+  template <typename VectorStateType, typename KC>
   inline
-  void KineticsEvaluator<CoeffType,StateType>::compute_mass_sources_and_derivs( const KineticsConditions<StateType,VectorStateType>& conditions,
+  void KineticsEvaluator<CoeffType,StateType>::compute_mass_sources_and_derivs( const KC& conditions,
                                                                                 const VectorStateType& molar_densities,
                                                                                 const VectorStateType& h_RT_minus_s_R,
                                                                                 const VectorStateType& dh_RT_minus_s_R_dT,

--- a/src/kinetics/include/antioch/kinetics_type.h
+++ b/src/kinetics/include/antioch/kinetics_type.h
@@ -30,6 +30,7 @@
 #include "antioch/antioch_asserts.h"
 #include "antioch/kinetics_enum.h"
 #include "antioch/metaprogramming.h"
+#include "antioch/kinetics_conditions.h"
 
 //C++
 #include <string>
@@ -83,19 +84,19 @@ namespace Antioch{
     virtual ~KineticsType();
 
     //!
-    template <typename StateType>
-    StateType operator()(const StateType& T) const;
+    template <typename StateType, typename VectorStateType>
+    StateType operator()(const KineticsConditions<StateType,VectorStateType> & conditions) const;
 
     //!
-    template <typename StateType>
-    StateType derivative( const StateType& T ) const;
+    template <typename StateType, typename VectorStateType>
+    StateType derivative( const KineticsConditions<StateType,VectorStateType> & conditions ) const;
 
     //!
-    template <typename StateType>
-    void compute_rate_and_derivative(const StateType& T, StateType& rate, StateType& drate_dT) const;
+    template <typename StateType, typename VectorStateType>
+    void compute_rate_and_derivative(const KineticsConditions<StateType, VectorStateType>& conditions, StateType& rate, StateType& drate_dT) const;
 
-    //!Particles flux supports
-    void calculate_rate_constant(const VectorCoeffType &abs,const VectorCoeffType &flux, bool x_update);
+    //!
+    void set_index(unsigned int nr);
 
     virtual const std::string numeric() const = 0;
 
@@ -111,6 +112,7 @@ namespace Antioch{
 
   private:
     KineticsModel::KineticsModel my_type;
+    unsigned int                 my_index;
   };
 
   /* ------------------------- Inline Functions -------------------------*/
@@ -124,7 +126,8 @@ namespace Antioch{
   template <typename CoeffType, typename VectorCoeffType>
   inline
   KineticsType<CoeffType,VectorCoeffType>::KineticsType(const KineticsModel::KineticsModel type):
-    my_type(type)
+    my_type(type),
+    my_index(0)
   {
     return;
   }
@@ -136,77 +139,65 @@ namespace Antioch{
     return;
   }
 
-
   template <typename CoeffType, typename VectorCoeffType>
   inline
-  void KineticsType<CoeffType,VectorCoeffType>::calculate_rate_constant(const VectorCoeffType &abs,const VectorCoeffType &flux, bool x_update)
+  void KineticsType<CoeffType,VectorCoeffType>::set_index(unsigned int nr)
   {
-    switch(my_type) 
-      {
-      case(KineticsModel::PHOTOCHEM):
-        {
-          (static_cast<PhotochemicalRate<CoeffType,VectorCoeffType>*>(this))->calculate_rate_constant(abs,flux,x_update);
-        }
-      break;
-      default:
-        {
-          antioch_error();
-        }
-      }
+    my_index = nr;
   }
-
+    
   template <typename CoeffType, typename VectorCoeffType>
-  template <typename StateType>
+  template <typename StateType, typename VectorStateType>
   inline
-  StateType KineticsType<CoeffType,VectorCoeffType>::operator()(const StateType& T) const
+  StateType KineticsType<CoeffType,VectorCoeffType>::operator()(const KineticsConditions<StateType,VectorStateType>& conditions) const
   {
     switch(my_type) 
       {
       case(KineticsModel::CONSTANT):
         {
-          return (static_cast<const ConstantRate<CoeffType>*>(this))->rate(T);
+          return (static_cast<const ConstantRate<CoeffType>*>(this))->rate(conditions.T());
         }
         break;
 
       case(KineticsModel::HERCOURT_ESSEN):
         {
-          return (static_cast<const HercourtEssenRate<CoeffType>*>(this))->rate(T);
+          return (static_cast<const HercourtEssenRate<CoeffType>*>(this))->rate(conditions.T());
         }
         break;
 
       case(KineticsModel::BERTHELOT):
         {
-          return (static_cast<const BerthelotRate<CoeffType>*>(this))->rate(T);
+          return (static_cast<const BerthelotRate<CoeffType>*>(this))->rate(conditions.T());
         }
         break;
 
       case(KineticsModel::ARRHENIUS):
         {
-          return (static_cast<const ArrheniusRate<CoeffType>*>(this))->rate(T);
+          return (static_cast<const ArrheniusRate<CoeffType>*>(this))->rate(conditions.T());
         }
         break;
 
       case(KineticsModel::BHE):
         {
-          return (static_cast<const BerthelotHercourtEssenRate<CoeffType>*>(this))->rate(T);
+          return (static_cast<const BerthelotHercourtEssenRate<CoeffType>*>(this))->rate(conditions.T());
         }
         break;
 
       case(KineticsModel::KOOIJ):
         {
-          return (static_cast<const KooijRate<CoeffType>*>(this))->rate(T);
+          return (static_cast<const KooijRate<CoeffType>*>(this))->rate(conditions.T());
         }
         break;
 
       case(KineticsModel::VANTHOFF):
         {
-          return (static_cast<const VantHoffRate<CoeffType>*>(this))->rate(T);
+          return (static_cast<const VantHoffRate<CoeffType>*>(this))->rate(conditions.T());
         }
         break;
 
       case(KineticsModel::PHOTOCHEM):
         {
-          return (static_cast<const PhotochemicalRate<CoeffType,VectorCoeffType>*>(this))->rate(T);
+          return (static_cast<const PhotochemicalRate<CoeffType,VectorCoeffType>*>(this))->rate(conditions.particle_flux(my_index));
         }
         break;
 
@@ -218,61 +209,61 @@ namespace Antioch{
       } // switch(my_type)
 
     // Dummy
-    return zero_clone(T);
+    return zero_clone(conditions.T());
   }
 
   template <typename CoeffType, typename VectorCoeffType>
-  template <typename StateType>
+  template <typename StateType, typename VectorStateType>
   inline
-  StateType KineticsType<CoeffType,VectorCoeffType>::derivative( const StateType& T ) const
+  StateType KineticsType<CoeffType,VectorCoeffType>::derivative( const KineticsConditions<StateType, VectorStateType> & conditions ) const
   {
     switch(my_type) 
       {
       case(KineticsModel::CONSTANT):
         {
-          return (static_cast<const ConstantRate<CoeffType>*>(this))->derivative(T);
+          return (static_cast<const ConstantRate<CoeffType>*>(this))->derivative(conditions.T());
         }
         break;
 
       case(KineticsModel::HERCOURT_ESSEN):
         {
-          return (static_cast<const HercourtEssenRate<CoeffType>*>(this))->derivative(T);
+          return (static_cast<const HercourtEssenRate<CoeffType>*>(this))->derivative(conditions.T());
         }
         break;
 
       case(KineticsModel::BERTHELOT):
         {
-          return (static_cast<const BerthelotRate<CoeffType>*>(this))->derivative(T);
+          return (static_cast<const BerthelotRate<CoeffType>*>(this))->derivative(conditions.T());
         }
         break;
 
       case(KineticsModel::ARRHENIUS):
         {
-          return (static_cast<const ArrheniusRate<CoeffType>*>(this))->derivative(T);
+          return (static_cast<const ArrheniusRate<CoeffType>*>(this))->derivative(conditions.T());
         }
         break;
 
       case(KineticsModel::BHE):
         {
-          return (static_cast<const BerthelotHercourtEssenRate<CoeffType>*>(this))->derivative(T);
+          return (static_cast<const BerthelotHercourtEssenRate<CoeffType>*>(this))->derivative(conditions.T());
         }
         break;
 
       case(KineticsModel::KOOIJ):
         {
-          return (static_cast<const KooijRate<CoeffType>*>(this))->derivative(T);
+          return (static_cast<const KooijRate<CoeffType>*>(this))->derivative(conditions.T());
         }
         break;
 
       case(KineticsModel::VANTHOFF):
         {
-          return (static_cast<const VantHoffRate<CoeffType>*>(this))->derivative(T);
+          return (static_cast<const VantHoffRate<CoeffType>*>(this))->derivative(conditions.T());
         }
         break;
 
       case(KineticsModel::PHOTOCHEM):
         {
-          return (static_cast<const PhotochemicalRate<CoeffType,VectorCoeffType>*>(this))->derivative(T);
+          return (static_cast<const PhotochemicalRate<CoeffType,VectorCoeffType>*>(this))->derivative(conditions.particle_flux(my_index)); 
         }
         break;
 
@@ -284,61 +275,62 @@ namespace Antioch{
       } // switch(my_type)
 
     // Dummy
-    return zero_clone(T);
+    return zero_clone(conditions.T());
   }
 
   template <typename CoeffType, typename VectorCoeffType>
-  template <typename StateType>
+  template <typename StateType, typename VectorStateType>
   inline
-  void KineticsType<CoeffType,VectorCoeffType>::compute_rate_and_derivative(const StateType& T, StateType& rate, StateType& drate_dT) const
+  void KineticsType<CoeffType,VectorCoeffType>::compute_rate_and_derivative(const KineticsConditions<StateType,VectorStateType>& conditions, 
+                                                                                  StateType& rate, StateType& drate_dT) const
   {
     switch (my_type) 
       {
       case(KineticsModel::CONSTANT):
         {
-          (static_cast<const ConstantRate<CoeffType>*>(this))->rate_and_derivative(T,rate,drate_dT);
+          (static_cast<const ConstantRate<CoeffType>*>(this))->rate_and_derivative(conditions.T(),rate,drate_dT);
         }
         break;
 
       case(KineticsModel::HERCOURT_ESSEN):
         {
-          (static_cast<const HercourtEssenRate<CoeffType>*>(this))->rate_and_derivative(T,rate,drate_dT);
+          (static_cast<const HercourtEssenRate<CoeffType>*>(this))->rate_and_derivative(conditions.T(),rate,drate_dT);
         }
         break;
 
       case(KineticsModel::BERTHELOT):
         {
-          (static_cast<const BerthelotRate<CoeffType>*>(this))->rate_and_derivative(T,rate,drate_dT);
+          (static_cast<const BerthelotRate<CoeffType>*>(this))->rate_and_derivative(conditions.T(),rate,drate_dT);
         }
         break;
 
       case(KineticsModel::ARRHENIUS):
         {
-          (static_cast<const ArrheniusRate<CoeffType>*>(this))->rate_and_derivative(T,rate,drate_dT);
+          (static_cast<const ArrheniusRate<CoeffType>*>(this))->rate_and_derivative(conditions.T(),rate,drate_dT);
         }
         break;
 
       case(KineticsModel::BHE):
         {
-          (static_cast<const BerthelotHercourtEssenRate<CoeffType>*>(this))->rate_and_derivative(T,rate,drate_dT);
+          (static_cast<const BerthelotHercourtEssenRate<CoeffType>*>(this))->rate_and_derivative(conditions.T(),rate,drate_dT);
         }
         break;
 
       case(KineticsModel::KOOIJ):
         {
-          (static_cast<const KooijRate<CoeffType>*>(this))->rate_and_derivative(T,rate,drate_dT);
+          (static_cast<const KooijRate<CoeffType>*>(this))->rate_and_derivative(conditions.T(),rate,drate_dT);
         }
         break;
 
       case(KineticsModel::VANTHOFF):
         {
-          (static_cast<const VantHoffRate<CoeffType>*>(this))->rate_and_derivative(T,rate,drate_dT);
+          (static_cast<const VantHoffRate<CoeffType>*>(this))->rate_and_derivative(conditions.T(),rate,drate_dT);
         }
         break;
 
       case(KineticsModel::PHOTOCHEM):
         {
-          (static_cast<const PhotochemicalRate<CoeffType,VectorCoeffType>*>(this))->rate_and_derivative(T,rate,drate_dT);
+          (static_cast<const PhotochemicalRate<CoeffType,VectorCoeffType>*>(this))->rate_and_derivative(conditions.particle_flux(my_index),rate,drate_dT);
         }
         break;
 

--- a/src/kinetics/include/antioch/photochemical_rate.h
+++ b/src/kinetics/include/antioch/photochemical_rate.h
@@ -142,11 +142,12 @@ namespace Antioch{
      const VectorStateType &hv_flux =  pf.flux();
      const VectorStateType &hv_lambda = pf.abscissa();
 
-     VectorStateType cross_section_on_flux_grid;
-
 //cross-section and lambda exists
      antioch_assert_greater(_cross_section.size(),0);
      antioch_assert_greater(_lambda_grid.size(),0);
+
+//needed grid to the right size
+     VectorStateType cross_section_on_flux_grid(hv_lambda.size());
 
 //put them on the right grid
       _converter.y_on_custom_grid(_lambda_grid,_cross_section,hv_lambda,cross_section_on_flux_grid);

--- a/src/kinetics/include/antioch/photochemical_rate.h
+++ b/src/kinetics/include/antioch/photochemical_rate.h
@@ -177,7 +177,7 @@ namespace Antioch{
   inline
   void PhotochemicalRate<CoeffType,VectorCoeffType>::rate_and_derivative(const ParticleFlux<VectorStateType> &pf, StateType& rate, StateType& drate_dT) const
   {
-    Antioch::constant_clone(rate,this->rate(pf));
+    Antioch::init_clone(rate,this->rate(pf));
     Antioch::set_zero(drate_dT);
     return;
   }

--- a/src/kinetics/include/antioch/reaction.h
+++ b/src/kinetics/include/antioch/reaction.h
@@ -44,8 +44,8 @@
 #include "antioch/vanthoff_rate.h"
 #include "antioch/photochemical_rate.h"
 #include "antioch/reaction_enum.h"
-#include "antioch/particle_flux.h"
 #include "antioch/chemical_mixture.h"
+#include "antioch/kinetics_conditions.h"
 
 //C++
 #include <string>
@@ -189,12 +189,8 @@ namespace Antioch
     //!
     CoeffType efficiency( const unsigned int s) const;
 
-    //! Sets the particle flux
-    template <typename VectorStateType>
-    void set_particle_flux(ParticleFlux<VectorStateType> *pf);
-
     //! Computes derived quantities.
-    void initialize();    
+    void initialize(unsigned int index);    
 
     //!
     int gamma() const;
@@ -213,33 +209,29 @@ namespace Antioch
                                               StateType& keq,
                                               StateType& dkeq_dT) const;
 
-
-    //// in reaction set
-    void update_particles_flux();
-
     //!
     template <typename StateType, typename VectorStateType>
     StateType compute_forward_rate_coefficient( const VectorStateType& molar_densities,
-                                                const StateType& T) const;
+                                                const KineticsConditions<StateType,VectorStateType>& conditions) const;
     
     //!
     template <typename StateType, typename VectorStateType>
     void compute_forward_rate_coefficient_and_derivatives( const VectorStateType& molar_densities,
-                                                           const StateType& T, 
+                                                           const KineticsConditions<StateType,VectorStateType>& conditions, 
                                                            StateType& kfwd, 
                                                            StateType& dkfwd_dT,
                                                            VectorStateType& dkfwd_dX) const;
     ////
     template <typename StateType, typename VectorStateType>
     StateType compute_rate_of_progress( const VectorStateType& molar_densities,
-                                        const StateType& T,  
+                                        const KineticsConditions<StateType,VectorStateType>& conditions,  
                                         const StateType& P0_RT,  
                                         const VectorStateType& h_RT_minus_s_R) const;
 
     template <typename StateType, typename VectorStateType>
     void compute_rate_of_progress_and_derivatives( const VectorStateType &molar_densities,
                                                    const ChemicalMixture<CoeffType>& chem_mixture,
-                                                   const StateType& T,
+                                                   const KineticsConditions<StateType,VectorStateType>& conditions,
                                                    const StateType &P0_RT,
                                                    const VectorStateType &h_RT_minus_s_R,
                                                    const VectorStateType &dh_RT_minus_s_R_dT,
@@ -291,8 +283,6 @@ namespace Antioch
     bool _reversible;
     ReactionType::ReactionType _type;
     KineticsModel::KineticsModel _kintype;
-
-    ParticleFlux<VectorCoeffType> * _particle_flux;
 
     //! The forward reaction rate modified Arrhenius form.
     std::vector<KineticsType<CoeffType,VectorCoeffType>* > _forward_rate;
@@ -519,33 +509,6 @@ namespace Antioch
   }
 
   template<typename CoeffType, typename VectorCoeffType>
-  template<typename VectorStateType>
-  inline
-  void Reaction<CoeffType,VectorCoeffType>::set_particle_flux(ParticleFlux<VectorStateType> *pf)
-  {
-
-   antioch_assert_equal_to(_type,ReactionType::ELEMENTARY);//elementary reaction
-
-///first deal with the particle_flux pointer, if there was another, tell him it loses a reaction
-    if(_particle_flux)_particle_flux->remove_a_reaction();
-//then we set it and tell the new one it's got a new reaction
-    _particle_flux = pf;
-
-    if(_particle_flux) //enable to give only a NULL pointer and deal with it later
-    {
-      _particle_flux->add_a_reaction();
-
-      if(_particle_flux->updated())
-      {
-        _forward_rate[0]->calculate_rate_constant(_particle_flux->flux(),_particle_flux->abscissa(),true);
-        _particle_flux->update_done();
-      }
-    }
-
-    return;
-  }
-
-  template<typename CoeffType, typename VectorCoeffType>
   inline
   int Reaction<CoeffType,VectorCoeffType>::gamma () const
   {
@@ -582,8 +545,7 @@ namespace Antioch
       _initialized(false),
       _reversible(reversible),
       _type(type),
-      _kintype(kin),
-      _particle_flux(NULL)
+      _kintype(kin)
   {
     _efficiencies.resize(_n_species); 
     std::fill (_efficiencies.begin(), _efficiencies.end(), 1.);
@@ -605,7 +567,7 @@ namespace Antioch
 
   template<typename CoeffType, typename VectorCoeffType>
   inline
-  void Reaction<CoeffType,VectorCoeffType>::initialize()
+  void Reaction<CoeffType,VectorCoeffType>::initialize(unsigned int index)
   {
     // Stoichiometric coefficients, by species id
     {
@@ -645,6 +607,13 @@ namespace Antioch
         
         _gamma += _species_delta_stoichiometry[s];
       }
+
+     // gives kinetics object index in reaction set
+     for(typename std::vector<KineticsType<CoeffType,VectorCoeffType>* >::iterator it = _forward_rate.begin();
+                it != _forward_rate.end(); it++)
+     {
+        (*it)->set_index(index);
+     }
    
     // set initialization flag
     _initialized = true;
@@ -752,56 +721,40 @@ namespace Antioch
 
 
   template<typename CoeffType, typename VectorCoeffType>
-  inline
-  void Reaction<CoeffType,VectorCoeffType>::update_particles_flux()
-  {
-    //if we have a photochemical rate, deal with it here
-    if(_particle_flux)
-    {
-      antioch_assert_equal_to(_type,ReactionType::ELEMENTARY);//elementary reaction
-      if(_particle_flux->updated())
-      {
-        _forward_rate[0]->calculate_rate_constant(_particle_flux->flux(),_particle_flux->abscissa(),_particle_flux->x_updated());
-        _particle_flux->update_done();
-      }
-    }
-  }
-
-  template<typename CoeffType, typename VectorCoeffType>
   template <typename StateType, typename VectorStateType>
   inline
   StateType Reaction<CoeffType,VectorCoeffType>::compute_forward_rate_coefficient( const VectorStateType& molar_densities,
-                                                                   const StateType& T) const
+                                                                   const KineticsConditions<StateType,VectorStateType>& conditions) const
   {
     switch(_type)
       {
       case(ReactionType::ELEMENTARY):
         {
-          return (static_cast<const ElementaryReaction<CoeffType>*>(this))->compute_forward_rate_coefficient(molar_densities,T);
+          return (static_cast<const ElementaryReaction<CoeffType>*>(this))->compute_forward_rate_coefficient(molar_densities,conditions);
         }
         break;
 
       case(ReactionType::DUPLICATE):
         {
-          return (static_cast<const DuplicateReaction<CoeffType>*>(this))->compute_forward_rate_coefficient(molar_densities,T);
+          return (static_cast<const DuplicateReaction<CoeffType>*>(this))->compute_forward_rate_coefficient(molar_densities,conditions);
         }
         break;
 
       case(ReactionType::THREE_BODY):
         {
-          return (static_cast<const ThreeBodyReaction<CoeffType>*>(this))->compute_forward_rate_coefficient(molar_densities,T);
+          return (static_cast<const ThreeBodyReaction<CoeffType>*>(this))->compute_forward_rate_coefficient(molar_densities,conditions);
         }
         break;
 
       case(ReactionType::LINDEMANN_FALLOFF):
         {
-          return (static_cast<const FalloffReaction<CoeffType,LindemannFalloff<CoeffType> >*>(this))->compute_forward_rate_coefficient(molar_densities,T);
+          return (static_cast<const FalloffReaction<CoeffType,LindemannFalloff<CoeffType> >*>(this))->compute_forward_rate_coefficient(molar_densities,conditions);
         }
         break;
 
       case(ReactionType::TROE_FALLOFF):
         {
-          return (static_cast<const FalloffReaction<CoeffType,TroeFalloff<CoeffType> >*>(this))->compute_forward_rate_coefficient(molar_densities,T);
+          return (static_cast<const FalloffReaction<CoeffType,TroeFalloff<CoeffType> >*>(this))->compute_forward_rate_coefficient(molar_densities,conditions);
         }
         break;
 
@@ -812,14 +765,14 @@ namespace Antioch
       } // switch(_type)
 
     // Dummy
-    return zero_clone(T);
+    return zero_clone(conditions.T());
   }
 
   template<typename CoeffType, typename VectorCoeffType>
   template <typename StateType, typename VectorStateType>
   inline
   void Reaction<CoeffType,VectorCoeffType>::compute_forward_rate_coefficient_and_derivatives( const VectorStateType& molar_densities,
-                                                                              const StateType& T, 
+                                                                              const KineticsConditions<StateType,VectorStateType>& conditions, 
                                                                               StateType& kfwd, 
                                                                               StateType& dkfwd_dT,
                                                                               VectorStateType& dkfwd_dX) const
@@ -828,31 +781,31 @@ namespace Antioch
       {
       case(ReactionType::ELEMENTARY):
         {
-          (static_cast<const ElementaryReaction<CoeffType>*>(this))->compute_forward_rate_coefficient_and_derivatives(molar_densities,T,kfwd,dkfwd_dT,dkfwd_dX);
+          (static_cast<const ElementaryReaction<CoeffType>*>(this))->compute_forward_rate_coefficient_and_derivatives(molar_densities,conditions,kfwd,dkfwd_dT,dkfwd_dX);
         }
         break;
 
       case(ReactionType::DUPLICATE):
         {
-          (static_cast<const DuplicateReaction<CoeffType>*>(this))->compute_forward_rate_coefficient_and_derivatives(molar_densities,T,kfwd,dkfwd_dT,dkfwd_dX);
+          (static_cast<const DuplicateReaction<CoeffType>*>(this))->compute_forward_rate_coefficient_and_derivatives(molar_densities,conditions,kfwd,dkfwd_dT,dkfwd_dX);
         }
         break;
 
       case(ReactionType::THREE_BODY):
         {
-          (static_cast<const ThreeBodyReaction<CoeffType>*>(this))->compute_forward_rate_coefficient_and_derivatives(molar_densities,T,kfwd,dkfwd_dT,dkfwd_dX);
+          (static_cast<const ThreeBodyReaction<CoeffType>*>(this))->compute_forward_rate_coefficient_and_derivatives(molar_densities,conditions,kfwd,dkfwd_dT,dkfwd_dX);
         }
         break;
 
       case(ReactionType::LINDEMANN_FALLOFF):
         {
-          (static_cast<const FalloffReaction<CoeffType,LindemannFalloff<CoeffType> >*>(this))->compute_forward_rate_coefficient_and_derivatives(molar_densities,T,kfwd,dkfwd_dT,dkfwd_dX);
+          (static_cast<const FalloffReaction<CoeffType,LindemannFalloff<CoeffType> >*>(this))->compute_forward_rate_coefficient_and_derivatives(molar_densities,conditions,kfwd,dkfwd_dT,dkfwd_dX);
         }
         break;
 
       case(ReactionType::TROE_FALLOFF):
         {
-          (static_cast<const FalloffReaction<CoeffType,TroeFalloff<CoeffType> >*>(this))->compute_forward_rate_coefficient_and_derivatives(molar_densities,T,kfwd,dkfwd_dT,dkfwd_dX);
+          (static_cast<const FalloffReaction<CoeffType,TroeFalloff<CoeffType> >*>(this))->compute_forward_rate_coefficient_and_derivatives(molar_densities,conditions,kfwd,dkfwd_dT,dkfwd_dX);
         }
         break;
 
@@ -871,11 +824,11 @@ namespace Antioch
   template <typename StateType, typename VectorStateType>
   inline
   StateType Reaction<CoeffType,VectorCoeffType>::compute_rate_of_progress( const VectorStateType& molar_densities,
-                                                           const StateType& T,  
+                                                           const KineticsConditions<StateType,VectorStateType>& conditions,  
                                                            const StateType& P0_RT,  
                                                            const VectorStateType& h_RT_minus_s_R) const
   {
-    StateType kfwd = this->compute_forward_rate_coefficient(molar_densities,T);
+    StateType kfwd = this->compute_forward_rate_coefficient(molar_densities,conditions);
     StateType kfwd_times_reactants = kfwd;
 
     // Rfwd
@@ -912,7 +865,7 @@ namespace Antioch
   inline
   void Reaction<CoeffType,VectorCoeffType>::compute_rate_of_progress_and_derivatives( const VectorStateType &molar_densities,
                                                                       const ChemicalMixture<CoeffType>& chem_mixture,
-                                                                      const StateType& T,
+                                                                      const KineticsConditions<StateType,VectorStateType>& conditions,
                                                                       const StateType &P0_RT,
                                                                       const VectorStateType &h_RT_minus_s_R,
                                                                       const VectorStateType &dh_RT_minus_s_R_dT,
@@ -924,12 +877,12 @@ namespace Antioch
 
 // First the forward component, if reversible, compute and add the backward component
 
-    StateType kfwd = Antioch::zero_clone(T);
-    StateType dkfwd_dT = Antioch::zero_clone(T);
+    StateType kfwd = Antioch::zero_clone(conditions.T());
+    StateType dkfwd_dT = Antioch::zero_clone(conditions.T());
     VectorStateType dkfwd_dX_s = Antioch::zero_clone(molar_densities);
     VectorStateType dkbkwd_dX_s = Antioch::zero_clone(molar_densities);
 
-    this->compute_forward_rate_coefficient_and_derivatives(molar_densities, T, kfwd, dkfwd_dT ,dkfwd_dX_s);
+    this->compute_forward_rate_coefficient_and_derivatives(molar_densities, conditions, kfwd, dkfwd_dT ,dkfwd_dX_s);
 
     // If users want to use valarrays, then the output reference sizes
     // had better already match the input value sizes...
@@ -951,7 +904,7 @@ namespace Antioch
       }
     
     //init
-    StateType facfwd = constant_clone(T,1);
+    StateType facfwd = constant_clone(conditions.T(),1);
     dRfwd_dT = dkfwd_dT;
 
     // Rfwd & derivatives
@@ -995,10 +948,10 @@ namespace Antioch
 
     //backward to be computed and added
 
-      StateType keq = Antioch::zero_clone(T);
-      StateType dkeq_dT = Antioch::zero_clone(T);
+      StateType keq = Antioch::zero_clone(conditions.T());
+      StateType dkeq_dT = Antioch::zero_clone(conditions.T());
 
-      equilibrium_constant_and_derivative( T, P0_RT, h_RT_minus_s_R,
+      equilibrium_constant_and_derivative( conditions.T(), P0_RT, h_RT_minus_s_R,
                                            dh_RT_minus_s_R_dT,
                                            keq, dkeq_dT );
 
@@ -1029,7 +982,7 @@ namespace Antioch
         }
 
       //init
-      StateType facbkwd = constant_clone(T,1);
+      StateType facbkwd = constant_clone(conditions.T(),1);
       dRbkwd_dT = dkbkwd_dT;
 
       // Rbkwd & derivatives

--- a/src/kinetics/include/antioch/reaction.h
+++ b/src/kinetics/include/antioch/reaction.h
@@ -190,7 +190,7 @@ namespace Antioch
     CoeffType efficiency( const unsigned int s) const;
 
     //! Computes derived quantities.
-    void initialize(unsigned int index);    
+    void initialize(unsigned int index = 0);
 
     //!
     int gamma() const;

--- a/src/kinetics/include/antioch/reaction_set.h
+++ b/src/kinetics/include/antioch/reaction_set.h
@@ -34,6 +34,7 @@
 // Antioch
 #include "antioch/chemical_mixture.h"
 #include "antioch/reaction.h"
+#include "antioch/kinetics_conditions.h"
 #include "antioch/elementary_reaction.h"
 #include "antioch/duplicate_reaction.h"
 #include "antioch/threebody_reaction.h"
@@ -77,10 +78,6 @@ namespace Antioch
     // object, they are deleted in the desctructor.
     void add_reaction(Reaction<CoeffType>* reaction);
 
-    //!
-    template<typename VectorStateType>
-    void set_particle_flux(ParticleFlux<VectorStateType> *pf, int r = -1);
-
     //! \returns a constant reference to reaction \p r.
     const Reaction<CoeffType>& reaction(const unsigned int r) const;
 
@@ -88,14 +85,14 @@ namespace Antioch
 
     //! Compute the rates of progress for each reaction
     template <typename StateType, typename VectorStateType, typename VectorReactionsType>
-    void compute_reaction_rates( const StateType& T,
+    void compute_reaction_rates( const KineticsConditions<StateType,VectorStateType>& conditions,
                                  const VectorStateType& molar_densities,
                                  const VectorStateType& h_RT_minus_s_R,
                                  VectorReactionsType& net_reaction_rates ) const;
 
     //! Compute the rates of progress and derivatives for each reaction
     template <typename StateType, typename VectorStateType, typename VectorReactionsType, typename MatrixReactionsType>
-    void compute_reaction_rates_and_derivs( const StateType& T,
+    void compute_reaction_rates_and_derivs( const KineticsConditions<StateType,VectorStateType>& conditions,
                                             const VectorStateType& molar_densities,
                                             const VectorStateType& h_RT_minus_s_R,
                                             const VectorStateType& dh_RT_minus_s_R_dT,
@@ -104,12 +101,9 @@ namespace Antioch
                                             MatrixReactionsType& dnet_rate_dX_s ) const;
 
     //!
-    void update_particle_flux_chemistry();
-
-    //!
     template <typename StateType, typename VectorStateType>
     void print_chemical_scheme( std::ostream& output,
-                                const StateType& T,
+                                const KineticsConditions<StateType,VectorStateType>& conditions,
                                 const VectorStateType& molar_densities,
                                 const VectorStateType& h_RT_minus_s_R ,
                                 std::vector<VectorStateType> &lossMatrix,
@@ -118,7 +112,7 @@ namespace Antioch
 
     //!
     template<typename StateType, typename VectorStateType>
-    void get_reactive_scheme( const StateType& T,
+    void get_reactive_scheme( const KineticsConditions<StateType,VectorStateType>& conditions,
                               const VectorStateType& molar_densities,
                               const VectorStateType& h_RT_minus_s_R,
                               VectorStateType& net_rates,
@@ -175,7 +169,7 @@ namespace Antioch
     _reactions.push_back(reaction);
     
     // and make sure it is initialized!
-    _reactions.back()->initialize();
+    _reactions.back()->initialize(_reactions.size() - 1);
 
     return;
   }
@@ -200,7 +194,7 @@ namespace Antioch
   inline
   ReactionSet<CoeffType>::ReactionSet( const ChemicalMixture<CoeffType>& chem_mixture )
     : _chem_mixture(chem_mixture),
-      _P0_R(1.0e5/Constants::R_universal<CoeffType>())
+      _P0_R(1.0e5/Constants::R_universal<CoeffType>()) //SI
   {
     return;
   }
@@ -215,44 +209,9 @@ namespace Antioch
   }
   
   template<typename CoeffType>
-  template<typename VectorStateType>
-  inline
-  void ReactionSet<CoeffType>::set_particle_flux(ParticleFlux<VectorStateType> *pf, int r)
-  {
-     //in that case, everyone gets the same particle flux
-     if(r < 0)
-     {
-        for(unsigned int ir = 0; ir < _reactions.size(); ir++)
-        {
-          if(_reactions[ir]->kinetics_model() == KineticsModel::PHOTOCHEM)
-          {
-             _reactions[ir]->set_particle_flux(pf);
-             _reactions[ir]->update_particles_flux();
-          }
-        }
-     }else
-     {
-        _reactions[r]->set_particle_flux(pf);
-        _reactions[r]->update_particles_flux();
-     }
-
-     return;
-  }
-
-  template<typename CoeffType>
-  inline
-  void ReactionSet<CoeffType>::update_particle_flux_chemistry()
-  {
-      for(unsigned int ir = 0; ir < _reactions.size(); ir++)
-      {
-         _reactions[ir]->update_particles_flux();
-      }
-  }
-
-  template<typename CoeffType>
   template<typename StateType, typename VectorStateType, typename VectorReactionsType>
   inline
-  void ReactionSet<CoeffType>::compute_reaction_rates ( const StateType& T,
+  void ReactionSet<CoeffType>::compute_reaction_rates ( const KineticsConditions<StateType,VectorStateType>& conditions,
                                                         const VectorStateType& molar_densities,
                                                         const VectorStateType& h_RT_minus_s_R,
                                                         VectorReactionsType& net_reaction_rates ) const
@@ -266,12 +225,12 @@ namespace Antioch
     antioch_assert_equal_to( h_RT_minus_s_R.size(), this->n_species() );
 
     // useful constants
-    const StateType P0_RT = _P0_R/T; // used to transform equilibrium constant from pressure units
+    const StateType P0_RT = _P0_R/conditions.T(); // used to transform equilibrium constant from pressure units
 
     // compute reaction forward rates & other reaction-sized arrays
     for (unsigned int rxn=0; rxn<this->n_reactions(); rxn++)
       {
-        net_reaction_rates[rxn] = this->reaction(rxn).compute_rate_of_progress(molar_densities, T, P0_RT, h_RT_minus_s_R);
+        net_reaction_rates[rxn] = this->reaction(rxn).compute_rate_of_progress(molar_densities, conditions, P0_RT, h_RT_minus_s_R);
       }
     
     return;
@@ -280,7 +239,7 @@ namespace Antioch
   template<typename CoeffType>
   template<typename StateType, typename VectorStateType, typename VectorReactionsType, typename MatrixReactionsType>
   inline
-  void ReactionSet<CoeffType>::compute_reaction_rates_and_derivs( const StateType& T,
+  void ReactionSet<CoeffType>::compute_reaction_rates_and_derivs( const KineticsConditions<StateType,VectorStateType>& conditions,
                                                                   const VectorStateType& molar_densities,
                                                                   const VectorStateType& h_RT_minus_s_R,
                                                                   const VectorStateType& dh_RT_minus_s_R_dT,
@@ -306,13 +265,13 @@ namespace Antioch
     antioch_assert_equal_to( h_RT_minus_s_R.size(), this->n_species() );
 
     // useful constants
-    const StateType P0_RT = _P0_R/T; // used to transform equilibrium constant from pressure units
+    const StateType P0_RT = _P0_R/conditions.T(); // used to transform equilibrium constant from pressure units
 
     // compute reaction forward rates & other reaction-sized arrays
     for (unsigned int rxn=0; rxn<this->n_reactions(); rxn++)
       {
         this->reaction(rxn).compute_rate_of_progress_and_derivatives( molar_densities, _chem_mixture, 
-                                                                      T, P0_RT, h_RT_minus_s_R, dh_RT_minus_s_R_dT,
+                                                                      conditions, P0_RT, h_RT_minus_s_R, dh_RT_minus_s_R_dT,
                                                                       net_reaction_rates[rxn], 
                                                                       dnet_rate_dT[rxn], 
                                                                       dnet_rate_dX_s[rxn] );
@@ -325,7 +284,7 @@ namespace Antioch
   template<typename StateType, typename VectorStateType>
   inline
   void ReactionSet<CoeffType>::print_chemical_scheme( std::ostream& output,
-                                                      const StateType& T,
+                                                      const KineticsConditions<StateType,VectorStateType>& conditions,
                                                       const VectorStateType& molar_densities,
                                                       const VectorStateType& h_RT_minus_s_R,
                                                       std::vector<VectorStateType>& lossMatrix,
@@ -337,7 +296,7 @@ namespace Antioch
     VectorStateType netRate,kfwd_const,kbkwd_const,kfwd,kbkwd,fwd_conc,bkwd_conc;
 
     //getting reaction infos
-    get_reactive_scheme(T,molar_densities,h_RT_minus_s_R,netRate,kfwd_const,kbkwd_const,kfwd,kbkwd,fwd_conc,bkwd_conc);
+    get_reactive_scheme(conditions,molar_densities,h_RT_minus_s_R,netRate,kfwd_const,kbkwd_const,kfwd,kbkwd,fwd_conc,bkwd_conc);
 
     lossMatrix.resize(this->n_species());
     prodMatrix.resize(this->n_species());
@@ -570,7 +529,7 @@ namespace Antioch
   template<typename CoeffType>
   template<typename StateType, typename VectorStateType>
   inline
-  void ReactionSet<CoeffType>::get_reactive_scheme( const StateType& T,
+  void ReactionSet<CoeffType>::get_reactive_scheme( const KineticsConditions<StateType,VectorStateType>& conditions,
                                                     const VectorStateType& molar_densities,
                                                     const VectorStateType& h_RT_minus_s_R,
                                                     VectorStateType& net_rates,
@@ -588,7 +547,7 @@ namespace Antioch
     antioch_assert_equal_to( h_RT_minus_s_R.size(), this->n_species() );
 
     // useful constants
-    const StateType P0_RT = _P0_R/T; // used to transform equilibrium constant from pressure units
+    const StateType P0_RT = _P0_R/conditions.T(); // used to transform equilibrium constant from pressure units
 
     net_rates.resize(this->n_reactions(),0.);
     kfwd_const.resize(this->n_reactions(),0.);
@@ -602,7 +561,7 @@ namespace Antioch
     for (unsigned int rxn=0; rxn<this->n_reactions(); rxn++)
       {
         const Reaction<CoeffType>& reaction = this->reaction(rxn);
-        kfwd_const[rxn] = reaction.compute_forward_rate_coefficient(molar_densities,T);
+        kfwd_const[rxn] = reaction.compute_forward_rate_coefficient(molar_densities,conditions);
         kfwd[rxn] = kfwd_const[rxn];
 
         for (unsigned int r=0; r<reaction.n_reactants(); r++)

--- a/src/kinetics/include/antioch/threebody_reaction.h
+++ b/src/kinetics/include/antioch/threebody_reaction.h
@@ -33,6 +33,7 @@
 
 // Antioch
 #include "antioch/reaction.h"
+#include "antioch/kinetics_conditions.h"
 
 //C++
 #include <string>
@@ -79,12 +80,12 @@ namespace Antioch
     //!
     template <typename StateType, typename VectorStateType>
     StateType compute_forward_rate_coefficient( const VectorStateType& molar_densities,
-                                                const StateType& T ) const;
+                                                const KineticsConditions<StateType,VectorStateType>& conditions ) const;
     
     //!
     template <typename StateType, typename VectorStateType>
     void compute_forward_rate_coefficient_and_derivatives( const VectorStateType& molar_densities,
-                                                           const StateType& T,  
+                                                           const KineticsConditions<StateType,VectorStateType>& conditions,  
                                                            StateType& kfwd,  
                                                            StateType& dkfwd_dT, 
                                                            VectorStateType& dkfwd_dX) const;
@@ -118,7 +119,7 @@ namespace Antioch
   template<typename StateType, typename VectorStateType>
   inline
   StateType ThreeBodyReaction<CoeffType>::compute_forward_rate_coefficient( const VectorStateType& molar_densities,
-                                                                            const StateType& T  ) const
+                                                                            const KineticsConditions<StateType,VectorStateType>& conditions  ) const
   {
     //k(T,[M]) = (sum eff_i * C_i) * ...
     StateType kfwd = (this->efficiency(0) * molar_densities[0] );
@@ -129,7 +130,7 @@ namespace Antioch
       }
 
     //... alpha(T)
-    return (kfwd * (*this->_forward_rate[0])(T));
+    return (kfwd * (*this->_forward_rate[0])(conditions));
   }
 
 
@@ -137,7 +138,7 @@ namespace Antioch
   template<typename StateType, typename VectorStateType>
   inline
   void ThreeBodyReaction<CoeffType>::compute_forward_rate_coefficient_and_derivatives( const VectorStateType &molar_densities,
-                                                                                       const StateType& T,  
+                                                                                       const KineticsConditions<StateType,VectorStateType>& conditions,  
                                                                                        StateType& kfwd, 
                                                                                        StateType& dkfwd_dT,
                                                                                        VectorStateType& dkfwd_dX) const
@@ -146,7 +147,7 @@ namespace Antioch
 
     //dk_dT = dalpha_dT * [sum_s (eps_s * X_s)]
     //dk_dCi = alpha(T) * eps_i
-    this->_forward_rate[0]->compute_rate_and_derivative(T,kfwd,dkfwd_dT);
+    this->_forward_rate[0]->compute_rate_and_derivative(conditions,kfwd,dkfwd_dT);
 
     dkfwd_dX[0] = kfwd;
     StateType coef = (this->efficiency(0) * molar_densities[0]);

--- a/src/particles_flux/include/antioch/sigma_bin_converter.h
+++ b/src/particles_flux/include/antioch/sigma_bin_converter.h
@@ -173,12 +173,9 @@ void SigmaBinConverter<VectorCoeffType>::y_on_custom_grid(const VectorCoeffType 
                                                          (StateType)(ref_value * (custom_tail - custom_head)))
                        );
 
-       typedef typename Antioch::rebind<StateType, bool>::type BoolType;
-
        //body from ref head to ref last tail
-       // FIXME - remove the BoolType once vexcl disjunction / cunjunction are fixed
-       while(Antioch::disjunction((BoolType)(ref_tail < custom_tail &&                     // ref is below tail (<=> start_head < index_heads[custom_head_index + 1])
-                                   start_head < Antioch::constant_clone(start_head,list_ref_head_tails.size() - 1)))) // ref is still defined
+       while(Antioch::disjunction(ref_tail < custom_tail &&                     // ref is below tail (<=> start_head < index_heads[custom_head_index + 1])
+                                   start_head < Antioch::constant_clone(start_head,list_ref_head_tails.size() - 1))) // ref is still defined
        {
            ref_end_tail = min((UIntType)(start_head + Antioch::constant_clone(start_head,1)) ,
                               (UIntType)(Antioch::constant_clone(start_head,list_ref_head_tails.size() - 1)));

--- a/src/particles_flux/include/antioch/sigma_bin_converter.h
+++ b/src/particles_flux/include/antioch/sigma_bin_converter.h
@@ -152,9 +152,9 @@ void SigmaBinConverter<VectorCoeffType>::y_on_custom_grid(const VectorCoeffType 
 
 
         // if StateType is vectorized, it takes care of it here
-       StateType ref_head  = Antioch::upgrade_type(custom_head,list_ref_head_tails,start_head);
-       StateType ref_tail  = Antioch::upgrade_type(custom_head,list_ref_head_tails,ref_end_tail);
-       StateType ref_value = Antioch::upgrade_type(custom_head,list_ref_values,value_head);
+       StateType ref_head  = Antioch::custom_clone(custom_head,list_ref_head_tails,start_head);
+       StateType ref_tail  = Antioch::custom_clone(custom_head,list_ref_head_tails,ref_end_tail);
+       StateType ref_value = Antioch::custom_clone(custom_head,list_ref_values,value_head);
 
        //head from custom head to ref head
        // super not efficient, everything is calculated every time...
@@ -173,9 +173,9 @@ void SigmaBinConverter<VectorCoeffType>::y_on_custom_grid(const VectorCoeffType 
            ref_end_tail = min<typename Antioch::value_type<typename Antioch::value_type<VIntType>::type>::type>
                                 (start_head + Antioch::constant_clone(start_head,1),Antioch::constant_clone(start_head,list_ref_head_tails.size() - 1));
 
-           ref_head  = Antioch::upgrade_type(custom_head,list_ref_head_tails,start_head);
-           ref_tail  = Antioch::upgrade_type(custom_head,list_ref_head_tails,ref_end_tail);
-           ref_value = Antioch::upgrade_type(custom_head,list_ref_values,start_head);
+           ref_head  = Antioch::custom_clone(custom_head,list_ref_head_tails,start_head);
+           ref_tail  = Antioch::custom_clone(custom_head,list_ref_head_tails,ref_end_tail);
+           ref_value = Antioch::custom_clone(custom_head,list_ref_values,start_head);
 
            surf += Antioch::if_else<typename Antioch::value_type<StateType>::type>(ref_tail < custom_tail && start_head < Antioch::constant_clone(start_head,list_ref_head_tails.size()),
                                         (ref_tail - ref_head) * ref_value,
@@ -189,9 +189,9 @@ void SigmaBinConverter<VectorCoeffType>::y_on_custom_grid(const VectorCoeffType 
       ref_end_tail = min<typename Antioch::value_type<typename Antioch::value_type<VIntType>::type>::type>
                         (start_head + Antioch::constant_clone(start_head,1),Antioch::constant_clone(start_head,list_ref_head_tails.size() - 1));
                                                                                  
-       ref_head  = Antioch::upgrade_type(custom_head,list_ref_head_tails,start_head);
-       ref_tail  = Antioch::upgrade_type(custom_head,list_ref_head_tails,ref_end_tail);
-       ref_value = Antioch::upgrade_type(custom_head,list_ref_values,start_head);
+       ref_head  = Antioch::custom_clone(custom_head,list_ref_head_tails,start_head);
+       ref_tail  = Antioch::custom_clone(custom_head,list_ref_head_tails,ref_end_tail);
+       ref_value = Antioch::custom_clone(custom_head,list_ref_values,start_head);
 
        //tail from ref_head to custom_tail
        surf += Antioch::if_else<typename Antioch::value_type<StateType>::type>(

--- a/src/particles_flux/include/antioch/sigma_bin_converter.h
+++ b/src/particles_flux/include/antioch/sigma_bin_converter.h
@@ -162,7 +162,7 @@ void SigmaBinConverter<VectorCoeffType>::y_on_custom_grid(const VectorCoeffType 
        StateType ref_tail  = Antioch::custom_clone(custom_head,list_ref_head_tails,ref_end_tail);
        StateType ref_value = Antioch::custom_clone(custom_head,list_ref_values,value_head);
 
-       //head from custom head to ref head
+       // head from custom head to ref head
        // super not efficient, everything is calculated every time...
        surf += Antioch::if_else(Antioch::constant_clone(custom_head,list_ref_head_tails[0]) > custom_head ||
                                 Antioch::constant_clone(custom_head,list_ref_head_tails[list_ref_head_tails.size() - 1]) < custom_head, // custom is outside ref
@@ -200,7 +200,8 @@ void SigmaBinConverter<VectorCoeffType>::y_on_custom_grid(const VectorCoeffType 
       ref_tail  = Antioch::custom_clone(custom_head,list_ref_head_tails,ref_end_tail);
       ref_value = Antioch::custom_clone(custom_head,list_ref_values,start_head);
 
-       //tail from ref_head to custom_tail
+       // tail from ref_head to custom_tail
+       // super not efficient, everything is calculated every time...
       surf += Antioch::if_else(
                         Antioch::constant_clone(custom_tail,list_ref_head_tails[list_ref_head_tails.size() - 1]) < custom_tail || // custom is outside ref
                         Antioch::constant_clone(custom_tail,list_ref_head_tails.front()) > custom_tail || // custom is outside ref

--- a/src/particles_flux/include/antioch/sigma_bin_converter.h
+++ b/src/particles_flux/include/antioch/sigma_bin_converter.h
@@ -151,11 +151,13 @@ void SigmaBinConverter<VectorCoeffType>::y_on_custom_grid(const VectorCoeffType 
                         (start_head + Antioch::constant_clone(start_head,1),Antioch::constant_clone(start_head,list_ref_head_tails.size() - 1));
 
 
+        // if StateType is vectorized, it takes care of it here
        StateType ref_head  = Antioch::upgrade_type(custom_head,list_ref_head_tails,start_head);
        StateType ref_tail  = Antioch::upgrade_type(custom_head,list_ref_head_tails,ref_end_tail);
        StateType ref_value = Antioch::upgrade_type(custom_head,list_ref_values,value_head);
 
        //head from custom head to ref head
+       // super not efficient, everything is calculated every time...
        surf += Antioch::if_else(Antioch::constant_clone(custom_head,list_ref_head_tails.front()) > custom_head ||
                                 Antioch::constant_clone(custom_head,list_ref_head_tails.back()) < custom_head, // custom is outside ref
                                 Antioch::zero_clone(surf),

--- a/src/particles_flux/include/antioch/sigma_bin_converter.h
+++ b/src/particles_flux/include/antioch/sigma_bin_converter.h
@@ -144,6 +144,8 @@ void SigmaBinConverter<VectorCoeffType>::y_on_custom_grid(const VectorCoeffType 
 
        typedef typename Antioch::value_type<VUIntType>::type UIntType;
 
+       typedef typename Antioch::rebind<UIntType,bool>::type BoolType;
+
        UIntType start_head = index_heads[custom_head_index];
 
        UIntType value_head = Antioch::if_else(start_head > (typename Antioch::value_type<typename Antioch::value_type<VUIntType>::type>::type)0,
@@ -170,8 +172,9 @@ void SigmaBinConverter<VectorCoeffType>::y_on_custom_grid(const VectorCoeffType 
                        );
                                                 
        //body from ref head to ref last tail
-       while(Antioch::disjunction(ref_tail < custom_tail &&                     // ref is below tail (<=> start_head < index_heads[custom_head_index + 1])
-                                  start_head < Antioch::constant_clone(start_head,list_ref_head_tails.size() - 1))) // ref is still defined
+       // FIXME - remove the BoolType once vexcl disjunction / cunjunction are fixed
+       while(Antioch::disjunction((BoolType)(ref_tail < custom_tail &&                     // ref is below tail (<=> start_head < index_heads[custom_head_index + 1])
+                                   start_head < Antioch::constant_clone(start_head,list_ref_head_tails.size() - 1)))) // ref is still defined
        {
            ref_end_tail = min((UIntType)(start_head + Antioch::constant_clone(start_head,1)) ,
                               (UIntType)(Antioch::constant_clone(start_head,list_ref_head_tails.size() - 1)));

--- a/src/particles_flux/include/antioch/sigma_bin_converter.h
+++ b/src/particles_flux/include/antioch/sigma_bin_converter.h
@@ -97,8 +97,8 @@ void SigmaBinConverter<VectorCoeffType>::y_on_custom_grid(const VectorCoeffType 
 // within eigen vector (VIntType = Eigen<vexcl<unsigned int> >):
 //   Eigen => can't initialize in constructor VUIntType
 //   vexcl => fixed size accessible only within constructor
-  VUIntType ihead; 
-  ihead.resize(x_custom.size(),example);
+  VUIntType ihead(x_custom.size()); 
+  Antioch::init_constant(ihead,example);
 
   UIntType unfound = Antioch::constant_clone(example,x_old.size()-1);
 
@@ -116,10 +116,8 @@ void SigmaBinConverter<VectorCoeffType>::y_on_custom_grid(const VectorCoeffType 
       if(Antioch::conjunction(ihigh != unfound))break; // once we found everyone, don't waste time
     }
     ihead[ic] = ihigh;
-std::cout << ihigh << std::endl;
   }
 
-std::cout << "\nout of eval_index\n" << ihead << std::endl;
   // bin
   for(unsigned int ic = 0; ic < x_custom.size() - 1; ic++) // right stairs, last one = 0
   {

--- a/src/particles_flux/include/antioch/sigma_bin_converter.h
+++ b/src/particles_flux/include/antioch/sigma_bin_converter.h
@@ -3,6 +3,8 @@
 //
 // Antioch - A Gas Dynamics Thermochemistry Library
 //
+// Copyright (C) 2014 Paul T. Bauman, Benjamin S. Kirk, Sylvain Plessis,
+//                    Roy H. Stonger
 // Copyright (C) 2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/utilities/include/antioch/eigen_utils.h
+++ b/src/utilities/include/antioch/eigen_utils.h
@@ -277,6 +277,24 @@ eval_index(const VectorT& vec, const _Matrix<_UIntT, _Rows, _Cols, _Options, _Ma
   return returnval;
 }
 
+template <template <bool, int, int, int, int, int> class _Matrix,
+  bool _Cond, int _Rows, int _Cols, int _Options, int _MaxRows, int _MaxCols
+>
+inline
+bool conjunction(const _Matrix<_Cond,_Rows,_Cols,_Options,_MaxRows,_MaxCols> & vec)
+{
+  return vec.all();
+}
+
+template <template <bool, int, int, int, int, int> class _Matrix,
+  bool _Cond, int _Rows, int _Cols, int _Options, int _MaxRows, int _MaxCols
+>
+inline
+bool disjunction(const _Matrix<_Cond,_Rows,_Cols,_Options,_MaxRows,_MaxCols> & vec)
+{
+  return vec.any();
+}
+
 
 } // end namespace Antioch
 

--- a/src/utilities/include/antioch/eigen_utils.h
+++ b/src/utilities/include/antioch/eigen_utils.h
@@ -225,6 +225,24 @@ set_zero(_Matrix<_Scalar, _Rows, _Cols, _Options, _MaxRows, _MaxCols>& a)
     a.setConstant (zero_clone(a[0]));
 }
 
+/*
+template <template <typename, int, int, int, int, int> class _Matrix,
+          typename T, int _Rows, int _Cols, int _Options, int _MaxRows, int _MaxCols,
+  typename VectorScalar
+>
+inline
+_Matrix<T,_Rows,_Cols,_Options,_MaxRows,_MaxCols> 
+  custom_clone(const _Matrix<T,_Rows,_Cols,_Options,_MaxRows,_MaxCols> & /example/, const VectorScalar& values, const _Matrix<unsigned int,_Rows,_Cols,_Options,_MaxRows,_MaxCols> & indexes)
+{
+  _Matrix<T,_Rows,_Cols,_Options,_MaxRows,_MaxCols>  returnval;
+  returnval.resize(indexes.size());
+  for(std::size_t i = 0; i < indexes.size(); i++)
+  {
+      returnval[i] = values[indexes[i]];
+  }
+  return returnval;
+}
+*/
 
 template <typename Condition, typename T1, typename T2>
 inline
@@ -242,20 +260,23 @@ const T2& if_false)
 }
 
 
-template <typename VectorT, typename IntT>
+template <typename VectorT, 
+  template <typename , int, int, int, int, int> class _Matrix,
+  typename _UIntT, int _Rows, int _Cols, int _Options, int _MaxRows, int _MaxCols
+>
 inline
 typename enable_if_c<
-  is_eigen<typename value_type<VectorT>::type>::value &&
-  is_eigen<IntT>::value,
+  is_eigen<typename value_type<VectorT>::type>::value,
   typename value_type<VectorT>::type
 >::type
-eval_index(const VectorT& vec, const IntT& index)
+eval_index(const VectorT& vec, const _Matrix<_UIntT, _Rows, _Cols, _Options, _MaxRows, _MaxCols>& index)
 {
   typename value_type<VectorT>::type returnval = vec[0];
   for (std::size_t i=0; i != index.size(); ++i)
     returnval[i] = vec[index[i]][i];
   return returnval;
 }
+
 
 } // end namespace Antioch
 

--- a/src/utilities/include/antioch/eigen_utils.h
+++ b/src/utilities/include/antioch/eigen_utils.h
@@ -242,6 +242,21 @@ const T2& if_false)
 }
 
 
+template <typename VectorT, typename IntT>
+inline
+typename enable_if_c<
+  is_eigen<typename value_type<VectorT>::type>::value &&
+  is_eigen<IntT>::value,
+  typename value_type<VectorT>::type
+>::type
+eval_index(const VectorT& vec, const IntT& index)
+{
+  typename value_type<VectorT>::type returnval = vec[0];
+  for (std::size_t i=0; i != index.size(); ++i)
+    returnval[i] = vec[index[i]][i];
+  return returnval;
+}
+
 } // end namespace Antioch
 
 #endif //ANTIOCH_EIGEN_UTILS_H

--- a/src/utilities/include/antioch/eigen_utils.h
+++ b/src/utilities/include/antioch/eigen_utils.h
@@ -272,25 +272,21 @@ typename enable_if_c<
 eval_index(const VectorT& vec, const _Matrix<_UIntT, _Rows, _Cols, _Options, _MaxRows, _MaxCols>& index)
 {
   typename value_type<VectorT>::type returnval = vec[0];
-  for (std::size_t i=0; i != index.size(); ++i)
+  for (unsigned int i=0; i != index.size(); ++i)
     returnval[i] = vec[index[i]][i];
   return returnval;
 }
 
-template <template <bool, int, int, int, int, int> class _Matrix,
-  bool _Cond, int _Rows, int _Cols, int _Options, int _MaxRows, int _MaxCols
->
+template <typename T>
 inline
-bool conjunction(const _Matrix<_Cond,_Rows,_Cols,_Options,_MaxRows,_MaxCols> & vec)
+bool conjunction_root(const T & vec, eigen_library_tag)
 {
   return vec.all();
 }
 
-template <template <bool, int, int, int, int, int> class _Matrix,
-  bool _Cond, int _Rows, int _Cols, int _Options, int _MaxRows, int _MaxCols
->
+template <typename T>
 inline
-bool disjunction(const _Matrix<_Cond,_Rows,_Cols,_Options,_MaxRows,_MaxCols> & vec)
+bool disjunction_root(const T & vec, eigen_library_tag)
 {
   return vec.any();
 }

--- a/src/utilities/include/antioch/eigen_utils_decl.h
+++ b/src/utilities/include/antioch/eigen_utils_decl.h
@@ -38,6 +38,8 @@
 #include "antioch_config.h"
 #include "metaprogramming_decl.h"
 
+#include <type_traits> // std::enable_if
+
 #ifdef ANTIOCH_HAVE_EIGEN
 // While this logic is Eigen-specific, these forward declarations deliberately
 // do not require <Eigen/Dense> to be included.  This choice permits mixing

--- a/src/utilities/include/antioch/eigen_utils_decl.h
+++ b/src/utilities/include/antioch/eigen_utils_decl.h
@@ -114,6 +114,14 @@ a.array().min(b.array()));
 
 namespace Antioch
 {
+template <typename T>
+struct tag_type<T,
+                typename std::enable_if<is_eigen<T>::value>::type
+>
+{
+  typedef eigen_library_tag type;
+};
+
 template <
   template <typename, int, int, int, int, int> class _Matrix,
   typename _Scalar, int _Rows, int _Cols, int _Options, int _MaxRows, int _MaxCols,
@@ -243,17 +251,13 @@ typename enable_if_c<
 >::type
 eval_index(const VectorT& vec, const _Matrix<_UIntT, _Rows, _Cols, _Options, _MaxRows, _MaxCols>& index);
 
-template <template <bool, int, int, int, int, int> class _Matrix,
-  bool _Cond, int _Rows, int _Cols, int _Options, int _MaxRows, int _MaxCols
->
+template <typename T>
 inline
-bool conjunction(const _Matrix<_Cond,_Rows,_Cols,_Options,_MaxRows,_MaxCols> & vec);
+bool conjunction_root(const T & vec, eigen_library_tag);
 
-template <template <bool, int, int, int, int, int> class _Matrix,
-  bool _Cond, int _Rows, int _Cols, int _Options, int _MaxRows, int _MaxCols
->
+template <typename T>
 inline
-bool disjunction(const _Matrix<_Cond,_Rows,_Cols,_Options,_MaxRows,_MaxCols> & vec);
+bool disjunction_root(const T & vec, eigen_library_tag);
 
 } // end namespace Antioch
 

--- a/src/utilities/include/antioch/eigen_utils_decl.h
+++ b/src/utilities/include/antioch/eigen_utils_decl.h
@@ -243,6 +243,18 @@ typename enable_if_c<
 >::type
 eval_index(const VectorT& vec, const _Matrix<_UIntT, _Rows, _Cols, _Options, _MaxRows, _MaxCols>& index);
 
+template <template <bool, int, int, int, int, int> class _Matrix,
+  bool _Cond, int _Rows, int _Cols, int _Options, int _MaxRows, int _MaxCols
+>
+inline
+bool conjunction(const _Matrix<_Cond,_Rows,_Cols,_Options,_MaxRows,_MaxCols> & vec);
+
+template <template <bool, int, int, int, int, int> class _Matrix,
+  bool _Cond, int _Rows, int _Cols, int _Options, int _MaxRows, int _MaxCols
+>
+inline
+bool disjunction(const _Matrix<_Cond,_Rows,_Cols,_Options,_MaxRows,_MaxCols> & vec);
+
 } // end namespace Antioch
 
 #endif //ANTIOCH_EIGEN_UTILS_DECL_H

--- a/src/utilities/include/antioch/eigen_utils_decl.h
+++ b/src/utilities/include/antioch/eigen_utils_decl.h
@@ -114,7 +114,6 @@ a.array().min(b.array()));
 
 namespace Antioch
 {
-
 template <
   template <typename, int, int, int, int, int> class _Matrix,
   typename _Scalar, int _Rows, int _Cols, int _Options, int _MaxRows, int _MaxCols,
@@ -210,6 +209,15 @@ inline
 void
 set_zero(_Matrix<_Scalar, _Rows, _Cols, _Options, _MaxRows, _MaxCols>& a);
 
+/*
+template <template <typename, int, int, int, int, int> class _Matrix,
+          typename T, int _Rows, int _Cols, int _Options, int _MaxRows, int _MaxCols,
+  typename VectorScalar
+>
+inline
+_Matrix<T,_Rows,_Cols,_Options,_MaxRows,_MaxCols> 
+  custom_clone(const _Matrix<T,_Rows,_Cols,_Options,_MaxRows,_MaxCols> & example, const VectorScalar& values, const _Matrix<unsigned int,_Rows,_Cols,_Options,_MaxRows,_MaxCols> & indexes);
+*/
 
 template <typename Condition, typename T1, typename T2>
 inline
@@ -223,14 +231,17 @@ const Condition& condition,
 const T1& if_true,
 const T2& if_false);
 
-template <typename VectorT, typename IntT>
+
+template <typename VectorT, 
+  template <typename, int, int, int, int, int> class _Matrix,
+  typename _UIntT, int _Rows, int _Cols, int _Options, int _MaxRows, int _MaxCols
+>
 inline
 typename enable_if_c<
-  is_eigen<typename value_type<VectorT>::type>::value &&
-  is_eigen<IntT>::value,
+  is_eigen<typename value_type<VectorT>::type>::value,
   typename value_type<VectorT>::type
 >::type
-eval_index(const VectorT& vec, const IntT& index);
+eval_index(const VectorT& vec, const _Matrix<_UIntT, _Rows, _Cols, _Options, _MaxRows, _MaxCols>& index);
 
 } // end namespace Antioch
 

--- a/src/utilities/include/antioch/eigen_utils_decl.h
+++ b/src/utilities/include/antioch/eigen_utils_decl.h
@@ -223,6 +223,14 @@ const Condition& condition,
 const T1& if_true,
 const T2& if_false);
 
+template <typename VectorT, typename IntT>
+inline
+typename enable_if_c<
+  is_eigen<typename value_type<VectorT>::type>::value &&
+  is_eigen<IntT>::value,
+  typename value_type<VectorT>::type
+>::type
+eval_index(const VectorT& vec, const IntT& index);
 
 } // end namespace Antioch
 

--- a/src/utilities/include/antioch/metaphysicl_utils.h
+++ b/src/utilities/include/antioch/metaphysicl_utils.h
@@ -148,6 +148,24 @@ if_else(const Tbool& condition,
   return returnval;
 }
 
+template <typename VectorT, typename UIntType>
+inline
+typename Antioch::enable_if_c<
+   is_metaphysicl<typename Antioch::value_type<VectorT>::type >::value &&
+   is_metaphysicl<UIntType>::value,
+   typename Antioch::value_type<VectorT>::type
+>::type
+eval_index(const VectorT & vec, const UIntType & indexes)
+{
+  typename Antioch::value_type<VectorT>::type returnval;
+
+  for(typename Antioch::size_type<typename Antioch::value_type<VectorT>::type>::type i = 0;
+                i < indexes.size(); i++)
+    returnval[i] = vec[indexes[i]][i];
+
+  return returnval;
+}
+
 } // end namespace Antioch
 
 #endif // ANTIOCH_METAPHYSICL_UTILS_H

--- a/src/utilities/include/antioch/metaphysicl_utils_decl.h
+++ b/src/utilities/include/antioch/metaphysicl_utils_decl.h
@@ -127,6 +127,14 @@ if_else(const Tbool& condition,
         const Ttrue& if_true,
         const Tfalse& if_false);
 
+template <typename VectorT, typename UIntType>
+inline
+typename Antioch::enable_if_c<
+   is_metaphysicl<typename Antioch::value_type<VectorT>::type>::value &&
+   is_metaphysicl<UIntType>::value,
+   typename Antioch::value_type<VectorT>::type
+>::type
+eval_index(const VectorT & vec, const UIntType & indexes);
 } // end namespace Antioch
 
 #endif // ANTIOCH_METAPHYSICL_UTILS_DECL_H

--- a/src/utilities/include/antioch/metaprogramming.h
+++ b/src/utilities/include/antioch/metaprogramming.h
@@ -135,17 +135,14 @@ template <typename T, typename Scalar>
 inline
 void constant_fill(T& output, const Scalar& value) { output = value; }
 
+template <typename T, typename VectorScalar>
+inline
+T custom_clone(const T& /*example*/, const VectorScalar& values, const unsigned int & indexes) {return values[indexes];}
+
 template <typename VectorT, typename IntT>
 inline
 typename value_type<VectorT>::type
 eval_index(const VectorT& vec, const IntT& index)
-{
-  return vec[index];
-}
-
-template <typename VectorDownType, typename UpperType>
-inline
-UpperType upgrade_type(const UpperType & ex, const VectorDownType & vec, unsigned int index)
 {
   return vec[index];
 }

--- a/src/utilities/include/antioch/metaprogramming.h
+++ b/src/utilities/include/antioch/metaprogramming.h
@@ -135,6 +135,14 @@ template <typename T, typename Scalar>
 inline
 void constant_fill(T& output, const Scalar& value) { output = value; }
 
+template <typename VectorT, typename IntT>
+inline
+typename value_type<VectorT>::type
+eval_index(const VectorT& vec, const IntT& index)
+{
+  return vec[index];
+}
+
 } // end namespace Antioch
 
 #endif //ANTIOCH_METAPROGRAMMING_H

--- a/src/utilities/include/antioch/metaprogramming.h
+++ b/src/utilities/include/antioch/metaprogramming.h
@@ -145,7 +145,7 @@ T custom_clone(const T& /*example*/, const VectorScalar& values, const typename 
 {
   T returnval(indexes.size()); //bof bof - metaphysicl has size within type, this suppose that size_type<indexes>::type can be changed in value_type<T>::type
   
-  for(std::size_t i = 0; i < indexes.size(); i++)
+  for(unsigned int i = 0; i < indexes.size(); i++)
   {
       returnval[i] = values[indexes[i]];
   }
@@ -167,13 +167,17 @@ bool conjunction(const bool & vec)
   return vec;
 }
 
-// FIXME - vexcl needs better 
-// test: something in the flavor of
-// vex::vector_expression<Condition>
-
 template <typename T>
 inline
 bool conjunction(const T & vec)
+{
+  typedef typename tag_type<T>::type tag;
+  return conjunction_root(vec,tag());
+}
+
+template <typename T>
+inline
+bool conjunction_root(const T & vec, numeric_library_tag)
 {
   for(unsigned int i = 0; i < vec.size(); i++)
   {
@@ -191,6 +195,14 @@ bool disjunction(const bool & vec)
 template <typename T>
 inline
 bool disjunction(const T & vec)
+{
+  typedef typename tag_type<T>::type tag;
+  return disjunction_root(vec,tag());
+}
+
+template <typename T>
+inline
+bool disjunction_root(const T & vec, numeric_library_tag)
 {
   for(unsigned int i = 0; i < vec.size(); i++)
   {

--- a/src/utilities/include/antioch/metaprogramming.h
+++ b/src/utilities/include/antioch/metaprogramming.h
@@ -143,6 +143,47 @@ eval_index(const VectorT& vec, const IntT& index)
   return vec[index];
 }
 
+template <typename VectorDownType, typename UpperType>
+inline
+UpperType upgrade_type(const UpperType & ex, const VectorDownType & vec, unsigned int index)
+{
+  return vec[index];
+}
+
+inline
+bool conjunction(const bool & vec)
+{
+  return vec;
+}
+
+template <typename T>
+inline
+bool conjunction(const T & vec)
+{
+  for(unsigned int i = 0; i < vec.size(); i++)
+  {
+    if(!vec[i])return false;
+  }
+  return true;
+}
+
+inline
+bool disjunction(const bool & vec)
+{
+  return vec;
+}
+
+template <typename T>
+inline
+bool disjunction(const T & vec)
+{
+  for(unsigned int i = 0; i < vec.size(); i++)
+  {
+    if(vec[i])return true;
+  }
+  return false;
+}
+
 } // end namespace Antioch
 
 #endif //ANTIOCH_METAPROGRAMMING_H

--- a/src/utilities/include/antioch/metaprogramming.h
+++ b/src/utilities/include/antioch/metaprogramming.h
@@ -167,6 +167,10 @@ bool conjunction(const bool & vec)
   return vec;
 }
 
+// FIXME - vexcl needs better 
+// test: something in the flavor of
+// vex::vector_expression<Condition>
+
 template <typename T>
 inline
 bool conjunction(const T & vec)

--- a/src/utilities/include/antioch/metaprogramming.h
+++ b/src/utilities/include/antioch/metaprogramming.h
@@ -137,12 +137,26 @@ void constant_fill(T& output, const Scalar& value) { output = value; }
 
 template <typename T, typename VectorScalar>
 inline
-T custom_clone(const T& /*example*/, const VectorScalar& values, const unsigned int & indexes) {return values[indexes];}
+T custom_clone(const T& /*example*/, const VectorScalar& values, unsigned int indexes) {return values[indexes];}
 
-template <typename VectorT, typename IntT>
+template <typename T, typename VectorScalar>
+inline
+T custom_clone(const T& /*example*/, const VectorScalar& values, const typename Antioch::rebind<T,unsigned int>::type & indexes)
+{
+  T returnval(indexes.size()); //bof bof - metaphysicl has size within type, this suppose that size_type<indexes>::type can be changed in value_type<T>::type
+  
+  for(std::size_t i = 0; i < indexes.size(); i++)
+  {
+      returnval[i] = values[indexes[i]];
+  }
+  return returnval;
+}
+
+
+template <typename VectorT>
 inline
 typename value_type<VectorT>::type
-eval_index(const VectorT& vec, const IntT& index)
+eval_index(const VectorT& vec, unsigned int index)
 {
   return vec[index];
 }

--- a/src/utilities/include/antioch/metaprogramming_decl.h
+++ b/src/utilities/include/antioch/metaprogramming_decl.h
@@ -194,6 +194,19 @@ namespace Antioch
 	    T if_true,
 	    T if_false);
 
+  // A function for indexing a vector type with an (integral) numeric
+  // type.
+  //
+  // The first argument should be a vector of (scalar or vectorized)
+  // numeric types; the second argument should be a similarly scalar
+  // or vectorized integer type with values valid as indices to the
+  // first argument.  The output will be a similarly scalar or
+  // vectorized numeric type.
+  template <typename VectorT, typename IntT>
+  inline
+  typename value_type<VectorT>::type
+  eval_index(const VectorT& vec, const IntT& index);
+
 } // end namespace Antioch
 
 #endif //ANTIOCH_METAPROGRAMMING_DECL_H

--- a/src/utilities/include/antioch/metaprogramming_decl.h
+++ b/src/utilities/include/antioch/metaprogramming_decl.h
@@ -126,6 +126,12 @@ namespace Antioch
   min (const T& in);
   */
 
+  template <typename T, typename Enable=void>
+  struct tag_type
+  {
+    typedef const numeric_library_tag type;
+  };
+
   template <typename T>
   struct value_type<const T>
   {
@@ -232,6 +238,15 @@ namespace Antioch
   typename value_type<VectorT>::type
   eval_index(const VectorT& vec, unsigned int index);
 
+  //Root function for conjunction
+  template <typename T>
+  inline
+  bool conjunction_root(const T & vec, numeric_library_tag);
+
+  //Root function for disjunction
+  template <typename T>
+  inline
+  bool disjunction_root(const T & vec, numeric_library_tag);
 
   // A function to obtain the conjunction of boolean
   template <typename T>

--- a/src/utilities/include/antioch/metaprogramming_decl.h
+++ b/src/utilities/include/antioch/metaprogramming_decl.h
@@ -156,11 +156,17 @@ namespace Antioch
   inline
   T constant_clone(const T& example, const Scalar& value);
 
+  // A function for initializing non vectorized numeric types to
+  // custom constants stored in vector
+  template <typename T, typename VectorScalar>
+  inline
+  T custom_clone(const T& example, const VectorScalar& values, unsigned int indexes);
+
   // A function for initializing vectorized numeric types to
   // custom constants stored in vector
-  template <typename T, typename UIntType, typename VectorScalar>
+  template <typename T, typename VectorScalar>
   inline
-  T custom_clone(const T& example, const VectorScalar& values, const UIntType & indexes);
+  T custom_clone(const T& example, const VectorScalar& values, const typename Antioch::rebind<T,unsigned int>::type & indexes);
 
   // A function for filling already-initialized vectorized numeric
   // types with a constant.
@@ -208,10 +214,10 @@ namespace Antioch
   // or vectorized integer type with values valid as indices to the
   // first argument.  The output will be a similarly scalar or
   // vectorized numeric type.
-  template <typename VectorT, typename IntT>
+  template <typename VectorT>
   inline
   typename value_type<VectorT>::type
-  eval_index(const VectorT& vec, const IntT& index);
+  eval_index(const VectorT& vec, unsigned int index);
 
   // A function to obtain the conjunction of boolean
   template <typename T>

--- a/src/utilities/include/antioch/metaprogramming_decl.h
+++ b/src/utilities/include/antioch/metaprogramming_decl.h
@@ -207,6 +207,25 @@ namespace Antioch
   typename value_type<VectorT>::type
   eval_index(const VectorT& vec, const IntT& index);
 
+  // A function to `upgrade' a scalar.
+  // 
+  // The first argument is a vector of scalar, the return value
+  // is either a scalar or a vectorized numeric type, index being
+  // the similarly scalar or vectorized integer.
+  template <typename VectorDownType, typename UpperType>
+  inline
+  UpperType upgrade_type(const UpperType & ex, const VectorDownType & vec, const unsigned int index);
+
+  // A function to obtain the conjunction of boolean
+  template <typename T>
+  inline
+  bool conjunction(const T & vec);
+
+  // A function to obtain the disjunction of boolean
+  template <typename T>
+  inline
+  bool disjunction(const T & vec);
+
 } // end namespace Antioch
 
 #endif //ANTIOCH_METAPROGRAMMING_DECL_H

--- a/src/utilities/include/antioch/metaprogramming_decl.h
+++ b/src/utilities/include/antioch/metaprogramming_decl.h
@@ -156,6 +156,12 @@ namespace Antioch
   inline
   T constant_clone(const T& example, const Scalar& value);
 
+  // A function for initializing vectorized numeric types to
+  // custom constants stored in vector
+  template <typename T, typename UIntType, typename VectorScalar>
+  inline
+  T custom_clone(const T& example, const VectorScalar& values, const UIntType & indexes);
+
   // A function for filling already-initialized vectorized numeric
   // types with a constant.
   template <typename T, typename Scalar>
@@ -206,15 +212,6 @@ namespace Antioch
   inline
   typename value_type<VectorT>::type
   eval_index(const VectorT& vec, const IntT& index);
-
-  // A function to `upgrade' a scalar.
-  // 
-  // The first argument is a vector of scalar, the return value
-  // is either a scalar or a vectorized numeric type, index being
-  // the similarly scalar or vectorized integer.
-  template <typename VectorDownType, typename UpperType>
-  inline
-  UpperType upgrade_type(const UpperType & ex, const VectorDownType & vec, const unsigned int index);
 
   // A function to obtain the conjunction of boolean
   template <typename T>

--- a/src/utilities/include/antioch/metaprogramming_decl.h
+++ b/src/utilities/include/antioch/metaprogramming_decl.h
@@ -138,6 +138,19 @@ namespace Antioch
     typedef const typename raw_value_type<T>::type type;
   };
 
+  template <typename T1, typename T2>
+  struct constructor_or_reference
+  {
+    typedef T1 type;
+  };
+
+  template <typename T>
+  struct constructor_or_reference<T,T>
+  {
+    typedef T & type;
+  };
+
+
   // A function for zero-initializing vectorized numeric types
   // while resizing them to match the example input
   template <typename T>
@@ -218,6 +231,7 @@ namespace Antioch
   inline
   typename value_type<VectorT>::type
   eval_index(const VectorT& vec, unsigned int index);
+
 
   // A function to obtain the conjunction of boolean
   template <typename T>

--- a/src/utilities/include/antioch/valarray_utils.h
+++ b/src/utilities/include/antioch/valarray_utils.h
@@ -209,6 +209,19 @@ init_clone(std::valarray<T>& output, const std::valarray<T>& example)
     init_clone(output[i], example[i]);
 }
 
+template <typename T, typename VectorScalar>
+inline
+std::valarray<T> custom_clone(const std::valarray<T>& /*example*/, const VectorScalar& values, const std::valarray<unsigned int> & indexes)
+{
+  std::valarray<T> returnval;
+  returnval.resize(indexes.size());
+  for(std::size_t i = 0; i < indexes.size(); i++)
+  {
+      returnval[i] = values[indexes[i]];
+  }
+  return returnval;
+}
+
 
 template <typename T>
 inline
@@ -240,20 +253,6 @@ eval_index(const VectorT& vec, const std::valarray<IntT>& index)
   for (std::size_t i=0; i != sz; ++i)
     returnval[i] = vec[index[i]][i];
   return returnval;
-}
-
-template <typename VectorDownType, typename UpperType>
-inline
-std::valarray<UpperType>
-        upgrade_type(const std::valarray<UpperType> & ex,
-                     const VectorDownType & vec, const std::valarray<unsigned int> & index)
-{
-  std::valarray<UpperType> upgraded;
-  std::size_t sz = index.size();
-  upgraded.resize(sz);
-  for (std::size_t i=0; i != sz; ++i)
-    upgraded[i] = vec[index[i]];
-  return upgraded;
 }
 
 } // end namespace Antioch

--- a/src/utilities/include/antioch/valarray_utils.h
+++ b/src/utilities/include/antioch/valarray_utils.h
@@ -209,9 +209,10 @@ init_clone(std::valarray<T>& output, const std::valarray<T>& example)
     init_clone(output[i], example[i]);
 }
 
+/*
 template <typename T, typename VectorScalar>
 inline
-std::valarray<T> custom_clone(const std::valarray<T>& /*example*/, const VectorScalar& values, const std::valarray<unsigned int> & indexes)
+std::valarray<T> custom_clone(const std::valarray<T>& example, const VectorScalar& values, const std::valarray<unsigned int> & indexes)
 {
   std::valarray<T> returnval;
   returnval.resize(indexes.size());
@@ -221,7 +222,7 @@ std::valarray<T> custom_clone(const std::valarray<T>& /*example*/, const VectorS
   }
   return returnval;
 }
-
+*/
 
 template <typename T>
 inline
@@ -242,10 +243,14 @@ if_else(const std::valarray<bool>& condition,
   return returnval;
 }
 
-template <typename VectorT, typename IntT>
+
+template <typename VectorT>
 inline
-typename value_type<VectorT>::type
-eval_index(const VectorT& vec, const std::valarray<IntT>& index)
+typename Antioch::enable_if_c<
+        Antioch::is_valarray<typename value_type<VectorT>::type>::value,
+        typename value_type<VectorT>::type
+>::type
+eval_index(const VectorT& vec, const std::valarray<unsigned int>& index)
 {
   typename value_type<VectorT>::type returnval;
   std::size_t sz = index.size();
@@ -254,6 +259,7 @@ eval_index(const VectorT& vec, const std::valarray<IntT>& index)
     returnval[i] = vec[index[i]][i];
   return returnval;
 }
+
 
 } // end namespace Antioch
 

--- a/src/utilities/include/antioch/valarray_utils.h
+++ b/src/utilities/include/antioch/valarray_utils.h
@@ -242,6 +242,20 @@ eval_index(const VectorT& vec, const std::valarray<IntT>& index)
   return returnval;
 }
 
+template <typename VectorDownType, typename UpperType>
+inline
+std::valarray<UpperType>
+        upgrade_type(const std::valarray<UpperType> & ex,
+                     const VectorDownType & vec, const std::valarray<unsigned int> & index)
+{
+  std::valarray<UpperType> upgraded;
+  std::size_t sz = index.size();
+  upgraded.resize(sz);
+  for (std::size_t i=0; i != sz; ++i)
+    upgraded[i] = vec[index[i]];
+  return upgraded;
+}
+
 } // end namespace Antioch
 
 

--- a/src/utilities/include/antioch/valarray_utils.h
+++ b/src/utilities/include/antioch/valarray_utils.h
@@ -229,6 +229,19 @@ if_else(const std::valarray<bool>& condition,
   return returnval;
 }
 
+template <typename VectorT, typename IntT>
+inline
+typename value_type<VectorT>::type
+eval_index(const VectorT& vec, const std::valarray<IntT>& index)
+{
+  typename value_type<VectorT>::type returnval;
+  std::size_t sz = index.size();
+  returnval.resize(sz);
+  for (std::size_t i=0; i != sz; ++i)
+    returnval[i] = vec[index[i]][i];
+  return returnval;
+}
+
 } // end namespace Antioch
 
 

--- a/src/utilities/include/antioch/valarray_utils_decl.h
+++ b/src/utilities/include/antioch/valarray_utils_decl.h
@@ -157,6 +157,12 @@ std::valarray<T>
 if_else(const std::valarray<bool>& condition,
         const std::valarray<T>& if_true,
         const std::valarray<T>& if_false);
+
+template <typename VectorT, typename IntT>
+inline
+typename value_type<VectorT>::type
+eval_index(const VectorT& vec, const std::valarray<IntT>& index);
+
 } // end namespace Antioch
 
 

--- a/src/utilities/include/antioch/valarray_utils_decl.h
+++ b/src/utilities/include/antioch/valarray_utils_decl.h
@@ -163,6 +163,12 @@ inline
 typename value_type<VectorT>::type
 eval_index(const VectorT& vec, const std::valarray<IntT>& index);
 
+template <typename VectorDownType, typename UpperType>
+inline
+std::valarray<UpperType> 
+        upgrade_type(const std::valarray<UpperType> & ex,
+                     const VectorDownType & vec, const std::valarray<unsigned int> & index);
+
 } // end namespace Antioch
 
 

--- a/src/utilities/include/antioch/valarray_utils_decl.h
+++ b/src/utilities/include/antioch/valarray_utils_decl.h
@@ -151,6 +151,10 @@ inline
 void
 init_clone(std::valarray<T>& output, const std::valarray<T>& example);
 
+template <typename T, typename VectorScalar>
+inline
+std::valarray<T> custom_clone(const std::valarray<T>& example, const VectorScalar& values, const std::valarray<unsigned int> & indexes);
+
 template <typename T>
 inline
 std::valarray<T>
@@ -162,12 +166,6 @@ template <typename VectorT, typename IntT>
 inline
 typename value_type<VectorT>::type
 eval_index(const VectorT& vec, const std::valarray<IntT>& index);
-
-template <typename VectorDownType, typename UpperType>
-inline
-std::valarray<UpperType> 
-        upgrade_type(const std::valarray<UpperType> & ex,
-                     const VectorDownType & vec, const std::valarray<unsigned int> & index);
 
 } // end namespace Antioch
 

--- a/src/utilities/include/antioch/valarray_utils_decl.h
+++ b/src/utilities/include/antioch/valarray_utils_decl.h
@@ -151,9 +151,10 @@ inline
 void
 init_clone(std::valarray<T>& output, const std::valarray<T>& example);
 
-template <typename T, typename VectorScalar>
+/*template <typename T, typename VectorScalar>
 inline
 std::valarray<T> custom_clone(const std::valarray<T>& example, const VectorScalar& values, const std::valarray<unsigned int> & indexes);
+*/
 
 template <typename T>
 inline
@@ -162,10 +163,14 @@ if_else(const std::valarray<bool>& condition,
         const std::valarray<T>& if_true,
         const std::valarray<T>& if_false);
 
-template <typename VectorT, typename IntT>
+
+template <typename VectorT>
 inline
-typename value_type<VectorT>::type
-eval_index(const VectorT& vec, const std::valarray<IntT>& index);
+typename Antioch::enable_if_c<
+        Antioch::is_valarray<typename value_type<VectorT>::type>::value,
+        typename value_type<VectorT>::type
+>::type
+eval_index(const VectorT& vec, const std::valarray<unsigned int>& index);
 
 } // end namespace Antioch
 

--- a/src/utilities/include/antioch/vector_utils.h
+++ b/src/utilities/include/antioch/vector_utils.h
@@ -148,6 +148,18 @@ void set_zero(std::vector<T>& a)
     std::fill(a.begin(), a.end(), zero_clone(a[0]));
 }
 
+template <typename VectorDownType, typename UpType, typename IntType>
+inline
+std::vector<typename Antioch::value_type<UpType>::type> upgrade_type(const VectorDownType & vec, const std::vector<typename Antioch::value_type<IntType>::type> & index)
+{
+  UpType upgraded;
+  std::size_t sz = index.size();
+  upgraded.resize(sz);
+  for (std::size_t i=0; i != sz; ++i)
+    upgraded[i] = vec[index[i]];
+  return upgraded;
+}
+
 } // end namespace Antioch
 
 

--- a/src/utilities/include/antioch/vector_utils.h
+++ b/src/utilities/include/antioch/vector_utils.h
@@ -148,16 +148,15 @@ void set_zero(std::vector<T>& a)
     std::fill(a.begin(), a.end(), zero_clone(a[0]));
 }
 
-template <typename VectorDownType, typename UpType, typename IntType>
+template <typename T, typename VectorScalar>
 inline
-std::vector<typename Antioch::value_type<UpType>::type> upgrade_type(const VectorDownType & vec, const std::vector<typename Antioch::value_type<IntType>::type> & index)
+std::vector<T> custom_clone(const std::vector<T> & /*vec*/, const VectorScalar & vecsrc, std::vector<unsigned int> & indexes)
 {
-  UpType upgraded;
-  std::size_t sz = index.size();
-  upgraded.resize(sz);
-  for (std::size_t i=0; i != sz; ++i)
-    upgraded[i] = vec[index[i]];
-  return upgraded;
+  std::vector<T> returnval;
+  returnval.resize(indexes.size());
+  for (std::size_t i=0; i != indexes.size(); ++i)
+    returnval[i] = vecsrc[indexes[i]];
+  return returnval;
 }
 
 } // end namespace Antioch

--- a/src/utilities/include/antioch/vector_utils_decl.h
+++ b/src/utilities/include/antioch/vector_utils_decl.h
@@ -98,9 +98,9 @@ template <typename T>
 inline
 void set_zero(std::vector<T>& a);
 
-template <typename VectorDownType, typename UpType, typename IntType>
+template <typename T, typename VectorScalar>
 inline
-std::vector<typename Antioch::value_type<UpType>::type> upgrade_type(const VectorDownType & vec, const std::vector<typename Antioch::value_type<IntType>::type> & index);
+std::vector<T> custom_clone(const std::vector<T> & vec, const VectorScalar & vecsrc, const std::vector<unsigned int> & indexes);
 
 } // end namespace Antioch
 

--- a/src/utilities/include/antioch/vector_utils_decl.h
+++ b/src/utilities/include/antioch/vector_utils_decl.h
@@ -98,6 +98,10 @@ template <typename T>
 inline
 void set_zero(std::vector<T>& a);
 
+template <typename VectorDownType, typename UpType, typename IntType>
+inline
+std::vector<typename Antioch::value_type<UpType>::type> upgrade_type(const VectorDownType & vec, const std::vector<typename Antioch::value_type<IntType>::type> & index);
+
 } // end namespace Antioch
 
 

--- a/src/utilities/include/antioch/vexcl_utils.h
+++ b/src/utilities/include/antioch/vexcl_utils.h
@@ -203,6 +203,23 @@ if_else(const vex::vector_expression<BoolInput> &condition,
   return boost::proto::if_else(condition, if_true, if_false);
 }
 
+template <typename BoolInput>
+inline
+bool disjunction(const vex::vector<BoolInput> & vec_input)
+{
+  vex::vector<bool> tr(vec_input);
+
+  return Antioch::disjunction(tr);
+}
+
+template <typename BoolInput>
+inline
+bool conjunction(const vex::vector_expression<BoolInput> & vec_input)
+{
+  vex::vector<bool> tr(vec_input);
+  return Antioch::conjunction(tr);
+}
+
 #ifdef ANTIOCH_HAVE_VEXCL
 template <typename VectorT, typename IntT>
 inline
@@ -218,6 +235,7 @@ eval_index(const VectorT& vec, const IntT& index)
   // FIXME - this will be painfully slow
   for (std::size_t i=0; i != index.size(); ++i)
     returnval[i] = vec[index[i]][i];
+
   return returnval;
 }
 #endif

--- a/src/utilities/include/antioch/vexcl_utils.h
+++ b/src/utilities/include/antioch/vexcl_utils.h
@@ -43,7 +43,7 @@
 
 
 #ifdef ANTIOCH_HAVE_VEXCL
-// Though the following implementations are all valid without
+// Though the following implementations are almost all valid without
 // <vexcl/vexcl.hpp>, successfully using them with
 // VexCL types requires VexCL to be included first.
 // Configure-time VexCL support enforces this constraint but
@@ -214,22 +214,32 @@ template <typename T>
 inline
 bool disjunction_root(const T & vec_input, vexcl_library_tag)
 {
+#ifdef ANTIOCH_HAVE_VEXCL
   vex::detail::get_expression_properties prop;
   vex::detail::extract_terminals()(boost::proto::as_child(vec_input),prop);
 
   vex::any_of any_of(prop.queue);
   return any_of(vec_input); // at least one true
+#else
+  antioch_error();
+  return false;
+#endif
 }
 
 template <typename T>
 inline
 bool conjunction_root(const  T & vec_input, vexcl_library_tag)
 {
+#ifdef ANTIOCH_HAVE_VEXCL
   vex::detail::get_expression_properties prop;
   vex::detail::extract_terminals()(boost::proto::as_child(vec_input),prop);
 
   vex::all_of all_of(prop.queue);
   return all_of(vec_input); // at least one false
+#else
+  antioch_error();
+  return false;
+#endif
 }
 
 template <typename VectorT, typename IntT>

--- a/src/utilities/include/antioch/vexcl_utils.h
+++ b/src/utilities/include/antioch/vexcl_utils.h
@@ -203,6 +203,25 @@ if_else(const vex::vector_expression<BoolInput> &condition,
   return boost::proto::if_else(condition, if_true, if_false);
 }
 
+
+template <typename VectorT, typename IntT>
+inline
+typename enable_if_c<
+  vex::is_vector_expression<typename value_type<VectorT>::type>::value &&
+  vex::is_vector_expression<IntT>::value,
+  typename value_type<VectorT>::type
+>::type
+eval_index(const VectorT& vec, const IntT& index)
+{
+  typename value_type<VectorT>::type returnval = zero_clone(vec[0]);
+
+  // FIXME - this will be painfully slow
+  for (std::size_t i=0; i != index.size(); ++i)
+    returnval[i] = vec[index[i]][i];
+  return returnval;
+}
+
+
 } // end namespace Antioch
 
 

--- a/src/utilities/include/antioch/vexcl_utils.h
+++ b/src/utilities/include/antioch/vexcl_utils.h
@@ -205,10 +205,12 @@ if_else(const vex::vector_expression<BoolInput> &condition,
 
 template <typename BoolInput>
 inline
-bool disjunction(const vex::vector<BoolInput> & vec_input)
+bool disjunction(const vex::vector_expression<BoolInput> & vec_input)
 {
-  vex::vector<bool> tr(vec_input);
-
+  vex::vector<int> tr(vec_input);
+/*  vex::Reductor<int,vex::MIN> min(tr.queue_list());
+  return 1 != min( tr == 0);
+*/
   return Antioch::disjunction(tr);
 }
 
@@ -216,7 +218,11 @@ template <typename BoolInput>
 inline
 bool conjunction(const vex::vector_expression<BoolInput> & vec_input)
 {
-  vex::vector<bool> tr(vec_input);
+  vex::vector<int> tr(vec_input);
+/*  
+  vex::Reductor<int,vex::MIN> min(tr.queue_list());
+  return 1 == min( tr != 0);
+*/
   return Antioch::conjunction(tr);
 }
 

--- a/src/utilities/include/antioch/vexcl_utils.h
+++ b/src/utilities/include/antioch/vexcl_utils.h
@@ -203,7 +203,6 @@ if_else(const vex::vector_expression<BoolInput> &condition,
   return boost::proto::if_else(condition, if_true, if_false);
 }
 
-
 #ifdef ANTIOCH_HAVE_VEXCL
 template <typename VectorT, typename IntT>
 inline

--- a/src/utilities/include/antioch/vexcl_utils.h
+++ b/src/utilities/include/antioch/vexcl_utils.h
@@ -217,8 +217,8 @@ bool disjunction_root(const T & vec_input, vexcl_library_tag)
   vex::detail::get_expression_properties prop;
   vex::detail::extract_terminals()(boost::proto::as_child(vec_input),prop);
 
-  vex::Reductor<int,vex::MAX> max(prop.queue);
-  return 1 == max( vec_input == 1); // at least one true
+  vex::any_of any_of(prop.queue);
+  return any_of(vec_input); // at least one true
 }
 
 template <typename T>
@@ -228,8 +228,8 @@ bool conjunction_root(const  T & vec_input, vexcl_library_tag)
   vex::detail::get_expression_properties prop;
   vex::detail::extract_terminals()(boost::proto::as_child(vec_input),prop);
 
-  vex::Reductor<int,vex::MAX> max(prop.queue);
-  return 1 != max( vec_input == 0); // at least one false
+  vex::all_of all_of(prop.queue);
+  return all_of(vec_input); // at least one false
 }
 
 template <typename VectorT, typename IntT>

--- a/src/utilities/include/antioch/vexcl_utils.h
+++ b/src/utilities/include/antioch/vexcl_utils.h
@@ -204,6 +204,7 @@ if_else(const vex::vector_expression<BoolInput> &condition,
 }
 
 
+#ifdef ANTIOCH_HAVE_VEXCL
 template <typename VectorT, typename IntT>
 inline
 typename enable_if_c<
@@ -220,6 +221,7 @@ eval_index(const VectorT& vec, const IntT& index)
     returnval[i] = vec[index[i]][i];
   return returnval;
 }
+#endif
 
 
 } // end namespace Antioch

--- a/src/utilities/include/antioch/vexcl_utils_decl.h
+++ b/src/utilities/include/antioch/vexcl_utils_decl.h
@@ -155,6 +155,15 @@ if_else(const vex::vector_expression<BoolInput> &condition,
 	const IfValue   &if_true,
 	const ElseValue &if_false);
 
+template <typename BoolInput>
+inline
+bool disjunction(const vex::vector_expression<BoolInput> & vec_input);
+
+template <typename BoolInput>
+inline
+bool conjunction(const vex::vector_expression<BoolInput> & vec_input);
+
+
 #ifdef ANTIOCH_HAVE_VEXCL
 template <typename VectorT, typename IntT>
 inline

--- a/src/utilities/include/antioch/vexcl_utils_decl.h
+++ b/src/utilities/include/antioch/vexcl_utils_decl.h
@@ -155,6 +155,7 @@ if_else(const vex::vector_expression<BoolInput> &condition,
 	const IfValue   &if_true,
 	const ElseValue &if_false);
 
+#ifdef ANTIOCH_HAVE_VEXCL
 template <typename VectorT, typename IntT>
 inline
 typename enable_if_c<
@@ -163,6 +164,7 @@ typename enable_if_c<
   typename value_type<VectorT>::type
 >::type
 eval_index(const VectorT& vec, const IntT& index);
+#endif
 
 } // end namespace Antioch
 

--- a/src/utilities/include/antioch/vexcl_utils_decl.h
+++ b/src/utilities/include/antioch/vexcl_utils_decl.h
@@ -51,6 +51,7 @@
 namespace vex {
   template <typename T> class vector;
   template <typename T> class vector_expression;
+  template <typename T> class is_vector_expression;
 }
 namespace boost {
   namespace proto {
@@ -91,6 +92,14 @@ namespace Antioch
 
 // Class to allow tag dispatching to VexCL specializations
 struct vexcl_library_tag : public numeric_library_tag {};
+
+template <typename T>
+struct tag_type<T,
+          typename std::enable_if<vex::is_vector_expression<T>::value>::type
+        >
+{
+    typedef const vexcl_library_tag type;
+};
 
 template <typename T, typename NewScalar>
 struct rebind<vex::vector<T>, NewScalar>
@@ -155,16 +164,15 @@ if_else(const vex::vector_expression<BoolInput> &condition,
 	const IfValue   &if_true,
 	const ElseValue &if_false);
 
-template <typename BoolInput>
+template <typename T>
 inline
-bool disjunction(const vex::vector_expression<BoolInput> & vec_input);
+bool disjunction_root(const T & vec_input, vexcl_library_tag);
 
-template <typename BoolInput>
+template <typename T>
 inline
-bool conjunction(const vex::vector_expression<BoolInput> & vec_input);
+bool conjunction_root(const T & vec_input, vexcl_library_tag);
 
 
-#ifdef ANTIOCH_HAVE_VEXCL
 template <typename VectorT, typename IntT>
 inline
 typename enable_if_c<
@@ -173,7 +181,6 @@ typename enable_if_c<
   typename value_type<VectorT>::type
 >::type
 eval_index(const VectorT& vec, const IntT& index);
-#endif
 
 } // end namespace Antioch
 

--- a/src/utilities/include/antioch/vexcl_utils_decl.h
+++ b/src/utilities/include/antioch/vexcl_utils_decl.h
@@ -38,6 +38,8 @@
 // Antioch
 #include "antioch/metaprogramming_decl.h"
 
+#include <type_traits> // std::enable_if
+
 #ifdef ANTIOCH_HAVE_VEXCL
 // Though the following implementations are all valid without
 // <vexcl/vexcl.hpp>, successfully using them with

--- a/src/utilities/include/antioch/vexcl_utils_decl.h
+++ b/src/utilities/include/antioch/vexcl_utils_decl.h
@@ -155,6 +155,15 @@ if_else(const vex::vector_expression<BoolInput> &condition,
 	const IfValue   &if_true,
 	const ElseValue &if_false);
 
+template <typename VectorT, typename IntT>
+inline
+typename enable_if_c<
+  vex::is_vector_expression<typename value_type<VectorT>::type>::value &&
+  vex::is_vector_expression<IntT>::value,
+  typename value_type<VectorT>::type
+>::type
+eval_index(const VectorT& vec, const IntT& index);
+
 } // end namespace Antioch
 
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -169,7 +169,7 @@ TESTS += kinetics_reversibility_unit
 TESTS += parsing_xml.sh
 TESTS += units_unit
 TESTS += kinetics_reactive_scheme_unit.sh
-TESTS += sigma_bin_converter_unit.sh
+TESTS += sigma_bin_converter_unit
 
 if ANTIOCH_ENABLE_EIGEN
 TESTS += stat_mech_thermo_unit_eigen

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -48,6 +48,7 @@ check_PROGRAMS += parsing_xml
 check_PROGRAMS += units_unit
 check_PROGRAMS += kinetics_reactive_scheme_unit
 check_PROGRAMS += sigma_bin_converter_unit
+check_PROGRAMS += sigma_bin_converter_vec_unit
 
 if ANTIOCH_ENABLE_EIGEN
 check_PROGRAMS += stat_mech_thermo_unit_eigen
@@ -116,6 +117,7 @@ parsing_xml_SOURCES = parsing_xml.C
 units_unit_SOURCES = units_unit.C
 kinetics_reactive_scheme_unit_SOURCES = kinetics_reactive_scheme_unit.C
 sigma_bin_converter_unit_SOURCES = sigma_bin_converter_unit.C
+sigma_bin_converter_vec_unit_SOURCES = sigma_bin_converter_vec_unit.C
 
 if ANTIOCH_ENABLE_EIGEN
 stat_mech_thermo_unit_eigen_SOURCES = stat_mech_thermo_unit_eigen.C
@@ -170,6 +172,7 @@ TESTS += parsing_xml.sh
 TESTS += units_unit
 TESTS += kinetics_reactive_scheme_unit.sh
 TESTS += sigma_bin_converter_unit
+TESTS += sigma_bin_converter_vec_unit
 
 if ANTIOCH_ENABLE_EIGEN
 TESTS += stat_mech_thermo_unit_eigen

--- a/test/duplicate_process_unit.C
+++ b/test/duplicate_process_unit.C
@@ -62,6 +62,9 @@ int tester()
 
   for(Scalar T = 300.1; T <= 2500.1; T += 10.)
   {
+
+    const Antioch::KineticsConditions<Scalar> conditions(T);
+
     for(unsigned int ikinmod = 0; ikinmod < 6; ikinmod++)
     {
 
@@ -133,12 +136,12 @@ int tester()
     Antioch::DuplicateReaction<Scalar> * dupl_reaction = new Antioch::DuplicateReaction<Scalar>(n_species,equation,true,kin_mod);
     dupl_reaction->add_forward_rate(rate_kinetics1);
     dupl_reaction->add_forward_rate(rate_kinetics2);
-    Scalar rate1 = dupl_reaction->compute_forward_rate_coefficient(mol_densities,T);
+    Scalar rate1 = dupl_reaction->compute_forward_rate_coefficient(mol_densities,conditions);
     Scalar rate(0.);
     Scalar drate_dT(0.);
     std::vector<Scalar> drate_dx;
     drate_dx.resize(n_species);
-    dupl_reaction->compute_forward_rate_coefficient_and_derivatives(mol_densities,T,rate,drate_dT,drate_dx);
+    dupl_reaction->compute_forward_rate_coefficient_and_derivatives(mol_densities,conditions,rate,drate_dT,drate_dx);
 
     if( abs( (rate1 - rate_exact)/rate_exact ) > tol )
       {

--- a/test/elementary_process_unit.C
+++ b/test/elementary_process_unit.C
@@ -57,6 +57,9 @@ int tester()
 
   for(Scalar T = 300.1; T <= 2500.1; T += 10.)
   {
+
+    const Antioch::KineticsConditions<Scalar> conditions(T);
+
     for(unsigned int ikinmod = 0; ikinmod < 6; ikinmod++)
     {
 
@@ -119,12 +122,12 @@ int tester()
 
     Antioch::ElementaryReaction<Scalar> * elem_reaction = new Antioch::ElementaryReaction<Scalar>(n_species,equation,true,kin_mod);
     elem_reaction->add_forward_rate(rate_kinetics);
-    Scalar rate1 = elem_reaction->compute_forward_rate_coefficient(mol_densities,T);
+    Scalar rate1 = elem_reaction->compute_forward_rate_coefficient(mol_densities,conditions);
     Scalar rate;
     Scalar drate_dT;
     std::vector<Scalar> drate_dx;
     drate_dx.resize(n_species);
-    elem_reaction->compute_forward_rate_coefficient_and_derivatives(mol_densities,T,rate,drate_dT,drate_dx);
+    elem_reaction->compute_forward_rate_coefficient_and_derivatives(mol_densities,conditions,rate,drate_dT,drate_dx);
 
     if( abs( (rate1 - rate_exact)/rate_exact ) > tol )
       {

--- a/test/kinetics_reactive_scheme_unit.C
+++ b/test/kinetics_reactive_scheme_unit.C
@@ -87,6 +87,8 @@ int tester(const std::string& input_name)
   const Scalar T = 1500.0; // K
   const Scalar P = 1.0e5; // Pa
 
+  const Antioch::KineticsConditions<Scalar> conditions(T);
+
   // Mass fractions
   std::vector<Scalar> Y(n_species,0.2);
 
@@ -104,7 +106,7 @@ int tester(const std::string& input_name)
 
   std::vector<Scalar> net_rates,kfwd_const,kbkwd_const,kfwd,kbkwd,fwd_conc,bkwd_conc;
 
-  reaction_set.get_reactive_scheme(T,molar_densities,h_RT_minus_s_R,net_rates,
+  reaction_set.get_reactive_scheme(conditions,molar_densities,h_RT_minus_s_R,net_rates,
                                    kfwd_const,kbkwd_const,kfwd,kbkwd,fwd_conc,bkwd_conc);
 
   std::vector<Scalar> net_rates_exact,

--- a/test/kinetics_regression.C
+++ b/test/kinetics_regression.C
@@ -89,18 +89,32 @@ int tester(const std::string& input_name)
 
   std::vector<Scalar> omega_dot(n_species);
   std::vector<Scalar> omega_dot_2(n_species);
+  std::vector<Scalar> omega_dot_3(n_species);
+  std::vector<Scalar> omega_dot_4(n_species);
   std::vector<Scalar> domega_dot_dT(n_species);
+  std::vector<Scalar> domega_dot_dT_2(n_species);
 
   std::vector<std::vector<Scalar> > domega_dot_drho_s(n_species);
+  std::vector<std::vector<Scalar> > domega_dot_drho_s_2(n_species);
   for( unsigned int s = 0; s < n_species; s++ )
     {
       domega_dot_drho_s[s].resize(n_species);
+      domega_dot_drho_s_2[s].resize(n_species);
     }
   
-  kinetics.compute_mass_sources( conditions, molar_densities, h_RT_minus_s_R, omega_dot);
+// backward compatibility
 
-  kinetics.compute_mass_sources_and_derivs( conditions, molar_densities, h_RT_minus_s_R, dh_RT_minus_s_R_dT,
+  kinetics.compute_mass_sources( T , molar_densities, h_RT_minus_s_R, omega_dot);
+
+  kinetics.compute_mass_sources_and_derivs( T , molar_densities, h_RT_minus_s_R, dh_RT_minus_s_R_dT,
                                             omega_dot_2, domega_dot_dT, domega_dot_drho_s );
+
+// kinetics conditions
+
+  kinetics.compute_mass_sources( conditions , molar_densities, h_RT_minus_s_R, omega_dot_3);
+
+  kinetics.compute_mass_sources_and_derivs( conditions , molar_densities, h_RT_minus_s_R, dh_RT_minus_s_R_dT,
+                                            omega_dot_4, domega_dot_dT_2, domega_dot_drho_s_2 );
 
   for( unsigned int s = 0; s < n_species; s++)
     {
@@ -150,6 +164,24 @@ int tester(const std::string& input_name)
         }
     }
 
+  for( unsigned int s = 0; s < n_species; s++)
+    {
+      const Scalar rel_error = abs( (omega_dot_3[s] - omega_dot_reg[s])/omega_dot_reg[s]);
+      if( rel_error > tol )
+        {
+          return_flag = 1;
+        }
+    }
+ 
+  for( unsigned int s = 0; s < n_species; s++)
+    {
+      const Scalar rel_error = abs( (omega_dot_4[s] - omega_dot_reg[s])/omega_dot_reg[s]);
+      if( rel_error > tol )
+        {
+          return_flag = 1;
+        }
+    }
+
   // Regression values for domega_dot_dT
   std::vector<Scalar> domega_dot_reg_dT(n_species);
   domega_dot_reg_dT[0] =  1.8014990183270937e+02;
@@ -161,6 +193,15 @@ int tester(const std::string& input_name)
   for( unsigned int s = 0; s < n_species; s++)
     {
       const Scalar rel_error = abs( (domega_dot_dT[s] - domega_dot_reg_dT[s])/domega_dot_reg_dT[s]);
+      if( rel_error > tol )
+        {
+          return_flag = 1;
+        }
+    }
+
+  for( unsigned int s = 0; s < n_species; s++)
+    {
+      const Scalar rel_error = abs( (domega_dot_dT_2[s] - domega_dot_reg_dT[s])/domega_dot_reg_dT[s]);
       if( rel_error > tol )
         {
           return_flag = 1;
@@ -209,6 +250,18 @@ int tester(const std::string& input_name)
       for( unsigned int t = 0; t < n_species; t++)
         {
           const Scalar rel_error = abs( (domega_dot_drho_s[s][t] - domega_dot_reg_drhos[s][t])/domega_dot_reg_drhos[s][t]);
+          if( rel_error > tol )
+            {
+              return_flag = 1;
+            }
+        }
+    }
+
+  for( unsigned int s = 0; s < n_species; s++)
+    {
+      for( unsigned int t = 0; t < n_species; t++)
+        {
+          const Scalar rel_error = abs( (domega_dot_drho_s_2[s][t] - domega_dot_reg_drhos[s][t])/domega_dot_reg_drhos[s][t]);
           if( rel_error > tol )
             {
               return_flag = 1;

--- a/test/kinetics_regression.C
+++ b/test/kinetics_regression.C
@@ -66,6 +66,7 @@ int tester(const std::string& input_name)
 
   const Scalar T = 1500.0; // K
   const Scalar P = 1.0e5; // Pa
+  const Antioch::KineticsConditions<Scalar> conditions(T);
 
   // Mass fractions
   std::vector<Scalar> Y(n_species,0.2);
@@ -96,9 +97,9 @@ int tester(const std::string& input_name)
       domega_dot_drho_s[s].resize(n_species);
     }
   
-  kinetics.compute_mass_sources( T, molar_densities, h_RT_minus_s_R, omega_dot);
+  kinetics.compute_mass_sources( conditions, molar_densities, h_RT_minus_s_R, omega_dot);
 
-  kinetics.compute_mass_sources_and_derivs( T, molar_densities, h_RT_minus_s_R, dh_RT_minus_s_R_dT,
+  kinetics.compute_mass_sources_and_derivs( conditions, molar_densities, h_RT_minus_s_R, dh_RT_minus_s_R_dT,
                                             omega_dot_2, domega_dot_dT, domega_dot_drho_s );
 
   for( unsigned int s = 0; s < n_species; s++)

--- a/test/kinetics_regression_vec.C
+++ b/test/kinetics_regression_vec.C
@@ -232,6 +232,8 @@ int vectester(const std::string& input_name,
     gt.BeginTimer(testeigenA);
 #endif
 
+    const Antioch::KineticsConditions<PairScalars,SpeciesVecEigenType> eigen_conditions(T);
+
     SpeciesVecEigenType eigen_Y;
     Antioch::init_constant(eigen_Y, massfrac);
 
@@ -259,7 +261,7 @@ int vectester(const std::string& input_name,
 
     thermo.dh_RT_minus_s_R_dT(Cache(T),eigen_dh_RT_minus_s_R_dT);
 
-    kinetics.compute_mass_sources( T, eigen_molar_densities, eigen_h_RT_minus_s_R, eigen_omega_dot );
+    kinetics.compute_mass_sources( eigen_conditions, eigen_molar_densities, eigen_h_RT_minus_s_R, eigen_omega_dot );
 
 #ifdef ANTIOCH_HAVE_GRVY
     gt.EndTimer(testeigenA);
@@ -286,6 +288,8 @@ int vectester(const std::string& input_name,
 
   {
     typedef Eigen::Matrix<PairScalars,Eigen::Dynamic,1> SpeciesVecEigenType;
+    const Antioch::KineticsConditions<PairScalars,SpeciesVecEigenType> eigen_conditions(T);
+
     SpeciesVecEigenType eigen_Y(n_species,1);
     Antioch::init_constant(eigen_Y, massfrac);
 
@@ -319,7 +323,7 @@ int vectester(const std::string& input_name,
 
     thermo.dh_RT_minus_s_R_dT(Cache(T),eigen_dh_RT_minus_s_R_dT);
 
-    kinetics.compute_mass_sources( T, eigen_molar_densities, eigen_h_RT_minus_s_R, eigen_omega_dot );
+    kinetics.compute_mass_sources( eigen_conditions, eigen_molar_densities, eigen_h_RT_minus_s_R, eigen_omega_dot );
 
 #ifdef ANTIOCH_HAVE_GRVY
     gt.EndTimer(testeigenV);

--- a/test/kinetics_regression_vec.C
+++ b/test/kinetics_regression_vec.C
@@ -175,6 +175,7 @@ int vectester(const std::string& input_name,
       massfrac[2*tuple+1] = 0.2;
     }
 
+  const Antioch::KineticsConditions<PairScalars> conditions(T);
   const std::vector<PairScalars> Y(n_species,massfrac);
   std::vector<PairScalars> molar_densities(n_species, example);
   std::vector<PairScalars> h_RT_minus_s_R(n_species, example);
@@ -206,9 +207,9 @@ int vectester(const std::string& input_name,
   thermo.h_RT_minus_s_R(Cache(T),h_RT_minus_s_R);
   thermo.dh_RT_minus_s_R_dT(Cache(T),dh_RT_minus_s_R_dT);
 
-  kinetics.compute_mass_sources( T, molar_densities, h_RT_minus_s_R, omega_dot );
+  kinetics.compute_mass_sources( conditions, molar_densities, h_RT_minus_s_R, omega_dot );
 
-  kinetics.compute_mass_sources_and_derivs ( T,
+  kinetics.compute_mass_sources_and_derivs ( conditions,
 					     molar_densities,
 					     h_RT_minus_s_R,
 					     dh_RT_minus_s_R_dT,

--- a/test/kinetics_reversibility_unit.C
+++ b/test/kinetics_reversibility_unit.C
@@ -69,6 +69,7 @@ int tester(const std::string& testname)
 
   const Scalar T = 1500.0L; // K
   const Scalar P = 1.0e5L; // Pa
+  const Antioch::KineticsConditions<Scalar> conditions(T);
 
   const Scalar P0_RT(1.0e5/Antioch::Constants::R_universal<Scalar>()/T);
   std::vector<Scalar> h_RT_minus_s_R(n_species);
@@ -103,11 +104,11 @@ int tester(const std::string& testname)
   my_rxn->print();
 
 //
-  Scalar rate_reversible = my_rxn->compute_rate_of_progress(molar_densities,T,P0_RT,h_RT_minus_s_R);
+  Scalar rate_reversible = my_rxn->compute_rate_of_progress(molar_densities,conditions,P0_RT,h_RT_minus_s_R);
 
 //irreversible reaction
   my_rxn->set_reversibility(false);
-  Scalar rate_irreversible = my_rxn->compute_rate_of_progress(molar_densities,T,P0_RT,h_RT_minus_s_R);
+  Scalar rate_irreversible = my_rxn->compute_rate_of_progress(molar_densities,conditions,P0_RT,h_RT_minus_s_R);
 
   int return_flag = 0;
 

--- a/test/kinetics_unit.C
+++ b/test/kinetics_unit.C
@@ -80,13 +80,12 @@ int tester_N2N(const std::string& input_name)
 
   int return_flag = 0;
 
-  Antioch::KineticsConditions<Scalar> cond(T0); //init
   for( unsigned int i = 0; i < n_T_samples; i++ )
     {
       const Scalar T = T0 + T_inc*static_cast<Scalar>(i);
       const Scalar rho = P/(R_mix*T);
       chem_mixture.molar_densities(rho,Y,molar_densities);
-      cond.change_temperature(T);
+      const Antioch::KineticsConditions<Scalar> cond(T);
 
       typedef typename Antioch::CEAThermodynamics<Scalar>::template Cache<Scalar> Cache;
 
@@ -170,13 +169,12 @@ int tester(const std::string& input_name)
 
   int return_flag = 0;
 
-  Antioch::KineticsConditions<Scalar> cond(T0); //init
   for( unsigned int i = 0; i < n_T_samples; i++ )
     {
       const Scalar T = T0 + T_inc*static_cast<Scalar>(i);
       const Scalar rho = P/(R_mix*T);
       chem_mixture.molar_densities(rho,Y,molar_densities);
-      cond.change_temperature(T);
+      const Antioch::KineticsConditions<Scalar> cond(T); 
 
       typedef typename Antioch::CEAThermodynamics<Scalar>::template Cache<Scalar> Cache;
 

--- a/test/kinetics_unit.C
+++ b/test/kinetics_unit.C
@@ -80,7 +80,7 @@ int tester_N2N(const std::string& input_name)
 
   int return_flag = 0;
 
-  Antioch::KineticsConditions<Scalar> cond;
+  Antioch::KineticsConditions<Scalar> cond(T0); //init
   for( unsigned int i = 0; i < n_T_samples; i++ )
     {
       const Scalar T = T0 + T_inc*static_cast<Scalar>(i);
@@ -170,7 +170,7 @@ int tester(const std::string& input_name)
 
   int return_flag = 0;
 
-  Antioch::KineticsConditions<Scalar> cond;
+  Antioch::KineticsConditions<Scalar> cond(T0); //init
   for( unsigned int i = 0; i < n_T_samples; i++ )
     {
       const Scalar T = T0 + T_inc*static_cast<Scalar>(i);

--- a/test/kinetics_unit.C
+++ b/test/kinetics_unit.C
@@ -80,11 +80,13 @@ int tester_N2N(const std::string& input_name)
 
   int return_flag = 0;
 
+  Antioch::KineticsConditions<Scalar> cond;
   for( unsigned int i = 0; i < n_T_samples; i++ )
     {
       const Scalar T = T0 + T_inc*static_cast<Scalar>(i);
       const Scalar rho = P/(R_mix*T);
       chem_mixture.molar_densities(rho,Y,molar_densities);
+      cond.change_temperature(T);
 
       typedef typename Antioch::CEAThermodynamics<Scalar>::template Cache<Scalar> Cache;
 
@@ -96,10 +98,10 @@ int tester_N2N(const std::string& input_name)
           std::vector<std::vector<Scalar> > prod_matrix;
           std::vector<std::vector<Scalar> > net_matrix;
 
-          reaction_set.print_chemical_scheme( std::cout, T, molar_densities, h_RT_minus_s_R, loss_matrix, prod_matrix, net_matrix );
+          reaction_set.print_chemical_scheme( std::cout, cond, molar_densities, h_RT_minus_s_R, loss_matrix, prod_matrix, net_matrix );
         }
       
-      kinetics.compute_mass_sources( T, molar_densities, h_RT_minus_s_R, omega_dot );
+      kinetics.compute_mass_sources( cond, molar_densities, h_RT_minus_s_R, omega_dot );
 
       // Omega dot had better sum to 0.0
       Scalar sum = 0;
@@ -168,17 +170,19 @@ int tester(const std::string& input_name)
 
   int return_flag = 0;
 
+  Antioch::KineticsConditions<Scalar> cond;
   for( unsigned int i = 0; i < n_T_samples; i++ )
     {
       const Scalar T = T0 + T_inc*static_cast<Scalar>(i);
       const Scalar rho = P/(R_mix*T);
       chem_mixture.molar_densities(rho,Y,molar_densities);
+      cond.change_temperature(T);
 
       typedef typename Antioch::CEAThermodynamics<Scalar>::template Cache<Scalar> Cache;
 
       thermo.h_RT_minus_s_R(Cache(T),h_RT_minus_s_R);
 
-      kinetics.compute_mass_sources( T, molar_densities, h_RT_minus_s_R, omega_dot );
+      kinetics.compute_mass_sources( cond, molar_densities, h_RT_minus_s_R, omega_dot );
 
       // Omega dot had better sum to 0.0
       Scalar sum = 0;

--- a/test/kinetics_vec_unit.C
+++ b/test/kinetics_vec_unit.C
@@ -146,6 +146,8 @@ int vectester(const std::string& input_name,
           T[2*tuple+1] = T[0]+T_inc/2;
 	}
 
+      Antioch::KineticsConditions<PairScalars> cond(T);
+
 #ifdef ANTIOCH_HAVE_GRVY
   const std::string testnormal = testname + "-normal";
   gt.BeginTimer(testnormal);
@@ -159,7 +161,7 @@ int vectester(const std::string& input_name,
 
       thermo.h_RT_minus_s_R(Cache(T),h_RT_minus_s_R);
 
-      kinetics.compute_mass_sources( T, molar_densities, h_RT_minus_s_R, omega_dot );
+      kinetics.compute_mass_sources( cond, molar_densities, h_RT_minus_s_R, omega_dot );
 
 #ifdef ANTIOCH_HAVE_GRVY
   gt.EndTimer(testnormal);

--- a/test/kinetics_vec_unit.C
+++ b/test/kinetics_vec_unit.C
@@ -146,7 +146,7 @@ int vectester(const std::string& input_name,
           T[2*tuple+1] = T[0]+T_inc/2;
 	}
 
-      Antioch::KineticsConditions<PairScalars> cond(T);
+      const Antioch::KineticsConditions<PairScalars> cond(T);
 
 #ifdef ANTIOCH_HAVE_GRVY
   const std::string testnormal = testname + "-normal";

--- a/test/lindemann_falloff_unit.C
+++ b/test/lindemann_falloff_unit.C
@@ -67,6 +67,9 @@ int tester()
 
   for(Scalar T = 300.1; T <= 2500.1; T += 10.)
   {
+
+    const Antioch::KineticsConditions<Scalar> conditions(T);
+
     for(unsigned int ikinmod = 0; ikinmod < 6; ikinmod++)
     {
 
@@ -150,12 +153,12 @@ int tester()
 
     fall_reaction->add_forward_rate(rate_kinetics1);
     fall_reaction->add_forward_rate(rate_kinetics2);
-    Scalar rate1 = fall_reaction->compute_forward_rate_coefficient(mol_densities,T);
+    Scalar rate1 = fall_reaction->compute_forward_rate_coefficient(mol_densities,conditions);
     Scalar rate;
     Scalar drate_dT;
     std::vector<Scalar> drate_dx;
     drate_dx.resize(n_species);
-    fall_reaction->compute_forward_rate_coefficient_and_derivatives(mol_densities,T,rate,drate_dT,drate_dx);
+    fall_reaction->compute_forward_rate_coefficient_and_derivatives(mol_densities,conditions,rate,drate_dT,drate_dx);
 
     for(unsigned int i = 0; i < n_species; i++)
     {

--- a/test/parsing_xml.C
+++ b/test/parsing_xml.C
@@ -203,7 +203,8 @@ int tester(const std::string &root_name)
   CH4_file.close();
 
   Antioch::ParticleFlux<std::vector<Scalar> > photons(lambda,hv);
-  reaction_set.set_particle_flux(&photons);
+
+  Antioch::KineticsConditions<Scalar,std::vector<Scalar> > conditions(T);
 
 //
   // Molar densities
@@ -526,6 +527,7 @@ int tester(const std::string &root_name)
 //
 //photochemistry
   k.push_back(k_photo(lambda,hv,CH4_lambda,CH4_s));
+  conditions.add_particle_flux(photons,k.size()-1);
 //Constant
   k.push_back(2.5e11);
   
@@ -535,7 +537,7 @@ int tester(const std::string &root_name)
   for(unsigned int ir = 0; ir < k.size(); ir++)
   {
      const Antioch::Reaction<Scalar> * reac = &reaction_set.reaction(ir);
-     if(std::abs(k[ir] - reac->compute_forward_rate_coefficient(molar_densities,T))/k[ir] > tol)
+     if(std::abs(k[ir] - reac->compute_forward_rate_coefficient(molar_densities,conditions))/k[ir] > tol)
      {
         std::cout << *reac << std::endl;
         std::cout << std::scientific << std::setprecision(16)
@@ -543,8 +545,8 @@ int tester(const std::string &root_name)
                   << "reaction #" << ir << "\n"
                   << "temperature: " << T << " K" << "\n"
                   << "theory: " << k[ir] << "\n"
-                  << "calculated: " << reac->compute_forward_rate_coefficient(molar_densities,T) << "\n"
-                  << "relative error = " << std::abs(k[ir] - reac->compute_forward_rate_coefficient(molar_densities,T))/k[ir] << "\n"
+                  << "calculated: " << reac->compute_forward_rate_coefficient(molar_densities,conditions) << "\n"
+                  << "relative error = " << std::abs(k[ir] - reac->compute_forward_rate_coefficient(molar_densities,conditions))/k[ir] << "\n"
                   << "tolerance = " <<  tol
                   << std::endl;
         return_flag = 1;

--- a/test/parsing_xml.C
+++ b/test/parsing_xml.C
@@ -119,7 +119,7 @@ typename Antioch::value_type<VectorScalar>::type k_photo(const VectorScalar &sol
                                                          const VectorScalar &sigma_lambda, const VectorScalar &sigma_sigma)
 {
   Antioch::SigmaBinConverter<VectorScalar> bin;
-  VectorScalar sigma_rescaled;
+  VectorScalar sigma_rescaled(solar_lambda.size());
   bin.y_on_custom_grid(sigma_lambda,sigma_sigma,solar_lambda,sigma_rescaled);
 
   typename Antioch::value_type<VectorScalar>::type _k(0.L);

--- a/test/photochemical_rate_unit.C
+++ b/test/photochemical_rate_unit.C
@@ -87,7 +87,7 @@ int tester(std::string path_to_files)
   Antioch::PhotochemicalRate<Scalar, std::vector<Scalar> > rate_hv(CH4_cs,CH4_lambda);
 
   Antioch::SigmaBinConverter<std::vector<Scalar> > bin;
-  std::vector<Scalar> sigma_rescaled;
+  std::vector<Scalar> sigma_rescaled(hv_lambda.size());
   bin.y_on_custom_grid(CH4_lambda,CH4_cs,hv_lambda,sigma_rescaled);
 
   Scalar rate = rate_hv.rate(part_flux);

--- a/test/photochemical_rate_unit.C
+++ b/test/photochemical_rate_unit.C
@@ -62,27 +62,27 @@ int tester(std::string path_to_files)
 
   while(!CH4.eof())
   {
-    Scalar cs,l;
+    Scalar cs,l(-1);
     CH4 >> l >> cs;
+    if(l == -1)break;
     CH4_lambda.push_back(l);
     CH4_cs.push_back(cs);
-    if(CH4_lambda.size() == 137)break;
   }
   CH4.close();
 
   while(!hv.eof())
   {
-    Scalar w,l,dw;
+    Scalar w,l(-1),dw;
     hv >> l >> w >> dw;
+    if(l == -1)break;
     hv_lambda.push_back(l * 10.L); //nm -> Angström
     hv_irr.push_back(w * 1e-4L  // * 1e-4: m-2 -> cm-2 
                        / (Antioch::Constants::Planck_constant<Scalar>() * Antioch::Constants::light_celerity<Scalar>() / l)// /(h*c/lambda): energy -> number of photons
                        / 10.); // by Angström
-    if(hv_lambda.size() == 796)break;
   }
   hv.close();
 
-  Scalar T(1500.L);
+  Antioch::ParticleFlux<std::vector<Scalar> > part_flux(hv_lambda,hv_irr);
 
   Antioch::PhotochemicalRate<Scalar, std::vector<Scalar> > rate_hv(CH4_cs,CH4_lambda);
 
@@ -90,8 +90,7 @@ int tester(std::string path_to_files)
   std::vector<Scalar> sigma_rescaled;
   bin.y_on_custom_grid(CH4_lambda,CH4_cs,hv_lambda,sigma_rescaled);
 
-  rate_hv.calculate_rate_constant(hv_irr, hv_lambda);
-  Scalar rate = rate_hv.rate(T);
+  Scalar rate = rate_hv.rate(part_flux);
 
   const Scalar tol = std::numeric_limits<Scalar>::epsilon() * 100;
   Scalar rate_exact(0.L);

--- a/test/sigma_bin_converter_unit.C
+++ b/test/sigma_bin_converter_unit.C
@@ -156,8 +156,8 @@ int tester()
   for(unsigned int i = 0; i < 4; i++)
   {
     std::vector<Scalar> bin_custom_x, exact_sol_y;
-    std::vector<Scalar> bin_custom_y;
     make_custom(i,bin_custom_x,exact_sol_y);
+    std::vector<Scalar> bin_custom_y(bin_custom_x.size());
 
     bin.y_on_custom_grid(bin_ref_x,bin_ref_y,
                          bin_custom_x,bin_custom_y);

--- a/test/sigma_bin_converter_unit.C
+++ b/test/sigma_bin_converter_unit.C
@@ -65,9 +65,9 @@ void make_custom(unsigned int choice, VectorScalar & x, VectorScalar & y)
           x[0] = 2.50L;  y[0] = 2.25L/0.75L; // 0.50 * 2  + 0.25 * 5
           x[1] = 3.25L;  y[1] = 3.75L/0.75L; // 0.75 * 5
           x[2] = 4.00L;  y[2] = 6.00L/0.75L; // 0.75 * 8
-          x[3] = 4.75L;  y[3] = 5.00L/0.75L; // 0.25 * 8  + 0.5 * 6
-          x[4] = 5.50L;  y[4] = 6.50L/0.75L; // 0.25 * 6  + 0.5 * 10
-          x[5] = 6.25L;  y[5] = 6.75L/0.75L; // 0.50 * 10 + 0.25 * 7
+          x[3] = 4.75L;  y[3] = 5.00L/0.75L; // 0.25 * 8  + 0.5  * 6
+          x[4] = 5.50L;  y[4] = 5.50L/0.75L; // 0.25 * 6  + 0.25 * 10
+          x[5] = 6.25L;  y[5] = 7.50L/0.75L; // 0.75 * 10
           x[6] = 7.00L;  y[6] = 5.25L/0.75L; // 0.75 * 7
           x[7] = 7.75L;  y[7] = 3.75L/0.75L; // 0.25 * 7 + 0.5 * 4
           x[8] = 8.50L;  y[8] = 0.00L/0.75L; // 0. (right stairs)
@@ -82,7 +82,7 @@ void make_custom(unsigned int choice, VectorScalar & x, VectorScalar & y)
           x[3] = 4.50L;  y[3] = 10.0L/1.50L; // 0.5 * 8  + 1.0 * 6
           x[4] = 6.00L;  y[4] = 13.5L/1.50L; // 1.0 * 10 + 0.5 * 7
           x[5] = 7.50L;  y[5] = 7.50L/1.50L; // 0.50 * 7 + 1.0 * 4
-          x[6] = 9.00L;  y[6] = 3.15L/1.50L; // 1.0 * 2 + 0.5 * 0.3
+          x[6] = 9.00L;  y[6] = 2.00L/1.50L; // 1.0 * 2 
           x[7] = 10.5L;  y[7] = 0.00L/1.50L; // 0
           x[8] = 12.0L;  y[8] = 0.00L/1.50L; // 0. (right stairs)
         break;
@@ -115,22 +115,23 @@ void make_custom(unsigned int choice, VectorScalar & x, VectorScalar & y)
 template <typename VectorScalar>
 void make_reference(VectorScalar & x, VectorScalar & y)
 {
-  x.resize(10);
-  y.resize(10);
-  for(unsigned int i = 1; i < 11; i++)
+  x.resize(10,0);
+  y.resize(10,0);
+  for(unsigned int i = 0; i < 10; i++)
   {
-     x[i-1] = ((typename Antioch::value_type<VectorScalar>::type)i);
+     x[i] = ((typename Antioch::value_type<VectorScalar>::type)(i+1));
   }
-  y[0] = 1.;
-  y[1] = 2.;
-  y[2] = 5.;
-  y[3] = 8.;
-  y[4] = 6.;
-  y[5] = 10.;
-  y[6] = 7.;
-  y[7] = 4.;
-  y[8] = 2.;
-  y[9] = 0.3;
+  y[0] = 1.L;
+  y[1] = 2.L;
+  y[2] = 5.L;
+  y[3] = 8.L;
+  y[4] = 6.L;
+  y[5] = 10.L;
+  y[6] = 7.L;
+  y[7] = 4.L;
+  y[8] = 2.L;
+  y[9] = 0.3L;
+
 }
 
 
@@ -143,7 +144,7 @@ int tester()
 
   Antioch::SigmaBinConverter<std::vector<Scalar> > bin;
 
-  const Scalar tol = std::numeric_limits<Scalar>::epsilon() * 100;
+  const Scalar tol = std::numeric_limits<Scalar>::epsilon() * 10;
 
   int return_flag = 0;
 
@@ -162,17 +163,18 @@ int tester()
                          bin_custom_x,bin_custom_y);
 
 
-    for(unsigned int il = 0; il < bin_custom_x.size(); il++)
+    for(unsigned int il = 0; il < bin_custom_x.size() - 1; il++)
     {
-      if( std::abs( (bin_custom_y[il] - exact_sol_y[il])/exact_sol_y[il]) > tol )
+      const Scalar dist = (exact_sol_y[il] < tol)?std::abs(bin_custom_y[il] - exact_sol_y[il]):std::abs(bin_custom_y[il] - exact_sol_y[il])/exact_sol_y[il];
+      if( dist > tol )
       {
         std::cout << std::scientific << std::setprecision(16)
-                  << "Error: Mismatch in bin values."                                                       << std::endl
-                  << "case "             << i                                                               << std::endl
-                  << "bin = "            << bin_custom_x[il]                                                << std::endl
-                  << "bin_exact = "      << exact_sol_y[il]                                                 << std::endl
-                  << "relative error = " << std::abs( (bin_custom_y[il] - exact_sol_y[il])/exact_sol_y[il]) << std::endl
-                  << "tolerance = "      << tol                                                             << std::endl;
+                  << "Error: Mismatch in bin values."                                                  << std::endl
+                  << "case ("            << bin_custom_x[il]   << ";"   << bin_custom_x[il+1]   << ")" << std::endl 
+                  << "bin = "            << bin_custom_y[il]                                           << std::endl
+                  << "bin_exact = "      << exact_sol_y[il]                                            << std::endl
+                  << "relative error = " << dist                                                       << std::endl
+                  << "tolerance = "      << tol                                                        << std::endl;
 
         return_flag = 1;
       }

--- a/test/sigma_bin_converter_unit.C
+++ b/test/sigma_bin_converter_unit.C
@@ -41,67 +41,152 @@
 #include "antioch/antioch_asserts.h"
 #include "antioch/physical_constants.h"
 #include "antioch/vector_utils.h"
+/*
+  x[0] = 1.;  y[0] = 1.;
+  x[1] = 2.;  y[1] = 2.;
+  x[2] = 3.;  y[2] = 5.;
+  x[3] = 4.;  y[3] = 8.;
+  x[4] = 5.;  y[4] = 6.;
+  x[5] = 6.;  y[5] = 10.;
+  x[6] = 7.;  y[6] = 7.;
+  x[7] = 8.;  y[7] = 4.;
+  x[8] = 9.;  y[8] = 2.;
+  x[9] = 10.; y[9] = 0.3; // right stairs, this value is useless
+*/
+template <typename VectorScalar>
+void make_custom(unsigned int choice, VectorScalar & x, VectorScalar & y)
+{
+  // sum_{bin} Delta x * y
+  switch(choice)
+  {
+      case(0): // 9 bin contained in ref -> [2.5;8.5] within [1;10]
+      {
+          x.resize(9);   y.resize(9);
+          x[0] = 2.50L;  y[0] = 2.25L/0.75L; // 0.50 * 2  + 0.25 * 5
+          x[1] = 3.25L;  y[1] = 3.75L/0.75L; // 0.75 * 5
+          x[2] = 4.00L;  y[2] = 6.00L/0.75L; // 0.75 * 8
+          x[3] = 4.75L;  y[3] = 5.00L/0.75L; // 0.25 * 8  + 0.5 * 6
+          x[4] = 5.50L;  y[4] = 6.50L/0.75L; // 0.25 * 6  + 0.5 * 10
+          x[5] = 6.25L;  y[5] = 6.75L/0.75L; // 0.50 * 10 + 0.25 * 7
+          x[6] = 7.00L;  y[6] = 5.25L/0.75L; // 0.75 * 7
+          x[7] = 7.75L;  y[7] = 3.75L/0.75L; // 0.25 * 7 + 0.5 * 4
+          x[8] = 8.50L;  y[8] = 0.00L/0.75L; // 0. (right stairs)
+        break;
+      }
+      case(1):// 9 bin outside ref -> [0;12] containing [1;10]
+      {
+          x.resize(9);   y.resize(9);
+          x[0] = 0.00L;  y[0] = 0.50L/1.50L; // 0.5 * 1
+          x[1] = 1.50L;  y[1] = 2.50L/1.50L; // 0.5 * 1  + 2.0 * 1
+          x[2] = 3.00L;  y[2] = 9.00L/1.50L; // 1.0 * 5  + 0.5 * 8
+          x[3] = 4.50L;  y[3] = 10.0L/1.50L; // 0.5 * 8  + 1.0 * 6
+          x[4] = 6.00L;  y[4] = 13.5L/1.50L; // 1.0 * 10 + 0.5 * 7
+          x[5] = 7.50L;  y[5] = 7.50L/1.50L; // 0.50 * 7 + 1.0 * 4
+          x[6] = 9.00L;  y[6] = 3.15L/1.50L; // 1.0 * 2 + 0.5 * 0.3
+          x[7] = 10.5L;  y[7] = 0.00L/1.50L; // 0
+          x[8] = 12.0L;  y[8] = 0.00L/1.50L; // 0. (right stairs)
+        break;
+      }
+      case(2): // 5 bins beyond only min -> [-1;3.8] in [0;10]
+      {
+          x.resize(5);    y.resize(5);
+          x[0] = -1.00L;  y[0] = 0.00L/1.20L; // 0
+          x[1] =  0.20L;  y[1] = 0.40L/1.20L; // 0.4 * 1
+          x[2] =  1.40L;  y[2] = 1.80L/1.20L; // 0.6 * 1  + 0.6 * 2
+          x[3] =  2.60L;  y[3] = 4.80L/1.20L; // 0.4 * 2  + 0.8 * 5
+          x[4] =  3.80L;  y[4] = 00.0L/1.20L; // 0. (right stairs)
+        break;
+      }
+      case(3):// 6 bins beyond only max -> [2;10.75] in [0;10]
+      {
+          x.resize(6);    y.resize(6);
+          x[0] =  2.00L;  y[0] =  5.75L/1.75L; // 1.00 * 2 + 0.75 * 5
+          x[1] =  3.75L;  y[1] = 12.25L/1.75L; // 0.25 * 5 + 1.00 * 8 + 0.50 * 6
+          x[2] =  5.50L;  y[2] = 14.75L/1.75L; // 0.50 * 6 + 1.00 * 10 + 0.25 * 7
+          x[3] =  7.25L;  y[3] =  9.25L/1.75L; // 0.75 * 7 + 1.00 * 4
+          x[4] =  9.00L;  y[4] =  2.00L/1.75L; // 1.00 * 2
+          x[5] = 10.75L;  y[5] = 00.00L/1.75L; // 0. (right stairs)
+        break;
+      }
+  }
+
+}
+
+template <typename VectorScalar>
+void make_reference(VectorScalar & x, VectorScalar & y)
+{
+  x.resize(10);
+  y.resize(10);
+  for(unsigned int i = 1; i < 11; i++)
+  {
+     x[i-1] = ((typename Antioch::value_type<VectorScalar>::type)i);
+  }
+  y[0] = 1.;
+  y[1] = 2.;
+  y[2] = 5.;
+  y[3] = 8.;
+  y[4] = 6.;
+  y[5] = 10.;
+  y[6] = 7.;
+  y[7] = 4.;
+  y[8] = 2.;
+  y[9] = 0.3;
+}
+
 
 template <typename Scalar>
-int tester(std::string path_to_files)
+int tester()
 {
-  std::ifstream  hv(path_to_files + "/solar_flux.dat");
+  std::vector<Scalar> bin_ref_x,bin_ref_y;
 
-  std::string first_line;
-
-  getline(hv,first_line);
-
-  std::vector<Scalar> hv_irr;
-  std::vector<Scalar> hv_lambda;
-
-  while(!hv.eof())
-  {
-    Scalar w,l,dw;
-    hv >> l >> w >> dw;
-    hv_lambda.push_back(l * 10.L); //nm -> Angström
-    hv_irr.push_back(w * 1e-4L  // * 1e-4: m-2 -> cm-2 
-                       / (Antioch::Constants::Planck_constant<Scalar>() * Antioch::Constants::light_celerity<Scalar>() / l)// /(h*c/lambda): energy -> number of photons
-                       / 10.); // by Angström
-    if(hv_lambda.size() == 796)break;
-  }
-  hv.close();
+  make_reference(bin_ref_x,bin_ref_y);
 
   Antioch::SigmaBinConverter<std::vector<Scalar> > bin;
-  std::vector<Scalar> flux_recalculated;
-  bin.y_on_custom_grid(hv_lambda,hv_irr,hv_lambda,flux_recalculated);
 
   const Scalar tol = std::numeric_limits<Scalar>::epsilon() * 100;
 
   int return_flag = 0;
-  for(unsigned int il = 0; il < hv_lambda.size() - 1; il++)
-  {
-    if( std::abs( (flux_recalculated[il] - hv_irr[il])/hv_irr[il]) > tol )
-    {
-      std::cout << std::scientific << std::setprecision(16)
-                << "Error: Mismatch in bin values."            << std::endl
-                << "bin = "           << flux_recalculated[il] << std::endl
-                << "bin_exact = "     << hv_irr[il]            << std::endl
-                << "relative error = " << std::abs( (flux_recalculated[il] - hv_irr[il])/hv_irr[il]) << std::endl
-                << "tolerance = "      << tol            << std::endl;
 
-      return_flag = 1;
+  // 4 cases:
+  //   - custom inside ref
+  //   - ref inside custom
+  //   - custom beyond only min ref
+  //   - custom beyond only max ref
+  for(unsigned int i = 0; i < 4; i++)
+  {
+    std::vector<Scalar> bin_custom_x, exact_sol_y;
+    std::vector<Scalar> bin_custom_y;
+    make_custom(i,bin_custom_x,exact_sol_y);
+
+    bin.y_on_custom_grid(bin_ref_x,bin_ref_y,
+                         bin_custom_x,bin_custom_y);
+
+
+    for(unsigned int il = 0; il < bin_custom_x.size(); il++)
+    {
+      if( std::abs( (bin_custom_y[il] - exact_sol_y[il])/exact_sol_y[il]) > tol )
+      {
+        std::cout << std::scientific << std::setprecision(16)
+                  << "Error: Mismatch in bin values."                                                       << std::endl
+                  << "case "             << i                                                               << std::endl
+                  << "bin = "            << bin_custom_x[il]                                                << std::endl
+                  << "bin_exact = "      << exact_sol_y[il]                                                 << std::endl
+                  << "relative error = " << std::abs( (bin_custom_y[il] - exact_sol_y[il])/exact_sol_y[il]) << std::endl
+                  << "tolerance = "      << tol                                                             << std::endl;
+
+        return_flag = 1;
+      }
     }
   }
 
   return return_flag;
 }
 
-int main(int argc, char* argv[])
+int main()
 {
-  if( argc < 2 )
-    {
-      // TODO: Need more consistent error handling.
-      std::cerr << "Error: Must specify input files location." << std::endl;
-      antioch_error();
-    }
 
-   return (tester<float>(std::string(argv[1]))  ||
-           tester<double>(std::string(argv[1])) ||
-           tester<long double>(std::string(argv[1]))
+   return (tester<float>()  ||
+           tester<double>() ||
+           tester<long double>()
           );
 }

--- a/test/sigma_bin_converter_unit.sh.in
+++ b/test/sigma_bin_converter_unit.sh.in
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-PROG="@top_builddir@/test/sigma_bin_converter_unit"
-
-INPUT="@top_srcdir@/test/input_files"
-
-$PROG $INPUT
-

--- a/test/sigma_bin_converter_vec_unit.C
+++ b/test/sigma_bin_converter_vec_unit.C
@@ -180,16 +180,18 @@ int vectester(const PairScalars& example, const std::string& testname)
 
   int return_flag = 0;
 
+#ifdef ANTIOCH_HAVE_GRVY
+  gt.BeginTimer(testname);
+#endif
+
   // 2 * 2  cases:
-  //   - custom inside ref
-  //   - ref inside custom
-  //   - custom beyond only min ref
-  //   - custom beyond only max ref
+  //   - custom inside ref, ref inside custom
+  //   - custom beyond only min ref, custom beyond only max ref
   for(unsigned int i = 0; i < 2; i++)
   {
     std::vector<PairScalars> bin_custom_x, exact_sol_y;
-    std::vector<PairScalars> bin_custom_y;
     make_custom(i,example,bin_custom_x,exact_sol_y);
+    std::vector<PairScalars> bin_custom_y(bin_custom_x.size(),Antioch::zero_clone(bin_custom_x[0]));
 
     bin.y_on_custom_grid(bin_ref_x,bin_ref_y,
                          bin_custom_x,bin_custom_y);
@@ -239,6 +241,10 @@ int vectester(const PairScalars& example, const std::string& testname)
     }
   }
 
+#ifdef ANTIOCH_HAVE_GRVY
+  gt.EndTimer(testname);
+#endif
+
   return return_flag;
 }
 
@@ -253,7 +259,7 @@ int main()
     vectester (std::valarray<double>(2*ANTIOCH_N_TUPLES), "valarray<double>");
   returnval = returnval ||
     vectester (std::valarray<long double>(2*ANTIOCH_N_TUPLES), "valarray<ld>");
-/*
+
 #ifdef ANTIOCH_HAVE_EIGEN
   returnval = returnval ||
     vectester (Eigen::Array<float, 2*ANTIOCH_N_TUPLES, 1>(), "Eigen::ArrayXf");
@@ -281,7 +287,7 @@ int main()
     returnval = returnval ||
       vectester (vex::vector<double> (ctx_d, 2*ANTIOCH_N_TUPLES), "vex::vector<double>");
 #endif
-*/
+
 #ifdef ANTIOCH_HAVE_GRVY
   gt.Finalize();
   gt.Summarize();

--- a/test/sigma_bin_converter_vec_unit.C
+++ b/test/sigma_bin_converter_vec_unit.C
@@ -1,0 +1,259 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// Antioch - A Gas Dynamics Thermochemistry Library
+//
+// Copyright (C) 2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+//
+// $Id$
+//
+//--------------------------------------------------------------------------
+//--------------------------------------------------------------------------
+
+// C++
+#include <limits>
+#include <string>
+#include <iostream>
+#include <iomanip>
+#include <fstream>
+
+// Antioch
+#include "antioch/vector_utils_decl.h"
+#include "antioch/sigma_bin_converter.h"
+#include "antioch/antioch_asserts.h"
+#include "antioch/physical_constants.h"
+#include "antioch/vector_utils.h"
+/*
+  x[0] = 1.;  y[0] = 1.;
+  x[1] = 2.;  y[1] = 2.;
+  x[2] = 3.;  y[2] = 5.;
+  x[3] = 4.;  y[3] = 8.;
+  x[4] = 5.;  y[4] = 6.;
+  x[5] = 6.;  y[5] = 10.;
+  x[6] = 7.;  y[6] = 7.;
+  x[7] = 8.;  y[7] = 4.;
+  x[8] = 9.;  y[8] = 2.;
+  x[9] = 10.; y[9] = 0.3; // right stairs, this value is useless
+*/
+template <typename VectorPairScalar>
+void make_custom(unsigned int choice, VectorPairScalar & x, VectorPairScalar & y)
+{
+  // sum_{bin} Delta x * y
+  switch(choice)
+  {
+      case(0): // 9 bin contained in ref -> [2.5;8.5] within [1;10]
+      {
+       x.resize(9);   y.resize(9);
+       for (unsigned int tuple=0; tuple != ANTIOCH_N_TUPLES; ++tuple)
+       {
+          x[0 * tuple] = 2.50L;  y[0 * tuple] = 2.25L/0.75L; // 0.50 * 2  + 0.25 * 5
+          x[1 * tuple] = 3.25L;  y[1 * tuple] = 3.75L/0.75L; // 0.75 * 5
+          x[2 * tuple] = 4.00L;  y[2 * tuple] = 6.00L/0.75L; // 0.75 * 8
+          x[3 * tuple] = 4.75L;  y[3 * tuple] = 5.00L/0.75L; // 0.25 * 8  + 0.5  * 6
+          x[4 * tuple] = 5.50L;  y[4 * tuple] = 5.50L/0.75L; // 0.25 * 6  + 0.25 * 10
+          x[5 * tuple] = 6.25L;  y[5 * tuple] = 7.50L/0.75L; // 0.75 * 10
+          x[6 * tuple] = 7.00L;  y[6 * tuple] = 5.25L/0.75L; // 0.75 * 7
+          x[7 * tuple] = 7.75L;  y[7 * tuple] = 3.75L/0.75L; // 0.25 * 7 + 0.5 * 4
+          x[8 * tuple] = 8.50L;  y[8 * tuple] = 0.00L/0.75L; // 0. (right stairs)
+
+      // 9 bin outside ref -> [0;12] containing [1;10]
+          
+          x[0 * tuple + 1] = 0.00L;  y[0 * tuple + 1] = 0.50L/1.50L; // 0.5 * 1
+          x[1 * tuple + 1] = 1.50L;  y[1 * tuple + 1] = 2.50L/1.50L; // 0.5 * 1  + 2.0 * 1
+          x[2 * tuple + 1] = 3.00L;  y[2 * tuple + 1] = 9.00L/1.50L; // 1.0 * 5  + 0.5 * 8
+          x[3 * tuple + 1] = 4.50L;  y[3 * tuple + 1] = 10.0L/1.50L; // 0.5 * 8  + 1.0 * 6
+          x[4 * tuple + 1] = 6.00L;  y[4 * tuple + 1] = 13.5L/1.50L; // 1.0 * 10 + 0.5 * 7
+          x[5 * tuple + 1] = 7.50L;  y[5 * tuple + 1] = 7.50L/1.50L; // 0.50 * 7 + 1.0 * 4
+          x[6 * tuple + 1] = 9.00L;  y[6 * tuple + 1] = 2.00L/1.50L; // 1.0 * 2 
+          x[7 * tuple + 1] = 10.5L;  y[7 * tuple + 1] = 0.00L/1.50L; // 0
+          x[8 * tuple + 1] = 12.0L;  y[8 * tuple + 1] = 0.00L/1.50L; // 0. (right stairs)
+       }
+       break;
+      }
+      case(1): // 5 bins beyond only min -> [-1;3.8] in [0;10]
+      {
+       x.resize(5);    y.resize(5);
+       for (unsigned int tuple=0; tuple != ANTIOCH_N_TUPLES; ++tuple)
+       {
+          x[0 * tuple] = -1.00L;  y[0 * tuple] = 0.00L/1.20L; // 0
+          x[1 * tuple] =  0.20L;  y[1 * tuple] = 0.40L/1.20L; // 0.4 * 1
+          x[2 * tuple] =  1.40L;  y[2 * tuple] = 1.80L/1.20L; // 0.6 * 1  + 0.6 * 2
+          x[3 * tuple] =  2.60L;  y[3 * tuple] = 4.80L/1.20L; // 0.4 * 2  + 0.8 * 5
+          x[4 * tuple] =  3.80L;  y[4 * tuple] = 00.0L/1.20L; // 0. (right stairs)
+       
+        // 6 bins beyond only max -> [2;10.75] in [0;10]
+          x.resize(6);    y.resize(6);
+          x[0 * tuple + 1] =  2.0000L;  y[0 * tuple + 1] =  8.50L/2.1875L; // 1.0000 * 2  + 1.0000 * 5 + 0.1875 * 8
+          x[1 * tuple + 1] =  4.1875L;  y[1 * tuple + 1] = 16.25L/2.1875L; // 0.8125 * 8  + 1.0000 * 6 + 0.3750 * 10
+          x[2 * tuple + 1] =  6.3750L;  y[2 * tuple + 1] = 15.50L/2.1875L; // 0.6250 * 10 + 1.0000 * 7 + 0.5625 * 4
+          x[3 * tuple + 1] =  8.5625L;  y[3 * tuple + 1] =  3.75L/2.1875L; // 0.4375 * 4  + 1.0000 * 2 + 0
+          x[4 * tuple + 1] = 10.7500L;  y[4 * tuple + 1] =  0.00L/2.1875L; // 0. (right stairs)
+        }
+        break;
+      }
+  }
+
+}
+
+template <typename VectorScalar>
+void make_reference(VectorScalar & x, VectorScalar & y)
+{
+  x.resize(10,0);
+  y.resize(10,0);
+  for(unsigned int i = 0; i < 10; i++)
+  {
+     x[i] = ((typename Antioch::value_type<VectorScalar>::type)(i+1));
+  }
+  y[0] = 1.L;
+  y[1] = 2.L;
+  y[2] = 5.L;
+  y[3] = 8.L;
+  y[4] = 6.L;
+  y[5] = 10.L;
+  y[6] = 7.L;
+  y[7] = 4.L;
+  y[8] = 2.L;
+  y[9] = 0.3L;
+
+}
+
+
+template <typename PairScalars>
+int vectester(const PairScalars& example, const std::string& testname)
+{
+
+  typedef typename Antioch::value_type<PairScalars>::type Scalar;
+
+  std::vector<Scalar> bin_ref_x,bin_ref_y;
+
+  make_reference(bin_ref_x,bin_ref_y);
+
+  Antioch::SigmaBinConverter<std::vector<Scalar> > bin;
+
+  const Scalar tol = std::numeric_limits<Scalar>::epsilon() * 10;
+
+  int return_flag = 0;
+
+  // 2 * 2  cases:
+  //   - custom inside ref
+  //   - ref inside custom
+  //   - custom beyond only min ref
+  //   - custom beyond only max ref
+  for(unsigned int i = 0; i < 2; i++)
+  {
+    std::vector<PairScalars> bin_custom_x, exact_sol_y;
+    std::vector<PairScalars> bin_custom_y;
+    make_custom(i,bin_custom_x,exact_sol_y);
+
+    bin.y_on_custom_grid(bin_ref_x,bin_ref_y,
+                         bin_custom_x,bin_custom_y);
+
+
+    for(unsigned int il = 0; il < bin_custom_x.size() - 1; il++)
+    {
+      for (unsigned int tuple=0; tuple != ANTIOCH_N_TUPLES; ++tuple)
+      {
+//tuple
+
+        Scalar dist = (exact_sol_y[il * tuple] < tol)?std::abs(bin_custom_y[il * tuple] - exact_sol_y[il * tuple]):
+                                                      std::abs(bin_custom_y[il * tuple] - exact_sol_y[il * tuple])/exact_sol_y[il * tuple];
+        if( dist > tol )
+        {
+         std::cout << std::scientific << std::setprecision(16)
+                   << "Error: Mismatch in bin values."                                                                    << std::endl
+                   << "case ("            << bin_custom_x[il * tuple]   << ";"   << bin_custom_x[il * tuple + 1]   << ")" << std::endl 
+                   << "bin = "            << bin_custom_y[il * tuple]                                                     << std::endl
+                   << "bin_exact = "      << exact_sol_y[il * tuple]                                                      << std::endl
+                   << "relative error = " << dist                                                                         << std::endl
+                   << "tolerance = "      << tol                                                                          << std::endl;
+
+         return_flag = 1;
+        }
+
+//tuple + 1
+        dist = (exact_sol_y[il * tuple + 1] < tol)?std::abs(bin_custom_y[il * tuple + 1] - exact_sol_y[il * tuple + 1]):
+                                                   std::abs(bin_custom_y[il * tuple + 1] - exact_sol_y[il * tuple + 1])/exact_sol_y[il * tuple + 1];
+        if( dist > tol )
+        {
+         std::cout << std::scientific << std::setprecision(16)
+                   << "Error: Mismatch in bin values."                                                                        << std::endl
+                   << "case ("            << bin_custom_x[il * tuple + 1]   << ";"   << bin_custom_x[il * tuple + 2]   << ")" << std::endl 
+                   << "bin = "            << bin_custom_y[il * tuple + 1]                                                     << std::endl
+                   << "bin_exact = "      << exact_sol_y[il * tuple + 1]                                                      << std::endl
+                   << "relative error = " << dist                                                                             << std::endl
+                   << "tolerance = "      << tol                                                                              << std::endl;
+
+         return_flag = 1;
+        }
+
+
+      }
+    }
+  }
+
+  return return_flag;
+}
+
+int main()
+{
+
+  int returnval(0);
+
+  returnval = returnval ||
+    vectester (std::valarray<float>(2*ANTIOCH_N_TUPLES), "valarray<float>");
+  returnval = returnval ||
+    vectester (std::valarray<double>(2*ANTIOCH_N_TUPLES), "valarray<double>");
+  returnval = returnval ||
+    vectester (std::valarray<long double>(2*ANTIOCH_N_TUPLES), "valarray<ld>");
+#ifdef ANTIOCH_HAVE_EIGEN
+  returnval = returnval ||
+    vectester (Eigen::Array<float, 2*ANTIOCH_N_TUPLES, 1>(), "Eigen::ArrayXf");
+  returnval = returnval ||
+    vectester (Eigen::Array<double, 2*ANTIOCH_N_TUPLES, 1>(), "Eigen::ArrayXd");
+  returnval = returnval ||
+    vectester (Eigen::Array<long double, 2*ANTIOCH_N_TUPLES, 1>(), "Eigen::ArrayXld");
+#endif
+#ifdef ANTIOCH_HAVE_METAPHYSICL
+  returnval = returnval ||
+    vectester (MetaPhysicL::NumberArray<2*ANTIOCH_N_TUPLES, float> (0), "NumberArray<float>");
+  returnval = returnval ||
+    vectester (MetaPhysicL::NumberArray<2*ANTIOCH_N_TUPLES, double> (0), "NumberArray<double>");
+  returnval = returnval ||
+    vectester (MetaPhysicL::NumberArray<2*ANTIOCH_N_TUPLES, long double> (0), "NumberArray<ld>");
+#endif
+#ifdef ANTIOCH_HAVE_VEXCL
+  vex::Context ctx_f (vex::Filter::All);
+  if (!ctx_f.empty())
+    returnval = returnval ||
+      vectester (vex::vector<float> (ctx_f, 2*ANTIOCH_N_TUPLES), "vex::vector<float>");
+
+  vex::Context ctx_d (vex::Filter::DoublePrecision);
+  if (!ctx_d.empty())
+    returnval = returnval ||
+      vectester (vex::vector<double> (ctx_d, 2*ANTIOCH_N_TUPLES), "vex::vector<double>");
+#endif
+
+#ifdef ANTIOCH_HAVE_GRVY
+  gt.Finalize();
+  gt.Summarize();
+#endif
+
+ return returnval;
+
+}

--- a/test/sigma_bin_converter_vec_unit.C
+++ b/test/sigma_bin_converter_vec_unit.C
@@ -3,6 +3,8 @@
 //
 // Antioch - A Gas Dynamics Thermochemistry Library
 //
+// Copyright (C) 2014 Paul T. Bauman, Benjamin S. Kirk, Sylvain Plessis,
+//                    Roy H. Stonger
 // Copyright (C) 2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/sigma_bin_converter_vec_unit.C
+++ b/test/sigma_bin_converter_vec_unit.C
@@ -83,15 +83,15 @@ GRVY::GRVY_Timer_Class gt;
   x[8] = 9.;  y[8] = 2.;
   x[9] = 10.; y[9] = 0.3; // right stairs, this value is useless
 */
-template <typename VectorPairScalar>
-void make_custom(unsigned int choice, VectorPairScalar & x, VectorPairScalar & y)
+template <typename PairScalars, typename VectorPairScalar>
+void make_custom(unsigned int choice, const PairScalars & ex, VectorPairScalar & x, VectorPairScalar & y)
 {
   // sum_{bin} Delta x * y
   switch(choice)
   {
       case(0): // 9 bin contained in ref -> [2.5;8.5] within [1;10]
       {
-       x.resize(9);   y.resize(9);
+       x.resize(9,ex);   y.resize(9,ex);
        for (unsigned int tuple=0; tuple != ANTIOCH_N_TUPLES; ++tuple)
        {
           x[0][2*tuple] = 2.50L;  y[0][2*tuple] = 2.25L/0.75L; // 0.50][2  + 0.25][5
@@ -120,7 +120,7 @@ void make_custom(unsigned int choice, VectorPairScalar & x, VectorPairScalar & y
       }
       case(1): // 5 bins beyond only min -> [-1;3.8] in [0;10]
       {
-       x.resize(5);    y.resize(5);
+       x.resize(5,ex);    y.resize(5,ex);
        for (unsigned int tuple=0; tuple != ANTIOCH_N_TUPLES; ++tuple)
        {
           x[0][2*tuple] = -1.00L;  y[0][2*tuple] = 0.00L/1.20L; // 0
@@ -130,7 +130,6 @@ void make_custom(unsigned int choice, VectorPairScalar & x, VectorPairScalar & y
           x[4][2*tuple] =  3.80L;  y[4][2*tuple] = 00.0L/1.20L; // 0. (right stairs)
        
         // 6 bins beyond only max -> [2;10.75] in [0;10]
-          x.resize(6);    y.resize(6);
           x[0][2*tuple + 1] =  2.0000L;  y[0][2*tuple + 1] =  8.50L/2.1875L; // 1.0000][2  + 1.0000][5 + 0.1875][8
           x[1][2*tuple + 1] =  4.1875L;  y[1][2*tuple + 1] = 16.25L/2.1875L; // 0.8125][8  + 1.0000][6 + 0.3750][10
           x[2][2*tuple + 1] =  6.3750L;  y[2][2*tuple + 1] = 15.50L/2.1875L; // 0.6250][10 + 1.0000][7 + 0.5625][4
@@ -169,7 +168,6 @@ void make_reference(VectorScalar & x, VectorScalar & y)
 template <typename PairScalars>
 int vectester(const PairScalars& example, const std::string& testname)
 {
-
   typedef typename Antioch::value_type<PairScalars>::type Scalar;
 
   std::vector<Scalar> bin_ref_x,bin_ref_y;
@@ -191,7 +189,7 @@ int vectester(const PairScalars& example, const std::string& testname)
   {
     std::vector<PairScalars> bin_custom_x, exact_sol_y;
     std::vector<PairScalars> bin_custom_y;
-    make_custom(i,bin_custom_x,exact_sol_y);
+    make_custom(i,example,bin_custom_x,exact_sol_y);
 
     bin.y_on_custom_grid(bin_ref_x,bin_ref_y,
                          bin_custom_x,bin_custom_y);
@@ -209,7 +207,7 @@ int vectester(const PairScalars& example, const std::string& testname)
         if( dist > tol )
         {
          std::cout << std::scientific << std::setprecision(16)
-                   << "Error: Mismatch in bin values."                                                                      << std::endl
+                   << "Error: Mismatch in bin values for " << testname                                                      << std::endl
                    << "case ("            << bin_custom_x[il][2*tuple]   << ";"   << bin_custom_x[il + 1][2*tuple]   << ")" << std::endl 
                    << "bin = "            << bin_custom_y[il][2*tuple]                                                      << std::endl
                    << "bin_exact = "      << exact_sol_y[il][2*tuple]                                                       << std::endl
@@ -226,7 +224,7 @@ int vectester(const PairScalars& example, const std::string& testname)
         if( dist > tol )
         {
          std::cout << std::scientific << std::setprecision(16)
-                   << "Error: Mismatch in bin values."                                                                            << std::endl
+                   << "Error: Mismatch in bin values for " << testname                                                      << std::endl
                    << "case ("            << bin_custom_x[il][2*tuple + 1]   << ";"   << bin_custom_x[il+1][2*tuple + 1]   << ")" << std::endl 
                    << "bin = "            << bin_custom_y[il][2*tuple + 1]                                                        << std::endl
                    << "bin_exact = "      << exact_sol_y[il][2*tuple + 1]                                                         << std::endl
@@ -255,6 +253,7 @@ int main()
     vectester (std::valarray<double>(2*ANTIOCH_N_TUPLES), "valarray<double>");
   returnval = returnval ||
     vectester (std::valarray<long double>(2*ANTIOCH_N_TUPLES), "valarray<ld>");
+/*
 #ifdef ANTIOCH_HAVE_EIGEN
   returnval = returnval ||
     vectester (Eigen::Array<float, 2*ANTIOCH_N_TUPLES, 1>(), "Eigen::ArrayXf");
@@ -282,7 +281,7 @@ int main()
     returnval = returnval ||
       vectester (vex::vector<double> (ctx_d, 2*ANTIOCH_N_TUPLES), "vex::vector<double>");
 #endif
-
+*/
 #ifdef ANTIOCH_HAVE_GRVY
   gt.Finalize();
   gt.Summarize();

--- a/test/threebody_process_unit.C
+++ b/test/threebody_process_unit.C
@@ -69,6 +69,9 @@ int tester()
 
   for(Scalar T = 300.1; T <= 2500.1; T += 10.)
   {
+
+    const Antioch::KineticsConditions<Scalar> conditions(T);
+
     for(unsigned int ikinmod = 0; ikinmod < 6; ikinmod++)
     {
 
@@ -161,12 +164,12 @@ int tester()
     {
         TB_reaction->set_efficiency("",i,species_eff[i]);
     }
-    Scalar rate1 = TB_reaction->compute_forward_rate_coefficient(mol_densities,T);
+    Scalar rate1 = TB_reaction->compute_forward_rate_coefficient(mol_densities,conditions);
     Scalar rate;
     Scalar drate_dT;
     std::vector<Scalar> drate_dx;
     drate_dx.resize(n_species);
-    TB_reaction->compute_forward_rate_coefficient_and_derivatives(mol_densities,T,rate,drate_dT,drate_dx);
+    TB_reaction->compute_forward_rate_coefficient_and_derivatives(mol_densities,conditions,rate,drate_dT,drate_dx);
 
 
     for(unsigned int i = 0; i < n_species; i++)

--- a/test/troe_falloff_unit.C
+++ b/test/troe_falloff_unit.C
@@ -72,6 +72,9 @@ int tester()
 
   for(Scalar T = 300.1; T <= 2500.1; T += 10.)
   {
+
+    const Antioch::KineticsConditions<Scalar> conditions(T);
+
     for(unsigned int ikinmod = 0; ikinmod < 6; ikinmod++)
     {
 
@@ -198,12 +201,12 @@ int tester()
     fall_reaction->F().set_alpha(alpha);
     fall_reaction->F().set_T1(T1);
     fall_reaction->F().set_T3(T3);
-    Scalar rate1 = fall_reaction->compute_forward_rate_coefficient(mol_densities,T);
+    Scalar rate1 = fall_reaction->compute_forward_rate_coefficient(mol_densities,conditions);
     Scalar rate;
     Scalar drate_dT;
     std::vector<Scalar> drate_dx;
     drate_dx.resize(n_species);
-    fall_reaction->compute_forward_rate_coefficient_and_derivatives(mol_densities,T,rate,drate_dT,drate_dx);
+    fall_reaction->compute_forward_rate_coefficient_and_derivatives(mol_densities,conditions,rate,drate_dT,drate_dx);
 
     for(unsigned int i = 0; i < n_species; i++)
     {


### PR DESCRIPTION
This is the branch that proposes a new API to deal with differences in chemical conditions and solves the thread safety problem (issue #58), right now only temperature and particle flux(es) are managed, generalization to multi-temperature, catalysis, any other stuff is easy by design.

It's quite big but there's (not so?) much to it.  

The global view is that instead of passing down a _const StateType & T_ from _KineticsEvaluator_ to the kinetics models (Arrhenius, Kooij and consorts), it passes down a _KineticsConditions_ object, which provides to the kinetics rate the right conditions (temperature or particle flux), the fork being made at the _KineticsType_ level, the base object to the rate constant calculators.
This _KineticsConditions_ object stores pointers to the conditions, either provided by the user himself
```
ChosenScalarType T = chosen_value_of_temperature;
ParticleFlux<ChosenVectorType> pf(wavelengths,irradiance);

... stuff to know what is the index of the photo reaction ...

KineticsConditions<ChosenScalarType,ChosenVectorType> kin_cond(T);
kin_cond.add_particle_flux(pf,index_of_concerned_photo_reaction);
```
or automatically generated by the _KineticsEvaluator_ to ensure backward compatibility.  I've found a not too expensive way: it either copies a reference or initializes the _KineticsConditions_ object.  Thus the changes in the _kinetics_evaluator.h_ file.
the meta funny structure _constructor_or_reference_ does very exactly what its name implies: if the two templates arguments are the same, it sends back a reference to the type, if not it sends back the type:
```
template<typename T1, typename T2>
struct constructor_or_reference
{
   typedef T1 type;
};

template <typename T>
struct constructor_or_reference<T,T>
 {
   typedef T & type;
 };
```

The biggest part of the changes are the photochemistry handling, in particular the rebinning phase.  Things to be aware are the new utilities functions _conjunction_,  _disjunction_ and _eval_index_, I expect them to be slow for anything other than Eigen, I haven't found a proper method for VexCl and metaphysicL (maybe I haven't been looking hard enough, I'm not sure).

This rebinning part is fully vectorized, sadly slow and I still consider as an almost bug that it recomputes the rate constant whatever happens, even if it does not change.  Good news is I have a few ideas playing with the _KineticsConditions_, though it needs better testing.

As photochemistry is not really essential right now, I think it's ok to proceed.