### PR TITLE
Kin reset

### DIFF
--- a/src/kinetics/include/antioch/arrhenius_rate.h
+++ b/src/kinetics/include/antioch/arrhenius_rate.h
@@ -32,6 +32,7 @@
 #define ANTIOCH_ARRHENIUS_RATE_H
 
 //Antioch
+#include "antioch/antioch_asserts.h"
 #include "antioch/cmath_shims.h"
 #include "antioch/kinetics_type.h"
 #include "antioch/physical_constants.h"
@@ -77,6 +78,19 @@ namespace Antioch
     void set_Cf(     const CoeffType Cf );
     void set_Ea(     const CoeffType Ea );
     void set_rscale( const CoeffType rscale );
+
+    /*! reset the coeffs
+     *
+     * Two ways of modifying your rate:
+     *   - you change totally the rate, thus you 
+     *        require exactly three parameters, the order
+     *        assumed is Cf, Ea, rscale 
+     *   - you just change the value, thus rscale is not
+     *        modified. You require exactly two parameters,
+     *        the order assumed is Cf, Ea
+     */
+    template <typename VectorCoeffType>
+    void reset_coefs(const VectorCoeffType & coefficients);
 
     CoeffType Cf()     const;
     CoeffType Ea()     const;
@@ -161,6 +175,18 @@ namespace Antioch
     _rscale = rscale;
     _Ea = _raw_Ea / _rscale;
     return;
+  }
+
+  template<typename CoeffType>
+  template <typename VectorCoeffType>
+  inline
+  void ArrheniusRate<CoeffType>::reset_coefs(const VectorCoeffType & coefficients)
+  {
+     antioch_assert_greater(coefficients.size(),1);
+     antioch_assert_less(coefficients.size(),4);
+     if(coefficients.size() == 3)this->set_rscale(coefficients[2]);
+     this->set_Cf(coefficients[0]);
+     this->set_Ea(coefficients[1]);
   }
 
   template<typename CoeffType>

--- a/src/kinetics/include/antioch/berthelot_rate.h
+++ b/src/kinetics/include/antioch/berthelot_rate.h
@@ -74,7 +74,7 @@ namespace Antioch
     template <typename VectorCoeffType>
     void reset_coefs(const VectorCoeffType & coefficients);
 
-    // TODO: delete this method, why does it exist?
+    // \todo delete this method, why does it exist?
     void scale_D( const CoeffType scale );
 
     CoeffType Cf() const;

--- a/src/kinetics/include/antioch/berthelot_rate.h
+++ b/src/kinetics/include/antioch/berthelot_rate.h
@@ -27,6 +27,7 @@
 #define ANTIOCH_BERTHELOT_RATE_H
 
 //Antioch
+#include "antioch/antioch_asserts.h"
 #include "antioch/kinetics_type.h"
 #include "antioch/cmath_shims.h"
 
@@ -66,6 +67,14 @@ namespace Antioch
     void set_Cf( const CoeffType Cf );
     void set_D( const CoeffType D );
 
+    /*! reset the coeffs
+     *
+     * You require exactly two parameters, the order assumed is Cf, D
+     */
+    template <typename VectorCoeffType>
+    void reset_coefs(const VectorCoeffType & coefficients);
+
+    // TODO: delete this method, why does it exist?
     void scale_D( const CoeffType scale );
 
     CoeffType Cf() const;
@@ -137,6 +146,16 @@ namespace Antioch
   {
     _D = D;
     return;
+  }
+
+  template<typename CoeffType>
+  template <typename VectorCoeffType>
+  inline
+  void BerthelotRate<CoeffType>::reset_coefs(const VectorCoeffType & coefficients)
+  {
+     antioch_assert_equal_to(coefficients.size(),2);
+     this->set_Cf(coefficients[0]);
+     this->set_D(coefficients[1]);
   }
 
   template<typename CoeffType>

--- a/src/kinetics/include/antioch/berthelothercourtessen_rate.h
+++ b/src/kinetics/include/antioch/berthelothercourtessen_rate.h
@@ -27,6 +27,7 @@
 #define ANTIOCH_BERTHELOT_HERCOURT_ESSEN_RATE_H
 
 //Antioch
+#include "antioch/antioch_asserts.h"
 #include "antioch/kinetics_type.h"
 #include "antioch/cmath_shims.h"
 
@@ -72,6 +73,19 @@ namespace Antioch
     void set_eta( const CoeffType eta );
     void set_D(   const CoeffType D );
     void set_Tref(const CoeffType Tref );
+
+    /*! reset the coeffs
+     *
+     * Two ways of modifying your rate:
+     *   - you change totally the rate, thus you 
+     *        require exactly four parameters, the order
+     *        assumed is Cf, eta, D, Tref
+     *   - you just change the value, thus Tref is not
+     *        modified. You require exactly three parameters,
+     *        the order assumed is Cf, eta, D
+     */
+    template <typename VectorCoeffType>
+    void reset_coefs(const VectorCoeffType & coefficients);
 
     CoeffType Cf()   const;
     CoeffType eta()  const;
