### PR TITLE
fixed the case "kg"

### DIFF
--- a/src/units/include/antioch/units.h
+++ b/src/units/include/antioch/units.h
@@ -124,6 +124,24 @@ class Units{
 /*!\brief Default destructor*/
         ~Units(){}
 
+    //! Formatted print
+    /*!
+     * Defaults to \p std::cout.
+     */
+        void print(std::ostream &os = std::cout) const;
+
+    //!Formatted print 
+    /*!
+     * Allows you to do std::cout << object << std::endl;
+     */
+       friend std::ostream& operator<<( std::ostream& os,
+				        const Units<T>& unit )
+       {
+         unit.print(os);
+         return os;
+       } 
+
+
 /*! \brief Comparison operator
  *
  * Compares the power vector and the coefficient, regardless
@@ -802,9 +820,10 @@ bool Units<T>::parse_single_unit(int signe,std::string unit,bool doConv)
 
   if(iUnit == -1)return false; //not found
 
-  T pre = 1.;
+  T pre = 1.L;
   if(iPre != -1)pre = UnitBaseStorage::known_prefixes().stored(iPre).value<T>();
-  if(UnitBaseStorage::known_units().stored(iUnit).symbol() == "kg")pre *= 1e-3; //rescale
+  if(UnitBaseStorage::known_units().stored(iUnit).symbol() == "kg" && 
+     unit != "kg")pre *= 1e-3L; //rescale
   InSI powerTmp = UnitBaseStorage::known_units().stored(iUnit).power_array();
   power += (powerTmp * signe * ipower);
   if(doConv)
@@ -1338,6 +1357,16 @@ Units<T> Units<T>::operator/(int r) const
 {
   return (Units<T>(*this) /= r);
 }
+
+  template <typename T>
+  void Units<T>::print(std::ostream &os) const
+  {
+     os << name << " (" << symbol << "), "
+        << toSI << ", "
+        << power << std::endl;
+  }
+
+
 } //Antioch namespace
 
 #endif

--- a/test/units_unit.C
+++ b/test/units_unit.C
@@ -66,6 +66,7 @@ int test_factor(int nAddition)
 {
   using std::abs;
 
+  int return_flag(0);
 
   const T tol = std::numeric_limits<T>::epsilon() * 2.;
   const T unity = 1.L;
@@ -76,57 +77,77 @@ int test_factor(int nAddition)
   {
     std::cerr << std::scientific << std::setprecision(16)
               << "mismatch in unit SI description, unity is not found" << std::endl
-              << "factor = " << test.get_SI_factor() << std::endl;
-    return 1;
+              << "unit is " << test << std::endl;
+    return_flag = 1;
   }
   test.set_unit("J");
   if(abs((test.get_SI_factor()-unity)/unity) > tol)
   {
     std::cerr << std::scientific << std::setprecision(16)
               << "mismatch in unit SI description, unity is not found" << std::endl
-              << "factor = " << test.get_SI_factor() << std::endl;
-    return 1;
+              << "unit is " << test << std::endl;
+    return_flag = 1;
   }
   test.set_unit("Hz");
   if(abs((test.get_SI_factor()-unity)/unity) > tol)
   {
     std::cerr << std::scientific << std::setprecision(16)
               << "mismatch in unit SI description, unity is not found" << std::endl
-              << "factor = " << test.get_SI_factor() << std::endl;
-    return 1;
+              << "unit is " << test << std::endl;
+    return_flag = 1;
   }
   test.set_unit("N");
   if(abs((test.get_SI_factor()-unity)/unity) > tol)
   {
     std::cerr << std::scientific << std::setprecision(16)
               << "mismatch in unit SI description, unity is not found" << std::endl
-              << "factor = " << test.get_SI_factor() << std::endl;
-    return 1;
+              << "unit is " << test << std::endl;
+    return_flag = 1;
   }
   test.set_unit("Pa");
   if(abs((test.get_SI_factor()-unity)/unity) > tol)
   {
     std::cerr << std::scientific << std::setprecision(16)
               << "mismatch in unit SI description, unity is not found" << std::endl
-              << "factor = " << test.get_SI_factor() << std::endl;
-    return 1;
+              << "unit is " << test << std::endl;
+    return_flag = 1;
   }
   test.set_unit("C");
   if(abs((test.get_SI_factor()-unity)/unity) > tol)
   {
     std::cerr << std::scientific << std::setprecision(16)
               << "mismatch in unit SI description, unity is not found" << std::endl
-              << "factor = " << test.get_SI_factor() << std::endl;
-    return 1;
+              << "unit is " << test << std::endl;
+    return_flag = 1;
   }
   test.set_unit("Bq");
   if(abs((test.get_SI_factor()-unity)/unity) > tol)
   {
     std::cerr << std::scientific << std::setprecision(16)
               << "mismatch in unit SI description, unity is not found" << std::endl
-              << "factor = " << test.get_SI_factor() << std::endl;
-    return 1;
+              << "unit is " << test << std::endl;
+    return_flag = 1;
   }
+  test.set_unit("kg");
+  if(abs((test.get_SI_factor()-unity)/unity) > tol)
+  {
+    std::cerr << std::scientific << std::setprecision(16)
+              << "mismatch in unit SI description, unity is not found" << std::endl
+              << "unit is " << test << std::endl;
+    return_flag = 1;
+  }
+  test.set_unit("mg");
+  T milli(1e-6L);
+  if(abs((test.get_SI_factor()-milli)/milli) > tol)
+  {
+    std::cerr << std::scientific << std::setprecision(16)
+              << "mismatch in unit SI description, unity is not found" << std::endl
+              << "unit is " << test << std::endl;
+    return_flag = 1;
+  }
+
+
+
 
 //testing composed unit
   srand(time(0)); //seed
@@ -169,8 +190,8 @@ int test_factor(int nAddition)
   {
     std::cerr << std::scientific << std::setprecision(16)
               << "mismatch in unit combination, unity is not found" << std::endl
-              << "factor = " << test.get_SI_factor() << std::endl;
-    return 1;
+              << "unit is " << test << std::endl;
+    return_flag = 1;
   }
   
   std::cout << "Combination done at ";
@@ -192,10 +213,8 @@ int test_factor(int nAddition)
               << "relative error  = " << abs((Rcalc - Rcal)/Rcal) << std::endl
               << "uncertainty in calorie = " << Runc << std::endl
               << "tol  = " << tol << std::endl;
-    return 1;
+    return_flag = 1;
   }
-
-  std::cout << "R calculation passed" << std::endl;
 
   // now combining with parenthesises E = m * c * c, [E] = [m] + [c] + [c]
   Antioch::Units<T> m("g"), c("m/s");
@@ -204,12 +223,10 @@ int test_factor(int nAddition)
   if(!E.is_homogeneous("J"))
   {
      std::cerr << "E = m * c *c failed, output unit is " << E.get_symbol() << std::endl;
-     return 1;
+     return_flag = 1;
   }
 
-  std::cout << "E = m * c * c calculation passed" << std::endl;
-
-  return 0;
+  return return_flag;
 }
 
 template <typename T>


### PR DESCRIPTION
Last "kg" bug in the `Units` object found.  This one was vicious, typically you don't use "kg" directly, that's why it didn't show up before.

Also added a `print` method to the `Units` object.

I'll merge it before leaving the lab.