@@ -143,7 +157,6 @@ namespace Antioch
   inline
   void BerthelotHercourtEssenRate<CoeffType>::set_Cf( const CoeffType Cf )
   {
-    using std::pow;
     _raw_Cf = Cf;
     this->compute_cf();
     return;
@@ -153,7 +166,6 @@ namespace Antioch
   inline
   void BerthelotHercourtEssenRate<CoeffType>::set_Tref( const CoeffType Tref )
   {
-    using std::pow;
     _Tref = Tref;
     this->compute_cf();
     return;
@@ -164,6 +176,7 @@ namespace Antioch
   void BerthelotHercourtEssenRate<CoeffType>::set_eta( const CoeffType eta )
   {
     _eta = eta;
+    this->compute_cf();
     return;
   }
 
@@ -173,6 +186,20 @@ namespace Antioch
   {
     _D = D;
     return;
+  }
+
+  template<typename CoeffType>
+  template <typename VectorCoeffType>
+  inline
+  void BerthelotHercourtEssenRate<CoeffType>::reset_coefs(const VectorCoeffType & coefficients)
+  {
+    antioch_assert_greater(coefficients.size(),2);
+    antioch_assert_less(coefficients.size(),5);
+
+    if(coefficients.size() == 4)this->set_Tref(coefficients[3]);
+    this->set_Cf(coefficients[0]);
+    this->set_eta(coefficients[1]);
+    this->set_D(coefficients[2]);
   }
 
   template<typename CoeffType>
@@ -211,7 +238,7 @@ namespace Antioch
   inline
   void BerthelotHercourtEssenRate<CoeffType>::compute_cf()
   {
-    _Cf = _raw_Cf * pow(KineticsModel::Tref<CoeffType>()/_Tref,_eta);
+    _Cf = _raw_Cf * ant_pow(KineticsModel::Tref<CoeffType>()/_Tref,_eta);
     return;
   }
 

--- a/src/kinetics/include/antioch/constant_rate.h
+++ b/src/kinetics/include/antioch/constant_rate.h
@@ -27,6 +27,7 @@
 #define ANTIOCH_CONSTANT_RATE_H
 
 //Antioch
+#include "antioch/antioch_asserts.h"
 #include "antioch/kinetics_type.h"
 
 // C++
@@ -63,6 +64,13 @@ namespace Antioch
     ~ConstantRate();
     
     void set_Cf(  const CoeffType Cf );
+
+    /*! reset the coeffs
+     *
+     * You require exactly one parameter
+     */
+    template <typename VectorCoeffType>
+    void reset_coefs(const VectorCoeffType & coefficients);
 
     CoeffType Cf()   const;
 
@@ -124,6 +132,16 @@ namespace Antioch
     _Cf = Cf;
 
     return;
+  }
+
+  template<typename CoeffType>
+  template <typename VectorCoeffType>
+  inline
+  void ConstantRate<CoeffType>::reset_coefs(const VectorCoeffType & coefficients)
+  {
+     antioch_assert_equal_to(coefficients.size(),1);
+
+     this->set_Cf(coefficients[0]);
   }
 
   template<typename CoeffType>

--- a/src/kinetics/include/antioch/hercourtessen_rate.h
+++ b/src/kinetics/include/antioch/hercourtessen_rate.h
@@ -27,6 +27,7 @@
 #define ANTIOCH_HERCOURT_ESSEN_RATE_H
 
 //Antioch
+#include "antioch/antioch_asserts.h"
 #include "antioch/kinetics_type.h"
 #include "antioch/cmath_shims.h"
 
@@ -70,6 +71,19 @@ namespace Antioch
     void set_Cf(  const CoeffType Cf );
     void set_eta( const CoeffType eta );
     void set_Tref(const CoeffType Tref );
+
+    /*! reset the coeffs
+     *
+     * Two ways of modifying your rate:
+     *   - you change totally the rate, thus you 
+     *        require exactly three parameters, the order
+     *        assumed is Cf, eta, Tref
+     *   - you just change the value, thus Tref is not
+     *        modified. You require exactly two parameters,
+     *        the order assumed is Cf, eta
+     */
+    template <typename VectorCoeffType>
+    void reset_coefs(const VectorCoeffType & coefficients);
 
     CoeffType Cf()   const;
     CoeffType eta()  const;
@@ -150,6 +164,7 @@ namespace Antioch
   void HercourtEssenRate<CoeffType>::set_eta( const CoeffType eta )
   {
     _eta = eta;
+    this->compute_cf();
     return;
   }
 
@@ -161,6 +176,18 @@ namespace Antioch
     this->compute_cf();
 
     return;
+  }
+
+  template<typename CoeffType>
+  template <typename VectorCoeffType>
+  inline
+  void HercourtEssenRate<CoeffType>::reset_coefs(const VectorCoeffType & coefficients)
+  {
+      antioch_assert_greater(coefficients.size(),1);
+      antioch_assert_less(coefficients.size(),4);
+      if(coefficients.size() == 3)this->set_Tref(coefficients[2]);
+      this->set_Cf(coefficients[0]);
+      this->set_eta(coefficients[1]);
   }
 
   template<typename CoeffType>
@@ -194,7 +221,7 @@ namespace Antioch
   inline
   void HercourtEssenRate<CoeffType>::compute_cf()
   {
-    _Cf = _raw_Cf * pow(KineticsModel::Tref<CoeffType>()/_Tref,_eta);
+    _Cf = _raw_Cf * ant_pow(KineticsModel::Tref<CoeffType>()/_Tref,_eta);
 
     return;
   }

--- a/src/kinetics/include/antioch/kinetics_parsing.h
+++ b/src/kinetics/include/antioch/kinetics_parsing.h
@@ -48,6 +48,8 @@ namespace Antioch
   KineticsType<CoeffType, VectorCoeffType>* build_rate( const VectorCoeffType &data,
                                                         const KineticsModel::KineticsModel &kin );
 
+  template<typename CoeffType, typename VectorCoeffType, typename VectorType>
+  void reset_rate( KineticsType<CoeffType,VectorCoeffType> & kin, const VectorType & coefs);
 
   //! We take here the parameters as:
   //  - \f$A\f$, \f$\beta\f$, \f$E_a\f$, \f$D\f$, \f$\mathrm{T_{ref}}\f$, \f$\mathrm{scale}\f$.
@@ -138,6 +140,69 @@ namespace Antioch
 
     return rate;
   }
+
+  template<typename CoeffType, typename VectorCoeffType, typename VectorType>
+  void reset_rate( KineticsType<CoeffType,VectorCoeffType> & kin, const VectorType & coefs)
+  {
+
+    switch(kin.type())
+      {
+      case(KineticsModel::CONSTANT):
+        {
+          static_cast<ConstantRate<CoeffType>*>(&kin)->reset_coefs(coefs);
+        }
+        break;
+
+      case(KineticsModel::HERCOURT_ESSEN):
+        {
+          static_cast< HercourtEssenRate<CoeffType>*>(&kin)->reset_coefs(coefs);
+        }
+        break;
+
+      case(KineticsModel::BERTHELOT):
+        {
+          static_cast< BerthelotRate<CoeffType>*>(&kin)->reset_coefs(coefs);
+        }
+        break;
+
+      case(KineticsModel::ARRHENIUS):
+        {
+          static_cast< ArrheniusRate<CoeffType>*>(&kin)->reset_coefs(coefs);
+        }
+        break;
+
+      case(KineticsModel::BHE):
+        {
+          static_cast< BerthelotHercourtEssenRate<CoeffType>*>(&kin)->reset_coefs(coefs);
+        }
+        break;
+
+      case(KineticsModel::KOOIJ):
+        {
+          static_cast< KooijRate<CoeffType>*>(&kin)->reset_coefs(coefs);
+        }
+        break;
+
+      case(KineticsModel::VANTHOFF):
+        {
+          static_cast< VantHoffRate<CoeffType>*>(&kin)->reset_coefs(coefs);
+        }
+        break;
+
+      case(KineticsModel::PHOTOCHEM):
+        {
+          static_cast<PhotochemicalRate<CoeffType,VectorCoeffType>*>(&kin)->reset_coefs(coefs);
+        }
+        break;
+
+      default:
+        {
+          antioch_error();
+        }
+
+      } // switch(kin.type())
+  }
+
 
 } // end namespace Antioch
 

--- a/src/kinetics/include/antioch/kinetics_type.h
+++ b/src/kinetics/include/antioch/kinetics_type.h
@@ -83,16 +83,15 @@ namespace Antioch{
     virtual ~KineticsType();
 
     //!
+    KineticsModel::KineticsModel type() const;
+
+    //!
     template <typename StateType>
     StateType operator()(const StateType& T) const;
 
     //!
     template <typename StateType>
     StateType derivative( const StateType& T ) const;
-
-    //! reset the coefficients, not necessarily a VectorCoeffType
-    template <typename VectorType>
-    void reset_coefs(const VectorType & coefficients);
 
     //!
     template <typename StateType>
@@ -131,6 +130,13 @@ namespace Antioch{
     my_type(type)
   {
     return;
+  }
+
+  template <typename CoeffType, typename VectorCoeffType>
+  inline
+  KineticsModel::KineticsModel KineticsType<CoeffType,VectorCoeffType>::type() const
+  {
+    return my_type;
   }
 
   template <typename CoeffType, typename VectorCoeffType>
@@ -354,69 +360,6 @@ namespace Antioch{
       } // switch(my_type)
     
     return;
-  }
-
-  template <typename CoeffType, typename VectorCoeffType>
-  template <typename VectorType>
-  inline
-  void KineticsType<CoeffType,VectorCoeffType>::reset_coefs(const VectorType& coeffs)
-  {
-    switch(my_type) 
-      {
-      case(KineticsModel::CONSTANT):
-        {
-          return (static_cast<const ConstantRate<CoeffType>*>(this))->reset_coefs(coeffs);
-        }
-        break;
-
-      case(KineticsModel::HERCOURT_ESSEN):
-        {
-          return (static_cast<const HercourtEssenRate<CoeffType>*>(this))->reset_coefs(coeffs);
-        }
-        break;
-
-      case(KineticsModel::BERTHELOT):
-        {
-          return (static_cast<const BerthelotRate<CoeffType>*>(this))->reset_coefs(coeffs);
-        }
-        break;
-
-      case(KineticsModel::ARRHENIUS):
-        {
-          return (static_cast<const ArrheniusRate<CoeffType>*>(this))->reset_coefs(coeffs);
-        }
-        break;
-
-      case(KineticsModel::BHE):
-        {
-          return (static_cast<const BerthelotHercourtEssenRate<CoeffType>*>(this))->reset_coefs(coeffs);
-        }
-        break;
-
-      case(KineticsModel::KOOIJ):
-        {
-          return (static_cast<const KooijRate<CoeffType>*>(this))->reset_coefs(coeffs);
-        }
-        break;
-
-      case(KineticsModel::VANTHOFF):
-        {
-          return (static_cast<const VantHoffRate<CoeffType>*>(this))->reset_coefs(coeffs);
-        }
-        break;
-
-      case(KineticsModel::PHOTOCHEM):
-        {
-          return (static_cast<const PhotochemicalRate<CoeffType,VectorCoeffType>*>(this))->reset_coefs(coeffs);
-        }
-        break;
-
-      default:
-        {
-          antioch_error();
-        }
-
-      } // switch(my_type)
   }
 
 } // end namespace Antioch

--- a/src/kinetics/include/antioch/kinetics_type.h
+++ b/src/kinetics/include/antioch/kinetics_type.h
@@ -90,6 +90,10 @@ namespace Antioch{
     template <typename StateType>
     StateType derivative( const StateType& T ) const;
 
+    //! reset the coefficients, not necessarily a VectorCoeffType
+    template <typename VectorType>
+    void reset_coefs(const VectorType & coefficients);
+
     //!
     template <typename StateType>
     void compute_rate_and_derivative(const StateType& T, StateType& rate, StateType& drate_dT) const;
@@ -350,6 +354,69 @@ namespace Antioch{
       } // switch(my_type)
     
     return;
+  }
+
+  template <typename CoeffType, typename VectorCoeffType>
+  template <typename VectorType>
+  inline
+  void KineticsType<CoeffType,VectorCoeffType>::reset_coefs(const VectorType& coeffs)
+  {
+    switch(my_type) 
+      {
+      case(KineticsModel::CONSTANT):
+        {
+          return (static_cast<const ConstantRate<CoeffType>*>(this))->reset_coefs(coeffs);
+        }
+        break;
+
+      case(KineticsModel::HERCOURT_ESSEN):
+        {
+          return (static_cast<const HercourtEssenRate<CoeffType>*>(this))->reset_coefs(coeffs);
+        }
+        break;
+
+      case(KineticsModel::BERTHELOT):
+        {
+          return (static_cast<const BerthelotRate<CoeffType>*>(this))->reset_coefs(coeffs);
+        }
+        break;
+
+      case(KineticsModel::ARRHENIUS):
+        {
+          return (static_cast<const ArrheniusRate<CoeffType>*>(this))->reset_coefs(coeffs);
+        }
+        break;
+
+      case(KineticsModel::BHE):
+        {
+          return (static_cast<const BerthelotHercourtEssenRate<CoeffType>*>(this))->reset_coefs(coeffs);
+        }
+        break;
+
+      case(KineticsModel::KOOIJ):
+        {
+          return (static_cast<const KooijRate<CoeffType>*>(this))->reset_coefs(coeffs);
+        }
+        break;
+
+      case(KineticsModel::VANTHOFF):
+        {
+          return (static_cast<const VantHoffRate<CoeffType>*>(this))->reset_coefs(coeffs);
+        }
+        break;
+
+      case(KineticsModel::PHOTOCHEM):
+        {
+          return (static_cast<const PhotochemicalRate<CoeffType,VectorCoeffType>*>(this))->reset_coefs(coeffs);
+        }
+        break;
+
+      default:
+        {
+          antioch_error();
+        }
+
+      } // switch(my_type)
   }
 
 } // end namespace Antioch

--- a/src/kinetics/include/antioch/photochemical_rate.h
+++ b/src/kinetics/include/antioch/photochemical_rate.h
@@ -27,6 +27,7 @@
 #define ANTIOCH_PHOTOCHEMICAL_RATE_H
 
 //Antioch
+#include "antioch/antioch_asserts.h"
 #include "antioch/metaprogramming.h"
 #include "antioch/sigma_bin_converter.h"
 #include "antioch/kinetics_type.h"
@@ -59,6 +60,13 @@ namespace Antioch{
 
        //!
        void set_lambda_grid(const VectorCoeffType &l);
+
+       /*! reset the coefficients
+        *
+        *  Contrary to the other rate models, no choice here in the VectorCoeffType type.
+        *  The order assumed is lambda, cross-section
+        */
+       void reset_coefs(const VectorCoeffType & coefficients);
 
        //! calculate _k for a given photon flux
        template<typename VectorStateType>
@@ -131,6 +139,25 @@ namespace Antioch{
   void PhotochemicalRate<CoeffType,VectorCoeffType>::set_lambda_grid(const VectorCoeffType &l)
   {
      _lambda_grid = l;
+  }
+
+  template<typename CoeffType, typename VectorCoeffType>
+  inline
+  void PhotochemicalRate<CoeffType,VectorCoeffType>::reset_coefs(const VectorCoeffType & coefficients)
+  {
+      // we require the two vectors being the same size
+      antioch_assert_equal_to(coefficients.size()%2,0);
+
+      const unsigned int subsize(coefficients.size()/2);
+      VectorCoeffType l(subsize);
+      VectorCoeffType cs(subsize);
+      for(unsigned int il = 0; il < subsize; il++)
+      {
+          l[il] = coefficients[il];
+          cs[il] = coefficients[il + subsize];
+      }
+      this->set_lambda_grid(l);
+      this->set_cross_section(cs);
   }
 
   template<typename CoeffType, typename VectorCoeffType>

--- a/src/kinetics/include/antioch/reaction.h
+++ b/src/kinetics/include/antioch/reaction.h
@@ -182,6 +182,12 @@ namespace Antioch
                       const unsigned int stoichiometric_coeff);
 
     //!
+    void clear_reactant();
+
+    //!
+    void clear_product();
+
+    //!
     void set_efficiency( const std::string &,
                          const unsigned int s,
                          const CoeffType efficiency);
@@ -252,6 +258,13 @@ namespace Antioch
 
     //! Return writeable reference to the forward rate object
     KineticsType<CoeffType,VectorCoeffType>& forward_rate(unsigned int ir = 0);
+
+    //! Return writeable reference to the falloff object, test type
+    //
+    // just a wrapper around the FalloffType & F() method
+    // of the FalloffReaction object, test consistency of type
+    template <typename FalloffType>
+    FalloffType & falloff();
 
     //! Add a forward rate object
     void add_forward_rate(KineticsType<CoeffType,VectorCoeffType> *rate);
@@ -494,6 +507,24 @@ namespace Antioch
     _product_ids.push_back(p_id);
     _product_stoichiometry.push_back(stoichiometric_coeff);
     return;
+  }
+
+  template<typename CoeffType, typename VectorCoeffType>
+  inline
+  void Reaction<CoeffType,VectorCoeffType>::clear_reactant()
+  {
+    _reactant_names.clear();
+    _reactant_ids.clear();
+    _reactant_stoichiometry.clear();
+  }
+
+  template<typename CoeffType, typename VectorCoeffType>
+  inline
+  void Reaction<CoeffType,VectorCoeffType>::clear_product()
+  {
+    _product_names.clear();
+    _product_ids.clear();
+    _product_stoichiometry.clear();
   }
 
   template<typename CoeffType, typename VectorCoeffType>
@@ -1073,6 +1104,36 @@ namespace Antioch
 
     return;
   }
+
+  template<typename CoeffType, typename VectorCoeffType>
+  template <typename FalloffType>
+  inline
+  FalloffType & Reaction<CoeffType,VectorCoeffType>::falloff()
+  {
+      switch(_type)
+      {
+        case(ReactionType::LINDEMANN_FALLOFF):
+        {
+          (static_cast<const FalloffReaction<CoeffType,LindemannFalloff<CoeffType> >*>(this))->F();
+        }
+        break;
+
+        case(ReactionType::TROE_FALLOFF):
+        {
+          (static_cast<const FalloffReaction<CoeffType,LindemannFalloff<CoeffType> >*>(this))->F();
+        }
+        break;
+
+        default:
+        {
+          std::cerr << "You are trying to retrieve a Falloff object in a reaction that is not a falloff.\n"
+                    << "The reaction is " << *this << std::endl;
+          antioch_error();
+        }
+        
+      }
+  }
+  
     
 } // namespace Antioch
 

--- a/src/kinetics/include/antioch/reaction_set.h
+++ b/src/kinetics/include/antioch/reaction_set.h
@@ -84,6 +84,9 @@ namespace Antioch
     //! \returns a constant reference to reaction \p r.
     const Reaction<CoeffType>& reaction(const unsigned int r) const;
 
+    //! \returns a writeable reference to reaction \p r.
+    Reaction<CoeffType>& reaction(const unsigned int r);
+
     const ChemicalMixture<CoeffType>& chemical_mixture() const;
 
     //! Compute the rates of progress for each reaction
@@ -183,6 +186,14 @@ namespace Antioch
   template<typename CoeffType>
   inline
   const Reaction<CoeffType>& ReactionSet<CoeffType>::reaction(const unsigned int r) const      
+  {
+    antioch_assert_less(r, this->n_reactions());
+    return *_reactions[r];
+  }
+
+  template<typename CoeffType>
+  inline
+  Reaction<CoeffType>& ReactionSet<CoeffType>::reaction(const unsigned int r)
   {
     antioch_assert_less(r, this->n_reactions());
     return *_reactions[r];

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -48,6 +48,7 @@ check_PROGRAMS += parsing_xml
 check_PROGRAMS += units_unit
 check_PROGRAMS += kinetics_reactive_scheme_unit
 check_PROGRAMS += sigma_bin_converter_unit
+check_PROGRAMS += kinetics_settings_unit
 
 if ANTIOCH_ENABLE_EIGEN
 check_PROGRAMS += stat_mech_thermo_unit_eigen
@@ -116,6 +117,7 @@ parsing_xml_SOURCES = parsing_xml.C
 units_unit_SOURCES = units_unit.C
 kinetics_reactive_scheme_unit_SOURCES = kinetics_reactive_scheme_unit.C
 sigma_bin_converter_unit_SOURCES = sigma_bin_converter_unit.C
+kinetics_settings_unit_SOURCES = kinetics_settings_unit.C
 
 if ANTIOCH_ENABLE_EIGEN
 stat_mech_thermo_unit_eigen_SOURCES = stat_mech_thermo_unit_eigen.C
@@ -170,6 +172,7 @@ TESTS += parsing_xml.sh
 TESTS += units_unit
 TESTS += kinetics_reactive_scheme_unit.sh
 TESTS += sigma_bin_converter_unit.sh
+TESTS += kinetics_settings_unit
 
 if ANTIOCH_ENABLE_EIGEN
 TESTS += stat_mech_thermo_unit_eigen

--- a/test/berthelot_rate_unit.C
+++ b/test/berthelot_rate_unit.C
@@ -30,20 +30,15 @@
 
 // C++
 #include <limits>
+#include <vector>
 // Antioch
 #include "antioch/berthelot_rate.h"
 
 template <typename Scalar>
-int tester()
+int test_values(const Scalar & Cf, const Scalar & D, const Antioch::BerthelotRate<Scalar> & berthelot_rate)
 {
   using std::abs;
   using std::exp;
-
-  const Scalar Cf = 1.4;
-  const Scalar D  = -5.0;
-
-  Antioch::BerthelotRate<Scalar> berthelot_rate(Cf,D);
-
   int return_flag = 0;
   const Scalar tol = std::numeric_limits<Scalar>::epsilon() * 100;
 
@@ -101,6 +96,33 @@ int tester()
       }
     if(return_flag)break;
   }
+  return return_flag;
+}
+
+template <typename Scalar>
+int tester()
+{
+  Scalar Cf = 1.4;
+  Scalar D  = -5.0;
+
+  Antioch::BerthelotRate<Scalar> berthelot_rate(Cf,D);
+
+  int return_flag = test_values(Cf,D,berthelot_rate);
+
+  Cf = 1e-7;
+  D = 1e-3;
+  berthelot_rate.set_Cf(Cf);
+  berthelot_rate.set_D(D);
+  return_flag = test_values(Cf,D,berthelot_rate) || return_flag;
+
+  
+  Cf = 2.1e-11;
+  D = -1.2;
+  std::vector<Scalar> values(2);
+  values[0] = Cf;
+  values[1] = D;
+  berthelot_rate.reset_coefs(values);
+  return_flag = test_values(Cf,D,berthelot_rate) || return_flag;
 
   return return_flag;
 }

--- a/test/berthelothercourtessen_rate_unit.C
+++ b/test/berthelothercourtessen_rate_unit.C
@@ -30,29 +30,24 @@
 
 // C++
 #include <limits>
+#include <vector>
 // Antioch
 #include "antioch/berthelothercourtessen_rate.h"
 
+
 template <typename Scalar>
-int tester()
+int test_values(const Scalar & Cf, const Scalar & eta, const Scalar & D, const Scalar & Tref, const Antioch::BerthelotHercourtEssenRate<Scalar> & berthelothercourtessen_rate)
 {
   using std::abs;
   using std::exp;
   using std::pow;
-
-  const Scalar Cf  = 1.4;
-  const Scalar eta = 1.2;
-  const Scalar D   = -5.0;
-
-  Antioch::BerthelotHercourtEssenRate<Scalar> berthelothercourtessen_rate(Cf,eta,D);
-
   int return_flag = 0;
   const Scalar tol = std::numeric_limits<Scalar>::epsilon() * 100;
 
-  for(Scalar T = 300.1; T <= 2500.1; T += 10.)
+  for(Scalar T = 300.1L; T <= 2500.1L; T += 10.L)
   {
-    const Scalar rate_exact = Cf*pow(T,eta)*exp(D*T);
-    const Scalar derive_exact = Cf * pow(T,eta) * exp(D*T) * (D + eta/T);
+    const Scalar rate_exact = Cf*pow(T/Tref,eta)*exp(D*T);
+    const Scalar derive_exact = Cf * pow(T/Tref,eta) * exp(D*T) * (D + eta/T);
 
     Scalar rate1 = berthelothercourtessen_rate(T);
     Scalar deriveRate1 = berthelothercourtessen_rate.derivative(T);
@@ -104,6 +99,58 @@ int tester()
 
     if(return_flag)break;
   }
+  return return_flag;
+
+}
+
+
+template <typename Scalar>
+int tester()
+{
+  Scalar Cf  = 1.4L;
+  Scalar eta = 1.2L;
+  Scalar D   = -5.0L;
+  Scalar Tref   = 1.0L;
+
+  Antioch::BerthelotHercourtEssenRate<Scalar> berthelothercourtessen_rate(Cf,eta,D);
+
+  int return_flag = test_values(Cf,eta,D,Tref,berthelothercourtessen_rate);
+
+  Cf  = 1e-7L;
+  eta = 0.6L;
+  D   = 1e-3L;
+  Tref   = 298.0L;
+  berthelothercourtessen_rate.set_Cf(Cf);
+  berthelothercourtessen_rate.set_eta(eta);
+  berthelothercourtessen_rate.set_D(D);
+  berthelothercourtessen_rate.set_Tref(Tref);
+
+  return_flag = test_values(Cf,eta,D,Tref,berthelothercourtessen_rate) || return_flag;
+
+  Cf  = 2.1e-7L;
+  eta = 0.35L;
+  D   = 8.1e-3L;
+  std::vector<Scalar> values(3);
+  values[0] = Cf;
+  values[1] = eta;
+  values[2] = D;
+  berthelothercourtessen_rate.reset_coefs(values);
+
+  return_flag = test_values(Cf,eta,D,Tref,berthelothercourtessen_rate) || return_flag;
+
+  Cf  = 2.1e-11L;
+  eta = -0.35L;
+  D   = -2.1;
+  Tref   = 300.L;
+  values.resize(4);
+  values[0] = Cf;
+  values[1] = eta;
+  values[2] = D;
+  values[3] = Tref;
+  berthelothercourtessen_rate.reset_coefs(values);
+
+  return_flag = test_values(Cf,eta,D,Tref,berthelothercourtessen_rate) || return_flag;
+
 
   return return_flag;
 }

--- a/test/constant_rate_unit.C
+++ b/test/constant_rate_unit.C
@@ -30,23 +30,18 @@
 
 // C++
 #include <limits>
+#include <vector>
 // Antioch
 #include "antioch/constant_rate.h"
 
 template <typename Scalar>
-int tester()
+int test_values(const Scalar & Cf, const Antioch::ConstantRate<Scalar> & constant_rate)
 {
-  using std::abs;
-
-  const Scalar Cf = 1.4;
-
-  Antioch::ConstantRate<Scalar> constant_rate(Cf);
-
-  int return_flag = 0;
   const Scalar tol = std::numeric_limits<Scalar>::epsilon() * 100;
-
+  int return_flag = 0;
   for(Scalar T = 300.1; T <= 2500.1; T += 10.)
   {
+
     const Scalar rate_exact = Cf;
     const Scalar derive_exact = 0.L;
 
@@ -98,8 +93,32 @@ int tester()
         return_flag = 1;
       }
    if(return_flag)break;
-
   }
+  return return_flag;
+}
+
+template <typename Scalar>
+int tester()
+{
+  using std::abs;
+
+  Scalar Cf = 1.4;
+
+  Antioch::ConstantRate<Scalar> constant_rate(Cf);
+
+  int return_flag = 0;
+
+  return_flag = test_values(Cf,constant_rate) || return_flag;
+
+  Cf = 1e-7;
+  constant_rate.set_Cf(Cf);
+  return_flag = test_values(Cf,constant_rate) || return_flag;
+
+  Cf = 2.5e-11;
+  std::vector<Scalar> values(1,Cf);
+  constant_rate.reset_coefs(values);
+  return_flag = test_values(Cf,constant_rate) || return_flag;
+
   return return_flag;
 }
 

--- a/test/hercourtessen_rate_unit.C
+++ b/test/hercourtessen_rate_unit.C
@@ -30,27 +30,22 @@
 
 // C++
 #include <limits>
+#include <vector>
 // Antioch
 #include "antioch/hercourtessen_rate.h"
 
 template <typename Scalar>
-int tester()
+int test_values(const Scalar & Cf, const Scalar & eta, const Scalar & Tref, const Antioch::HercourtEssenRate<Scalar> & hercourtessen_rate)
 {
   using std::abs;
   using std::pow;
-
-  const Scalar Cf = 1.4;
-  const Scalar eta = 1.2;
-
-  Antioch::HercourtEssenRate<Scalar> hercourtessen_rate(Cf,eta);
-
   int return_flag = 0;
   const Scalar tol = std::numeric_limits<Scalar>::epsilon() * 100;
 
-  for(Scalar T = 300.1; T <= 2500.1; T += 10.)
+  for(Scalar T = 300.1L; T <= 2500.1L; T += 10.L)
   {
-    const Scalar rate_exact = Cf*pow(T,eta);
-    const Scalar derive_exact = eta * Cf * pow(T,eta)/T;
+    const Scalar rate_exact = Cf * pow(T/Tref,eta);
+    const Scalar derive_exact = Cf * eta * pow(T/Tref,eta)/T;
 
     Scalar rate1 = hercourtessen_rate(T);
     Scalar deriveRate1 = hercourtessen_rate.derivative(T);
@@ -65,7 +60,10 @@ int tester()
                   << "Error: Mismatch in rate values." << std::endl
                   << "T = " << T << " K" << std::endl
                   << "rate(T) = " << rate1 << std::endl
-                  << "rate_exact = " << rate_exact << std::endl;
+                  << "rate_exact = " << rate_exact << std::endl
+                  << "tol = " << tol << std::endl
+                  << "relative error = " << abs( (rate1 - rate_exact)/rate_exact ) << std::endl
+                  << "object: " << hercourtessen_rate << std::endl;
  
         return_flag = 1;
       }
@@ -75,7 +73,10 @@ int tester()
                   << "Error: Mismatch in rate values." << std::endl
                   << "T = " << T << " K" << std::endl
                   << "rate(T) = " << rate << std::endl
-                  << "rate_exact = " << rate_exact << std::endl;
+                  << "rate_exact = " << rate_exact << std::endl
+                  << "tol = " << tol << std::endl
+                  << "relative error = " << abs( (rate1 - rate_exact)/rate_exact ) << std::endl
+                  << "object: " << hercourtessen_rate << std::endl;
  
         return_flag = 1;
       }
@@ -85,7 +86,10 @@ int tester()
                   << "Error: Mismatch in rate derivative values." << std::endl
                   << "T = " << T << " K" << std::endl
                   << "drate_dT(T) = " << deriveRate1 << std::endl
-                  << "derive_exact = " << derive_exact << std::endl;
+                  << "derive_exact = " << derive_exact << std::endl
+                  << "tol = " << tol << std::endl
+                  << "relative error = " << abs( (rate1 - rate_exact)/rate_exact ) << std::endl
+                  << "object: " << hercourtessen_rate << std::endl;
 
         return_flag = 1;
       }
@@ -95,14 +99,53 @@ int tester()
                   << "Error: Mismatch in rate derivative values." << std::endl
                   << "T = " << T << " K" << std::endl
                   << "drate_dT(T) = " << deriveRate << std::endl
-                  << "derive_exact = " << derive_exact << std::endl;
+                  << "derive_exact = " << derive_exact << std::endl
+                  << "tol = " << tol << std::endl
+                  << "relative error = " << abs( (rate1 - rate_exact)/rate_exact ) << std::endl
+                  << "object: " << hercourtessen_rate << std::endl;
 
         return_flag = 1;
       }
    if(return_flag)break;
-
   }
-//  std::cout << "Hercourt-Essen rate: " << hercourtessen_rate << std::endl;
+  return return_flag;
+}
+
+template <typename Scalar>
+int tester()
+{
+
+  Scalar Cf = 1.4L;
+  Scalar eta = 1.2L;
+  Scalar Tref = 1.L;
+
+  Antioch::HercourtEssenRate<Scalar> hercourtessen_rate(Cf,eta); // default
+
+  int return_flag = test_values(Cf,eta,Tref,hercourtessen_rate);
+  Cf = 1e-7L;
+  eta = 0.7L;
+  Tref = 300.L;
+  hercourtessen_rate.set_Cf(Cf);
+  hercourtessen_rate.set_eta(eta);
+  hercourtessen_rate.set_Tref(Tref);
+  return_flag = test_values(Cf,eta,Tref,hercourtessen_rate) || return_flag;
+
+  Cf = 2.1e-11L;
+  eta = -2.3L;
+  std::vector<Scalar> values(2);
+  values[0] = Cf;
+  values[1] = eta;
+  hercourtessen_rate.reset_coefs(values);
+  return_flag = test_values(Cf,eta,Tref,hercourtessen_rate) || return_flag;
+
+  Tref = 298.L;
+  values.resize(3);
+  values[0] = Cf;
+  values[1] = eta;
+  values[2] = Tref;
+  hercourtessen_rate.reset_coefs(values);
+  return_flag = test_values(Cf,eta,Tref,hercourtessen_rate) || return_flag;
+
   return return_flag;
 }
 

--- a/test/kinetics_settings_unit.C
+++ b/test/kinetics_settings_unit.C
@@ -1,0 +1,234 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// Antioch - A Gas Dynamics Thermochemistry Library
+//
+// Copyright (C) 2014 Paul T. Bauman, Benjamin S. Kirk, Sylvain Plessis,
+//                    Roy H. Stonger
+// Copyright (C) 2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+//
+// $Id: arrhenius_rate_unit.C 38747 2013-04-17 23:26:39Z splessis $
+//
+//--------------------------------------------------------------------------
+//--------------------------------------------------------------------------
+
+// C++
+#include <limits>
+#include <vector>
+// Antioch
+#include "antioch/kinetics_parsing.h"
+//#include "antioch/physical_constants.h"
+//#include "antioch/units.h"
+
+
+
+template <typename Scalar>
+int test_values(const Scalar & Cf, const Scalar & eta, const Scalar & Ea, const Scalar & D, const Scalar & Tref, const Scalar & R, const Antioch::KineticsType<Scalar> & rate_base)
+{
+  using std::abs;
+  using std::exp;
+  using std::pow;
+
+  int return_flag = 0;
+
+  const Scalar tol = std::numeric_limits<Scalar>::epsilon() * 100;
+
+  for(Scalar T = 300.1L; T <= 2500.1L; T += 10.L)
+  {
+  
+    const Scalar rate_exact = Cf*pow(T/Tref,eta)*exp(-Ea/(R*T) + D * T);
+    const Scalar derive_exact = exp(-Ea/(R*T) + D * T) * pow(T/Tref,eta) * Cf * (Ea/(R*T*T) + eta/T + D );
+
+    Scalar rate1 = rate_base(T);
+    Scalar deriveRate1 = rate_base.derivative(T);
+    Scalar rate;
+    Scalar deriveRate;
+
+    rate_base.compute_rate_and_derivative(T,rate,deriveRate);
+
+    if( abs( (rate1 - rate_exact)/rate_exact ) > tol )
+      {
+          std::cout << std::scientific << std::setprecision(16)
+                    << "Error: Mismatch in rate values." << std::endl
+                    << "T = " << T << " K" << std::endl
+                    << "rate(T) = " << rate1 << std::endl
+                    << "rate_exact = " << rate_exact << std::endl
+                    << "on rate " << rate_base << std::endl;
+
+          return_flag = 1;
+      }
+    if( abs( (rate - rate_exact)/rate_exact ) > tol )
+      {
+          std::cout << std::scientific << std::setprecision(16)
+                    << "Error: Mismatch in rate values." << std::endl
+                    << "T = " << T << " K" << std::endl
+                    << "rate(T) = " << rate << std::endl
+                    << "rate_exact = " << rate_exact << std::endl
+                    << "on rate " << rate_base << std::endl;
+
+          return_flag = 1;
+      }
+    if( abs( (deriveRate1 - derive_exact)/derive_exact ) > tol )
+      {
+          std::cout << std::scientific << std::setprecision(16)
+                    << "Error: Mismatch in rate derivative values." << std::endl
+                    << "T = " << T << " K" << std::endl
+                    << "drate_dT(T) = " << deriveRate1 << std::endl
+                    << "derive_exact = " << derive_exact << std::endl
+                    << "on rate " << rate_base << std::endl;
+
+          return_flag = 1;
+     }
+    if( abs( (deriveRate - derive_exact)/derive_exact ) > tol )
+      {
+          std::cout << std::scientific << std::setprecision(16)
+                    << "Error: Mismatch in rate derivative values." << std::endl
+                    << "T = " << T << " K" << std::endl
+                    << "drate_dT(T) = " << deriveRate << std::endl
+                    << "derive_exact = " << derive_exact << std::endl
+                    << "on rate " << rate_base << std::endl;
+
+          return_flag = 1;
+     }
+
+     if(return_flag)break;
+  }
+  return return_flag;
+}
+
+template <typename Scalar>
+int tester()
+{
+
+  const Scalar zero(0.L);
+  Scalar Cf = 1.4L;
+  Scalar eta = 1.2L;
+  Scalar Ea = 298.0L;
+  Scalar D = 0.05L;
+  Scalar Tref = 1.L;
+  Scalar R = 1.L;
+
+/// building only here
+
+   // constant
+  std::vector<Scalar> coeffs(1,Cf); 
+
+  Antioch::KineticsType<Scalar> * kin_base = Antioch::build_rate<Scalar>(coeffs,Antioch::KineticsModel::CONSTANT);
+
+  int return_flag = test_values(Cf,zero,zero,zero,Tref,R,*kin_base);
+
+   // Hercourt-Essen
+  coeffs.resize(3);
+  coeffs[0] = Cf;
+  coeffs[1] = eta;
+  coeffs[2] = Tref;
+
+  delete kin_base;
+  kin_base = Antioch::build_rate<Scalar>(coeffs,Antioch::KineticsModel::HERCOURT_ESSEN);
+  
+  return_flag = test_values(Cf,eta,zero,zero,Tref,R,*kin_base) || return_flag;
+
+   // Arrhenius
+  coeffs.resize(3);
+  coeffs[0] = Cf;
+  coeffs[1] = Ea;
+  coeffs[2] = R;
+
+  delete kin_base;
+  kin_base = Antioch::build_rate<Scalar>(coeffs,Antioch::KineticsModel::ARRHENIUS);
+  
+  return_flag = test_values(Cf,zero,Ea,zero,Tref,R,*kin_base) || return_flag;
+
+   // Berthelot
+  coeffs.resize(2);
+  coeffs[0] = Cf;
+  coeffs[1] = D;
+
+  delete kin_base;
+  kin_base = Antioch::build_rate<Scalar>(coeffs,Antioch::KineticsModel::BERTHELOT);
+  
+  return_flag = test_values(Cf,zero,zero,D,Tref,R,*kin_base) || return_flag;
+
+   // Berthelot Hercourt-Essen
+  coeffs.resize(4);
+  coeffs[0] = Cf;
+  coeffs[1] = eta;
+  coeffs[2] = D;
+  coeffs[3] = Tref;
+
+  delete kin_base;
+  kin_base = Antioch::build_rate<Scalar>(coeffs,Antioch::KineticsModel::BHE);
+  
+  return_flag = test_values(Cf,eta,zero,D,Tref,R,*kin_base) || return_flag;
+
+   // Kooij
+  coeffs.resize(5);
+  coeffs[0] = Cf;
+  coeffs[1] = eta;
+  coeffs[2] = Ea;
+  coeffs[3] = Tref;
+  coeffs[4] = R;
+
+  delete kin_base;
+  kin_base = Antioch::build_rate<Scalar>(coeffs,Antioch::KineticsModel::KOOIJ);
+  
+  return_flag = test_values(Cf,eta,Ea,zero,Tref,R,*kin_base) || return_flag;
+
+   // Van't Hoff
+  coeffs.resize(6);
+  coeffs[0] = Cf;
+  coeffs[1] = eta;
+  coeffs[2] = Ea;
+  coeffs[3] = D;
+  coeffs[4] = Tref;
+  coeffs[5] = R;
+
+  delete kin_base;
+  kin_base = Antioch::build_rate<Scalar>(coeffs,Antioch::KineticsModel::VANTHOFF);
+  
+  return_flag = test_values(Cf,eta,Ea,D,Tref,R,*kin_base) || return_flag;
+
+
+//// reset
+  Scalar Cf_reset = 1e-7L;
+  Scalar eta_reset = 0.8L;
+  Scalar Ea_reset = 36000.L;
+  Scalar D_reset = -5.e-2L;
+  Scalar Tref_reset = 298.;
+  Scalar R_reset = Antioch::Constants::R_universal<Scalar>() * Antioch::Units<Scalar>("cal").get_SI_factor();
+
+  coeffs[0] = Cf_reset;
+  coeffs[1] = eta_reset;
+  coeffs[2] = Ea_reset;
+  coeffs[3] = D_reset;
+  coeffs[4] = Tref_reset;
+  coeffs[5] = R_reset;
+  Antioch::reset_rate(*kin_base,coeffs);
+
+  return_flag = test_values(Cf_reset,eta_reset,Ea_reset,D_reset,Tref_reset,R_reset,*kin_base) || return_flag;
+
+  return return_flag;
+}
+
+int main()
+{
+  return (tester<double>() ||
+          tester<long double>() ||
+          tester<float>());
+}

--- a/test/kooij_rate_unit.C
+++ b/test/kooij_rate_unit.C
@@ -51,7 +51,7 @@ int test_values(const Scalar & Cf, const Scalar & eta, const Scalar & Ea, const 
   {
   
     const Scalar rate_exact = Cf*pow(T/Tref,eta)*exp(-Ea/(R*T));
-    const Scalar derive_exact = exp(-Ea/(R*T)) * pow(T/Tref,eta) * Cf/T * (Ea/(R*T) + eta );
+    const Scalar derive_exact = exp(-Ea/(R*T)) * pow(T/Tref,eta) * Cf * (Ea/(R*T*T) + eta/T );
 
     Scalar rate1 = kooij_rate(T);
     Scalar deriveRate1 = kooij_rate.derivative(T);

--- a/test/vanthoff_rate_unit.C
+++ b/test/vanthoff_rate_unit.C
@@ -30,30 +30,26 @@
 
 // C++
 #include <limits>
+#include <vector>
 // Antioch
 #include "antioch/vanthoff_rate.h"
+#include "antioch/physical_constants.h"
+#include "antioch/units.h"
 
 template <typename Scalar>
-int tester()
+int test_values(const Scalar & Cf, const Scalar & eta, const Scalar & Ea, const Scalar& D, const Scalar & Tref, const Scalar & R, const Antioch::VantHoffRate<Scalar> & vanthoff_rate)
 {
   using std::abs;
   using std::exp;
   using std::pow;
 
-  const Scalar Cf = 1.4;
-  const Scalar eta = 1.2;
-  const Scalar Ea = 5.0;
-  const Scalar D = 2.50;
-
-  Antioch::VantHoffRate<Scalar> vanthoff_rate(Cf,eta,Ea,D,1.,1.);
-
   int return_flag = 0;
   const Scalar tol = std::numeric_limits<Scalar>::epsilon() * 100;
 
-  for(Scalar T = 300.1; T <= 2500.1; T += 10.)
+  for(Scalar T = 300.1L; T <= 2500.1L; T += 10.L)
   {
-    const Scalar rate_exact = Cf*pow(T,eta)*exp(-Ea/T+D*T);
-    const Scalar derive_exact = Cf * pow(T,eta) * exp(-Ea/T + D*T) * (D + eta/T + Ea/(T*T)); 
+    const Scalar rate_exact = Cf * pow(T/Tref,eta) * exp(-Ea/(R*T) + D*T);
+    const Scalar derive_exact = Cf * pow(T/Tref,eta) * exp(-Ea/(R*T) + D*T) * (D + eta/T + Ea/(R*T*T)); 
 
     Scalar rate1 = vanthoff_rate(T);
     Scalar deriveRate1 = vanthoff_rate.derivative(T);
@@ -68,7 +64,8 @@ int tester()
                     << "Error: Mismatch in rate values." << std::endl
                     << "T = " << T << " K" << std::endl
                     << "rate(T) = " << rate1 << std::endl
-                    << "rate_exact = " << rate_exact << std::endl;
+                    << "rate_exact = " << rate_exact << std::endl
+                    << "Van't Hoff: " << vanthoff_rate << std::endl;
 
           return_flag = 1;
       }
@@ -78,7 +75,8 @@ int tester()
                     << "Error: Mismatch in rate values." << std::endl
                     << "T = " << T << " K" << std::endl
                     << "rate(T) = " << rate << std::endl
-                    << "rate_exact = " << rate_exact << std::endl;
+                    << "rate_exact = " << rate_exact << std::endl
+                    << "Van't Hoff: " << vanthoff_rate << std::endl;
 
           return_flag = 1;
       }
@@ -88,7 +86,8 @@ int tester()
                     << "Error: Mismatch in rate derivative values." << std::endl
                     << "T = " << T << " K" << std::endl
                     << "drate_dT(T) = " << deriveRate1 << std::endl
-                    << "derive_exact = " << derive_exact << std::endl;
+                    << "derive_exact = " << derive_exact << std::endl
+                    << "Van't Hoff: " << vanthoff_rate << std::endl;
 
           return_flag = 1;
       }
@@ -98,12 +97,78 @@ int tester()
                     << "Error: Mismatch in rate derivative values." << std::endl
                     << "T = " << T << " K" << std::endl
                     << "drate_dT(T) = " << deriveRate << std::endl
-                    << "derive_exact = " << derive_exact << std::endl;
+                    << "derive_exact = " << derive_exact << std::endl
+                    << "Van't Hoff: " << vanthoff_rate << std::endl;
 
           return_flag = 1;
       }
     if(return_flag)break;
   }
+
+  return return_flag;
+}
+
+template <typename Scalar>
+int tester()
+{
+
+  Scalar Cf = 1.4L;
+  Scalar eta = 1.2L;
+  Scalar Ea = 298.L;
+  Scalar D = 2.50L;
+  Scalar Tref = 1.L;
+  Scalar R = 1.L;
+
+  Antioch::VantHoffRate<Scalar> vanthoff_rate(Cf,eta,Ea,D,Tref,R);
+
+  int return_flag = test_values(Cf,eta,Ea,D,Tref,R,vanthoff_rate);
+
+  Cf = 1e-7L;
+  eta = 0.8L;
+  Ea = 36000.L;
+  D = -5.0L;
+  Tref = 298.;
+  R = Antioch::Constants::R_universal<Scalar>() * Antioch::Units<Scalar>("cal").get_SI_factor();
+
+  vanthoff_rate.set_Cf(Cf);
+  vanthoff_rate.set_eta(eta);
+  vanthoff_rate.set_Ea(Ea);
+  vanthoff_rate.set_D(D);
+  vanthoff_rate.set_Tref(Tref);
+  vanthoff_rate.set_rscale(R);
+
+  return_flag = test_values(Cf,eta,Ea,D,Tref,R,vanthoff_rate) || return_flag;
+
+  Cf = 2.8e-7L;
+  eta = 0.3L;
+  Ea = 45000.L;
+  D = -4.2L;
+  std::vector<Scalar> values(4);
+  values[0] = Cf;
+  values[1] = eta;
+  values[2] = Ea;
+  values[3] = D;
+  vanthoff_rate.reset_coefs(values);
+
+  return_flag = test_values(Cf,eta,Ea,D,Tref,R,vanthoff_rate) || return_flag;
+
+  Cf = 3.6e-11L;
+  eta = 0.235L;
+  Ea = 100000.L;
+  D = 0.025L;
+  Tref = 300.L;
+  R = Antioch::Constants::R_universal<Scalar>();
+  values.resize(6);
+  values[0] = Cf;
+  values[1] = eta;
+  values[2] = Ea;
+  values[3] = D;
+  values[4] = Tref;
+  values[5] = R;
+  vanthoff_rate.reset_coefs(values);
+
+  return_flag = test_values(Cf,eta,Ea,D,Tref,R,vanthoff_rate) || return_flag;
+
 
   return return_flag;
 }


### PR DESCRIPTION
![graph](https://cloud.githubusercontent.com/assets/4761614/5744137/9cc209b4-9be3-11e4-8e0e-332c263053ed.jpg)

Here is the branch for resetting the kinetics.  This is the first step, the type of resetting @pbauman talked about, the wrapper method with paranoid checks will come in a future PR.

##### Resetting
To reset your kinetics, you need first to get to your kinetics object, then you reset.  The tests (*kinetics_type*_unit.C) have been updated and provide nice examples on what to do once you have your rate object.
```
ReactionSet<Scalar> reac_set;
...do stuff...
// reinitialize reaction n
KineticsType<Scalar> & kinetics = reac_set.reaction(n).forward_rate();
VectorType new_values;
... fill new_values ...
kinetics.reset_coefs(new_values);
```
You can use at this level any method shown in the tests that uses the vector of values.  If you want to reset a single parameter (say Cf in a Kooij model), you need to change the ```KineticsType<Scalar>``` into the appropriate rate, here ```KooijRate<Scalar>```:
```
ReactionSet<Scalar> reac_set;
...do stuff...
// reinitialize reaction n
KooijRate<Scalar> * kinetics = static_cast<KooijRate<Scalar>*> (&reac_set.reaction(n).forward_rate());
Scalar new_Cf_value;
... define new_Cf_value ...
kinetics->set_Cf(new_Cf_value);
```

The subtleties about units are dealt with the parameters ```Tref``` and ```rscale``` (which is the value of R in the unit of given activation energy).  For details, see the doxygen documentation on the rate models (method ```reset_coefs```).

For third-body coefficients, the object ```Reaction<Scalar>``` already has what's necessary:
```
ReactionSet<Scalar> reac_set;
...do stuff...
// reinitialize third-body coefs of reaction n
Reaction<Scalar> & reac = reac_set.reaction(n);
... looping over species...
reac.set_efficiency(name_spec,id_spec,value_coef_spec);
```
And finally, for the falloff reactions, you can access the falloff model (Lindeman or Troe) using:
```
DesiredFalloffModel & falloff = reac_set.reaction(n).falloff()
... do whatever ...
```

##### For reviewers
Lots of lines, but always the same thing, mainly the ```reset_coefs``` method in the kinetics rates.  Only the tests for the reset of the kinetics objects have so far been made (update of the already existing tests), except for the photochemistry.  The falloff model fetch has not been added to the test (it's but a wrapper of the corresponding method in the ```FalloffReaction<Scalar>``` object).