### PR TITLE
Falloff three body

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -46,6 +46,7 @@ pkginclude_HEADERS += kinetics/include/antioch/elementary_reaction.h
 pkginclude_HEADERS += kinetics/include/antioch/duplicate_reaction.h
 pkginclude_HEADERS += kinetics/include/antioch/threebody_reaction.h
 pkginclude_HEADERS += kinetics/include/antioch/falloff_reaction.h
+pkginclude_HEADERS += kinetics/include/antioch/falloff_threebody_reaction.h
 pkginclude_HEADERS += kinetics/include/antioch/lindemann_falloff.h
 pkginclude_HEADERS += kinetics/include/antioch/troe_falloff.h
 # kinetics-other

--- a/src/diffusion/include/antioch/molecular_binary_diffusion.h
+++ b/src/diffusion/include/antioch/molecular_binary_diffusion.h
@@ -172,19 +172,19 @@ namespace Antioch{
      _j(sj.species()),
      _reduced_mass((si.species() == sj.species())?CoeffType(0.5L) * si.M():(si.M() * sj.M()) / (si.M() + sj.M())), // kg/mol
      _xi((si.polar() == sj.polar())?1L:this->composed_xi(si,sj)),
-     _reduced_LJ_diameter(CoeffType(0.5L) * (si.LJ_diameter() + sj.LJ_diameter()) * Units<CoeffType>("ang").get_SI_factor() * ant_pow(_xi,-1.L/6.L)), // 1/2 * (sigma_1 + sigma_2) * xi^(-1/6)
+     _reduced_LJ_diameter(CoeffType(0.5) * (si.LJ_diameter() + sj.LJ_diameter()) * Units<CoeffType>("ang").get_SI_factor() * ant_pow(_xi,-CoeffType(1)/CoeffType(6))), // 1/2 * (sigma_1 + sigma_2) * xi^(-1/6)
      _reduced_LJ_depth(ant_sqrt(si.LJ_depth() * sj.LJ_depth())  * _xi * _xi), // sqrt(eps_1 * eps_2) * xi^2
-     _reduced_dipole_moment((CoeffType(1e-7L) * ant_pow(Constants::light_celerity<CoeffType>(),2)) * 
+     _reduced_dipole_moment((CoeffType(1e-7) * ant_pow(Constants::light_celerity<CoeffType>(),2)) * 
                               (si.dipole_moment() * sj.dipole_moment() * ant_pow(Units<CoeffType>("D").get_SI_factor(),2 )) / 
-                            (CoeffType(2.L) * _reduced_LJ_depth * Constants::Boltzmann_constant<CoeffType>() * ant_pow(_reduced_LJ_diameter,3) )), // mu^2 / (2*eps*sigma^3)
+                            (2 * _reduced_LJ_depth * Constants::Boltzmann_constant<CoeffType>() * ant_pow(_reduced_LJ_diameter,3) )), // mu^2 / (2*eps*sigma^3)
 /*  = ~ 7.16 10^-25, 
         float can't take it, 
         we cheat on the kb / nAvo division that makes float cry
 
         3/16 * sqrt ( 2 * kb / (Navo * pi) )
 */
-      _coefficient(CoeffType(0.1875e-25L) * ant_sqrt(CoeffType(2.L) * Constants::Boltzmann_constant<CoeffType>() * CoeffType(1e25L)  /
-                                                            (Constants::Avogadro<CoeffType>() * CoeffType(1e-25L) * Constants::pi<CoeffType>())
+      _coefficient(CoeffType(0.1875e-25L) * ant_sqrt(2 * Constants::Boltzmann_constant<CoeffType>() * CoeffType(1e25)  /
+                                                            (Constants::Avogadro<CoeffType>() * CoeffType(1e-25) * Constants::pi<CoeffType>())
                                                           )
                                          / ( sqrt(_reduced_mass) * (_reduced_LJ_diameter * _reduced_LJ_diameter) )
                   )
@@ -210,15 +210,15 @@ namespace Antioch{
 #else
      _i(species[0].species()),
      _j(species[1].species()),
-     _reduced_mass((species[0].species() == species[1].species())?CoeffType(0.5L) * species[0].M():(species[0].M() * species[1].M()) / (species[0].M() + species[1].M())), // kg/mol
+     _reduced_mass((species[0].species() == species[1].species())?CoeffType(0.5) * species[0].M():(species[0].M() * species[1].M()) / (species[0].M() + species[1].M())), // kg/mol
      _xi((species[0].polar() == species[1].polar())?1L:this->composed_xi(species[0],species[1])),
-     _reduced_LJ_diameter(CoeffType(0.5L) * (species[0].LJ_diameter() + species[1].LJ_diameter()) * Units<CoeffType>("ang").get_SI_factor() * ant_pow(_xi,-1.L/6.L)), // 1/2 * (sigma_1 + sigma_2) * xi^(-1/6)
+     _reduced_LJ_diameter(CoeffType(0.5) * (species[0].LJ_diameter() + species[1].LJ_diameter()) * Units<CoeffType>("ang").get_SI_factor() * ant_pow(_xi,-CoeffType(1)/CoeffType(6))), // 1/2 * (sigma_1 + sigma_2) * xi^(-1/6)
      _reduced_LJ_depth(ant_sqrt(species[0].LJ_depth() * species[1].LJ_depth())  *_xi * _xi), // sqrt(eps_1 * eps_2) * xi^2
-     _reduced_dipole_moment((CoeffType(1e-7L) * ant_pow(Constants::light_celerity<CoeffType>(),2)) * 
+     _reduced_dipole_moment((CoeffType(1e-7) * ant_pow(Constants::light_celerity<CoeffType>(),2)) * 
                               (species[0].dipole_moment() * species[1].dipole_moment() * ant_pow(Units<CoeffType>("D").get_SI_factor(),2 )) / 
-                            (CoeffType(2.L) * _reduced_LJ_depth * Constants::Boltzmann_constant<CoeffType>() * ant_pow(_reduced_LJ_diameter,3) )), // mu^2 / (2*eps*sigma^3)
-      _coefficient(CoeffType(0.1875e-25L) * ant_sqrt(CoeffType(2.L) * Constants::Boltzmann_constant<CoeffType>() * CoeffType(1e25L)  /
-                                                            (Constants::Avogadro<CoeffType>() * CoeffType(1e-25L) * Constants::pi<CoeffType>())
+                            (2 * _reduced_LJ_depth * Constants::Boltzmann_constant<CoeffType>() * ant_pow(_reduced_LJ_diameter,3) )), // mu^2 / (2*eps*sigma^3)
+      _coefficient(CoeffType(0.1875e-25L) * ant_sqrt(2 * Constants::Boltzmann_constant<CoeffType>() * CoeffType(1e25)  /
+                                                            (Constants::Avogadro<CoeffType>() * CoeffType(1e-25) * Constants::pi<CoeffType>())
                                                           )
                                          / ( sqrt(_reduced_mass) * (_reduced_LJ_diameter * _reduced_LJ_diameter) )
                   )
@@ -250,20 +250,20 @@ namespace Antioch{
      _j                     = sj.species();
      _reduced_mass          = (si.species() == sj.species())?si.M():(si.M() * sj.M()) / (si.M() + sj.M());
      _reduced_dipole_moment = ant_sqrt(si.dipole_moment() * sj.dipole_moment());
-     _xi                    = (si.polar() == sj.polar())?1L:this->composed_xi(si,sj);
-     _reduced_LJ_diameter   = CoeffType(0.5L) * (si.LJ_diameter() + sj.LJ_diameter()) * Units<CoeffType>("ang").get_SI_factor() * ant_pow(_xi,-1.L/6.L);
+     _xi                    = (si.polar() == sj.polar())?1:this->composed_xi(si,sj);
+     _reduced_LJ_diameter   = CoeffType(0.5) * (si.LJ_diameter() + sj.LJ_diameter()) * Units<CoeffType>("ang").get_SI_factor() * ant_pow(_xi,-CoeffType(1)/CoeffType(6));
      _reduced_LJ_depth      = ant_sqrt(si.LJ_depth() * sj.LJ_depth()) *_xi * _xi;
-     _reduced_dipole_moment = CoeffType(1e-7L) * ant_pow(Constants::light_celerity<CoeffType>(),2) * // * 1/(4*pi * eps_0) = 10^-7 * c^2 
+     _reduced_dipole_moment = CoeffType(1e-7) * ant_pow(Constants::light_celerity<CoeffType>(),2) * // * 1/(4*pi * eps_0) = 10^-7 * c^2 
                              (si.dipole_moment() * sj.dipole_moment()) * ant_pow(Units<CoeffType>("D").get_SI_factor(),2)
-                                / ((CoeffType(2.L)*_reduced_LJ_depth * Constants::Boltzmann_constant<CoeffType>() * ant_pow(_reduced_LJ_diameter,3)));
+                                / ((2 * _reduced_LJ_depth * Constants::Boltzmann_constant<CoeffType>() * ant_pow(_reduced_LJ_diameter,3)));
 /*  = ~ 7.16 10^-25, 
         float can't take it, 
         we cheat on the kb / nAvo division that makes float cry
 
         3/16 * sqrt ( 2 * kb / (Navo * pi) )
 */
-      _coefficient = CoeffType(0.1875e-25L) * ant_sqrt(CoeffType(2.L) * Constants::Boltzmann_constant<CoeffType>() * CoeffType(1e25L)  /
-                                                            (Constants::Avogadro<CoeffType>() * CoeffType(1e-25L) * Constants::pi<CoeffType>())
+      _coefficient = CoeffType(0.1875e-25L) * ant_sqrt(2 * Constants::Boltzmann_constant<CoeffType>() * CoeffType(1e25)  /
+                                                            (Constants::Avogadro<CoeffType>() * CoeffType(1e-25) * Constants::pi<CoeffType>())
                                                           )
                                          / ( sqrt(_reduced_mass) * (_reduced_LJ_diameter * _reduced_LJ_diameter) );
   }
@@ -287,10 +287,10 @@ namespace Antioch{
 
         CoeffType pol    =  n.polarizability() / ant_pow(n.LJ_diameter(),3); //ang^3 / ang^3 -> cancel out
         CoeffType dipole = p.dipole_moment() * Units<CoeffType>("D").get_SI_factor() 
-                           / ant_sqrt((CoeffType)4.L * Constants::pi<CoeffType>() * Constants::vacuum_permittivity<CoeffType>()
+                           / ant_sqrt(4 * Constants::pi<CoeffType>() * Constants::vacuum_permittivity<CoeffType>()
                                         *  p.LJ_depth() * ant_pow(p.LJ_diameter(),3) );
 
-        return (CoeffType)(1.L) + (CoeffType)(0.25L) * pol * dipole * ant_sqrt(p.LJ_depth()/n.LJ_depth());
+        return 1 + CoeffType(0.25L) * pol * dipole * ant_sqrt(p.LJ_depth()/n.LJ_depth());
   }
 
   template <typename CoeffType, typename Interpolator>

--- a/src/kinetics/include/antioch/falloff_reaction.h
+++ b/src/kinetics/include/antioch/falloff_reaction.h
@@ -178,7 +178,7 @@ namespace Antioch
     const StateType k0   = (*this->_forward_rate[0])(conditions);
     const StateType kinf = (*this->_forward_rate[1])(conditions);
 
-    return k0 / (ant_pow(M,-1) + k0 / kinf) * _F(T,M,k0,kinf);
+    return k0 / (ant_pow(M,-1) + k0 / kinf) * _F(conditions.T(),M,k0,kinf);
   }
 
   template<typename CoeffType, typename FalloffType>
@@ -209,7 +209,7 @@ namespace Antioch
     StateType f = Antioch::zero_clone(M);
     StateType df_dT = Antioch::zero_clone(M);
     VectorStateType df_dX = Antioch::zero_clone(molar_densities);
-    _F.F_and_derivatives(conditions.T(),molar_densities,k0,dk0_dT,kinf,dkinf_dT,f,df_dT,df_dX);
+    _F.F_and_derivatives(conditions.T(),M,k0,dk0_dT,kinf,dkinf_dT,f,df_dT,df_dX);
 
 // k(T,[M]) = k0*[M]/(1 + [M]*k0/kinf) * F = k0 * ([M]^-1 + k0 * kinf^-1)^-1 * F    
     kfwd = k0 / (ant_pow(M,-1) + k0/kinf); //temp variable here for calculations dk_d{T,X}

--- a/src/kinetics/include/antioch/falloff_reaction.h
+++ b/src/kinetics/include/antioch/falloff_reaction.h
@@ -175,9 +175,10 @@ namespace Antioch
         M += molar_densities[i];
     }
 
+    const StateType k0   = (*this->_forward_rate[0])(conditions);
+    const StateType kinf = (*this->_forward_rate[1])(conditions);
 
-    return (*this->_forward_rate[0])(conditions) / (ant_pow(M,-1) + (*this->_forward_rate[0])(conditions) /(*this->_forward_rate[1])(conditions)) * 
-            _F(conditions.T(),molar_densities,(*this->_forward_rate[0])(conditions),(*this->_forward_rate[1])(conditions));
+    return k0 / (ant_pow(M,-1) + k0 / kinf) * _F(T,M,k0,kinf);
   }
 
   template<typename CoeffType, typename FalloffType>

--- a/src/kinetics/include/antioch/falloff_reaction.h
+++ b/src/kinetics/include/antioch/falloff_reaction.h
@@ -175,6 +175,7 @@ namespace Antioch
         M += molar_densities[i];
     }
 
+
     return (*this->_forward_rate[0])(conditions) / (ant_pow(M,-1) + (*this->_forward_rate[0])(conditions) /(*this->_forward_rate[1])(conditions)) * 
             _F(conditions.T(),molar_densities,(*this->_forward_rate[0])(conditions),(*this->_forward_rate[1])(conditions));
   }

--- a/src/kinetics/include/antioch/falloff_reaction.h
+++ b/src/kinetics/include/antioch/falloff_reaction.h
@@ -87,6 +87,11 @@ namespace Antioch
   * \f]
   *
   * By default, the falloff is LindemannFalloff and the kinetics model KooijRate.
+  *
+  * \todo Document the limiting accuracy of the denominator part at the float precision.
+  *       See the tests for the values, I (Sylvain) propose to make a paragraph in
+  *       the model doc explaining throughfully this issue.
+  *
   */
   template<typename CoeffType=double, typename FalloffType = LindemannFalloff<CoeffType> >
   class FalloffReaction: public Reaction<CoeffType>

--- a/src/kinetics/include/antioch/falloff_threebody_reaction.h
+++ b/src/kinetics/include/antioch/falloff_threebody_reaction.h
@@ -224,15 +224,18 @@ namespace Antioch
 //dk_dT = F * dkfwd_dT + kfwd * dF_dT
 //      = F * kfwd * (dk0_dT/k0 - dk0_dT/(kinf/[M] + k0) + k0 * dkinf_dT/(kinf * (kinf/[M] + k0) ) )
 //      + dF_dT * kfwd
-    dkfwd_dT = f * kfwd * (dk0_dT/k0 - dk0_dT/(kinf/M + k0) + dkinf_dT * k0/(kinf * (kinf/M + k0)))
+    StateType temp = (kinf/M + k0);
+    dkfwd_dT = f * kfwd * (dk0_dT/k0 - dk0_dT/temp + dkinf_dT * k0/(kinf * temp))
              + df_dT * kfwd;
 
     dkfwd_dX.resize(this->n_species(), kfwd);
+
+    StateType tmp = f * kfwd / (M + ant_pow(M,2) * k0/kinf);
 //dkfwd_dX = F * dkfwd_dX + kfwd * dF_dX
 //         = F * epsilon_i * kfwd / ([M] +  [M]^2 k0/kinf) + kfwd * dF_dX
     for(unsigned int ic = 0; ic < this->n_species(); ic++)
       {
-        dkfwd_dX[ic] = this->efficiency(ic) * ( f * kfwd / (M + ant_pow(M,2) * k0/kinf) + df_dX[ic] * kfwd );
+        dkfwd_dX[ic] = this->efficiency(ic) * ( tmp + df_dX[ic] * kfwd );
       }
 
     kfwd *= f; //finalize

--- a/src/kinetics/include/antioch/falloff_threebody_reaction.h
+++ b/src/kinetics/include/antioch/falloff_threebody_reaction.h
@@ -182,8 +182,10 @@ namespace Antioch
         M += this->efficiency(s) * molar_densities[s];
     }
 
-    return (*this->_forward_rate[0])(T) / (ant_pow(M,-1) + (*this->_forward_rate[0])(T) /(*this->_forward_rate[1])(T)) * 
-            _F(T,M,(*this->_forward_rate[0])(T),(*this->_forward_rate[1])(T));
+    const StateType k0   = (*this->_forward_rate[0])(T);
+    const StateType kinf = (*this->_forward_rate[1])(T);
+
+    return k0 / (ant_pow(M,-1) + k0 / kinf) * _F(T,M,k0,kinf);
   }
 
   template<typename CoeffType, typename FalloffType>

--- a/src/kinetics/include/antioch/falloff_threebody_reaction.h
+++ b/src/kinetics/include/antioch/falloff_threebody_reaction.h
@@ -1,0 +1,272 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// Antioch - A Gas Dynamics Thermochemistry Library
+//
+// Copyright (C) 2014 Paul T. Bauman, Benjamin S. Kirk, Sylvain Plessis,
+//                    Roy H. Stonger
+// Copyright (C) 2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef ANTIOCH_FALLOFF_THREE_BODY_REACTION_H
+#define ANTIOCH_FALLOFF_THREE_BODY_REACTION_H
+
+// Antioch
+#include "antioch/antioch_asserts.h"
+#include "antioch/cmath_shims.h"
+#include "antioch/reaction.h"
+#include "antioch/lindemann_falloff.h"
+#include "antioch/troe_falloff.h"
+
+//C++
+#include <string>
+#include <vector>
+#include <iostream>
+
+namespace Antioch
+{
+  /*!\class FalloffThreeBodyReaction
+  * Base class for falloff processes coupled with efficiencies
+  *
+  * This class encapsulates a bastard between falloff and three-body reaction.
+  * It performs the common operations.
+  * A falloff rate constant is defined by the equation
+  * \f[
+  *     k(T,[M]) = \frac{[M] k_0(T)}{1+[M]\frac{k_0(T)}{k_\infty(T)}}\times F
+  * \f]
+  * with 
+  * \f[
+  *  \begin{split}
+  *     k_0(T)      & = \lim_{[M] \rightarrow 0} k(T,[M])\\ 
+  *     k_\infty(T) & = \lim_{[M] \rightarrow \infty} k(T,[M])
+  *  \end{split}
+  * \f]
+  * \f$k_0\f$ and \f$k_\infty\f$ being respectively the low and high pressure
+  * rate constant limits, considered elementary (as pressure in these conditions is constant).
+  * Thus 
+  * \f[
+  *   \begin{split}
+  *     k_0(T)      & = \alpha_0(T) \\
+  *     k_\infty(T) & = \alpha_\infty(T)
+  *   \end{split}
+  * \f] 
+  * with \f$\alpha_{i,\,i=0,\infty}(T)\f$ any
+  * kinetics model (see base class KineticsType), and \f$[M]\f$
+  * the mixture concentration (or pressure, it's equivalent, \f$[M] = \frac{P}{\mathrm{R}T}\f$
+  * in the ideal gas model).  All reactions are assumed to be reversible, the kinetics models are
+  * assumed to be the same.  The three-body part is for the computations of \f$[M]\f$
+  * \f[
+  *     [M] = \sum_{s=1}^{n} \epsilon_sc_n
+  * \f]
+  *
+  * We have:
+  * \f[
+  *     \begin{split}
+  *       \frac{\partial k(T,[M])}{\partial T} & = k(T,[M]) F \left(
+  *                                                                 \frac{\partial k_0(T)}{\partial T}\frac{1}{k_0(T)} -
+  *                                                                 \frac{\partial k_0(T)}{\partial T}\frac{1}{k_0(T) + \frac{k_\infty(T)}{[M]}} +
+  *                                                                 \frac{\partial k_\infty(T)}{\partial T}
+  *                                                                     \frac{k_0(T)}{k_\infty \left(k_0(T) + \frac{k_\infty(T)}{[M]}\right)}
+  *                                                           \right) +
+  *                                                 k(T,[M]) \frac{\partial F}{\partial T} \\[10pt]
+  *       \frac{\partial k(T,[M])}{\partial c_i} & = F \epsilon_i\frac{k(T,[M])}{[M] + [M]^2\frac{k_0(T)}{k_\infty(T)}} +
+  *                                                  k(T,[M]) \frac{\partial F}{\partial c_i}
+  *     \end{split}
+  * \f]
+  *
+  * By default, the falloff is LindemannFalloff and the kinetics model KooijRate.
+  */
+  template<typename CoeffType=double, typename FalloffType = LindemannFalloff<CoeffType> >
+  class FalloffThreeBodyReaction: public Reaction<CoeffType>
+  {
+  public:
+
+    //! Construct a single reaction mechanism.
+    FalloffThreeBodyReaction( const unsigned int n_species,
+                     const std::string &equation, 
+                     const bool &reversible = true,
+                     const ReactionType::ReactionType &falloffType = ReactionType::LINDEMANN_FALLOFF_THREE_BODY,
+                     const KineticsModel::KineticsModel kin = KineticsModel::KOOIJ);
+    
+    ~FalloffThreeBodyReaction();
+
+    //!
+    template <typename StateType, typename VectorStateType>
+    StateType compute_forward_rate_coefficient( const VectorStateType& molar_densities,
+                                                const StateType& T ) const;
+    
+    //!
+    template <typename StateType, typename VectorStateType>
+    void compute_forward_rate_coefficient_and_derivatives( const VectorStateType& molar_densities,
+                                                           const StateType& T,  
+                                                           StateType& kfwd,  
+                                                           StateType& dkfwd_dT, 
+                                                           VectorStateType& dkfkwd_dX) const;
+
+
+    //! Return const reference to the falloff object
+    const FalloffType &F() const;
+
+    //! Return writeable reference to the falloff object
+    FalloffType &F();
+
+    //!
+    void set_efficiency( const std::string &,
+                         const unsigned int s,
+                         const CoeffType efficiency);
+
+    //!
+    CoeffType efficiency( const unsigned int s ) const;
+
+  protected:
+
+    FalloffType _F;
+
+    std::vector<CoeffType> _efficiencies;
+
+  };
+
+  /* ------------------------- Inline Functions -------------------------*/
+  template<typename CoeffType, typename FalloffType>
+  inline
+  FalloffThreeBodyReaction<CoeffType,FalloffType>::FalloffThreeBodyReaction( const unsigned int n_species,
+                                                           const std::string &equation,
+                                                           const bool &reversible,
+                                                           const ReactionType::ReactionType &falloffType, 
+                                                           const KineticsModel::KineticsModel kin)
+    :Reaction<CoeffType>(n_species,equation,reversible,falloffType,kin),
+     _F(n_species)
+     
+  {
+    _efficiencies.resize(n_species); 
+    std::fill (_efficiencies.begin(), _efficiencies.end(), 1.);
+  }
+
+
+  template<typename CoeffType, typename FalloffType>
+  inline
+  FalloffThreeBodyReaction<CoeffType,FalloffType>::~FalloffThreeBodyReaction()
+  {
+    return;
+  }
+
+  template<typename CoeffType, typename FalloffType>
+  inline
+  FalloffType &FalloffThreeBodyReaction<CoeffType,FalloffType>::F()
+  {
+    return _F;
+  }
+
+  template<typename CoeffType, typename FalloffType>
+  inline
+  const FalloffType &FalloffThreeBodyReaction<CoeffType,FalloffType>::F() const
+  {
+    return _F;
+  }
+
+  template<typename CoeffType, typename FalloffType>
+  template<typename StateType, typename VectorStateType>
+  inline
+  StateType FalloffThreeBodyReaction<CoeffType,FalloffType>::compute_forward_rate_coefficient( const VectorStateType& molar_densities,
+                                                                                      const StateType& T  ) const
+  {
+//falloff is k(T,[M]) = k0*[M]/(1 + [M]*k0/kinf) * F = k0 * ([M]^-1 + k0 * kinf^-1)^-1 * F    
+    StateType M = Antioch::zero_clone(T);
+    for(unsigned int s = 0; s < molar_densities.size(); s++)
+    {
+        M += _efficiencies[s] * molar_densities[s];
+    }
+
+    return (*this->_forward_rate[0])(T) / (ant_pow(M,-1) + (*this->_forward_rate[0])(T) /(*this->_forward_rate[1])(T)) * 
+            _F(T,M,(*this->_forward_rate[0])(T),(*this->_forward_rate[1])(T));
+  }
+
+  template<typename CoeffType, typename FalloffType>
+  template<typename StateType, typename VectorStateType>
+  inline
+  void FalloffThreeBodyReaction<CoeffType,FalloffType>::compute_forward_rate_coefficient_and_derivatives( const VectorStateType &molar_densities,
+                                                                                                 const StateType& T,
+                                                                                                 StateType& kfwd, 
+                                                                                                 StateType& dkfwd_dT,
+                                                                                                 VectorStateType& dkfwd_dX) const 
+  {
+    //variables, k0,kinf and derivatives
+   StateType k0 = Antioch::zero_clone(T);
+    StateType dk0_dT = Antioch::zero_clone(T);
+    StateType kinf = Antioch::zero_clone(T);
+    StateType dkinf_dT = Antioch::zero_clone(T);
+
+    this->_forward_rate[0]->compute_rate_and_derivative(T,k0,dk0_dT);
+    this->_forward_rate[1]->compute_rate_and_derivative(T,kinf,dkinf_dT);
+
+    StateType M = Antioch::zero_clone(T);
+    for(unsigned int s = 0; s < molar_densities.size(); s++)
+    {
+        M += _efficiencies[s] * molar_densities[s];
+    }
+
+    //F
+    StateType f = Antioch::zero_clone(T);
+    StateType df_dT = Antioch::zero_clone(T);
+    VectorStateType df_dX = Antioch::zero_clone(molar_densities);
+    _F.F_and_derivatives(T,M,k0,dk0_dT,kinf,dkinf_dT,f,df_dT,df_dX);
+
+// k(T,[M]) = k0*[M]/(1 + [M]*k0/kinf) * F = k0 * ([M]^-1 + k0 * kinf^-1)^-1 * F    
+    kfwd = k0 / (ant_pow(M,-1) + k0/kinf); //temp variable here for calculations dk_d{T,X}
+
+//dk_dT = F * dkfwd_dT + kfwd * dF_dT
+//      = F * kfwd * (dk0_dT/k0 - dk0_dT/(kinf/[M] + k0) + k0 * dkinf_dT/(kinf * (kinf/[M] + k0) ) )
+//      + dF_dT * kfwd
+    dkfwd_dT = f * kfwd * (dk0_dT/k0 - dk0_dT/(kinf/M + k0) + dkinf_dT * k0/(kinf * (kinf/M + k0)))
+             + df_dT * kfwd;
+
+    dkfwd_dX.resize(this->n_species(), kfwd);
+//dkfwd_dX = F * dkfwd_dX + kfwd * dF_dX
+//         = F * epsilon_i * kfwd / ([M] +  [M]^2 k0/kinf) + kfwd * dF_dX
+    for(unsigned int ic = 0; ic < this->n_species(); ic++)
+      {
+        dkfwd_dX[ic] = _efficiencies[ic] * ( f * kfwd / (M + ant_pow(M,2) * k0/kinf) + df_dX[ic] * kfwd );
+      }
+
+    kfwd *= f; //finalize
+
+    return;
+  }
+
+
+  template<typename CoeffType, typename FalloffType>
+  inline
+  void FalloffThreeBodyReaction<CoeffType,FalloffType>::set_efficiency( const std::string &,
+                                                     const unsigned int s,
+                                                     const CoeffType efficiency)
+  {
+    antioch_assert_less(s, _efficiencies.size());
+    _efficiencies[s] = efficiency;
+  }
+
+  template<typename CoeffType, typename FalloffType>
+  inline
+  CoeffType FalloffThreeBodyReaction<CoeffType,FalloffType>::efficiency( const unsigned int s ) const
+  {
+     antioch_assert_less(s, _efficiencies.size());
+     return _efficiencies[s];
+  }
+  
+} // namespace Antioch
+
+#endif // ANTIOCH_FALLOFF_REACTION_H

--- a/src/kinetics/include/antioch/falloff_threebody_reaction.h
+++ b/src/kinetics/include/antioch/falloff_threebody_reaction.h
@@ -125,19 +125,9 @@ namespace Antioch
     //! Return writeable reference to the falloff object
     FalloffType &F();
 
-    //!
-    void set_efficiency( const std::string &,
-                         const unsigned int s,
-                         const CoeffType efficiency);
-
-    //!
-    CoeffType efficiency( const unsigned int s ) const;
-
   protected:
 
     FalloffType _F;
-
-    std::vector<CoeffType> _efficiencies;
 
   };
 
@@ -153,8 +143,8 @@ namespace Antioch
      _F(n_species)
      
   {
-    _efficiencies.resize(n_species); 
-    std::fill (_efficiencies.begin(), _efficiencies.end(), 1.);
+    Reaction<CoeffType>::_efficiencies.resize(n_species); 
+    std::fill (Reaction<CoeffType>::_efficiencies.begin(), Reaction<CoeffType>::_efficiencies.end(), 1.);
   }
 
 
@@ -189,7 +179,7 @@ namespace Antioch
     StateType M = Antioch::zero_clone(T);
     for(unsigned int s = 0; s < molar_densities.size(); s++)
     {
-        M += _efficiencies[s] * molar_densities[s];
+        M += this->efficiency(s) * molar_densities[s];
     }
 
     return (*this->_forward_rate[0])(T) / (ant_pow(M,-1) + (*this->_forward_rate[0])(T) /(*this->_forward_rate[1])(T)) * 
@@ -206,7 +196,7 @@ namespace Antioch
                                                                                                  VectorStateType& dkfwd_dX) const 
   {
     //variables, k0,kinf and derivatives
-   StateType k0 = Antioch::zero_clone(T);
+    StateType k0 = Antioch::zero_clone(T);
     StateType dk0_dT = Antioch::zero_clone(T);
     StateType kinf = Antioch::zero_clone(T);
     StateType dkinf_dT = Antioch::zero_clone(T);
@@ -217,7 +207,7 @@ namespace Antioch
     StateType M = Antioch::zero_clone(T);
     for(unsigned int s = 0; s < molar_densities.size(); s++)
     {
-        M += _efficiencies[s] * molar_densities[s];
+        M += this->efficiency(s) * molar_densities[s];
     }
 
     //F
@@ -240,31 +230,12 @@ namespace Antioch
 //         = F * epsilon_i * kfwd / ([M] +  [M]^2 k0/kinf) + kfwd * dF_dX
     for(unsigned int ic = 0; ic < this->n_species(); ic++)
       {
-        dkfwd_dX[ic] = _efficiencies[ic] * ( f * kfwd / (M + ant_pow(M,2) * k0/kinf) + df_dX[ic] * kfwd );
+        dkfwd_dX[ic] = this->efficiency(ic) * ( f * kfwd / (M + ant_pow(M,2) * k0/kinf) + df_dX[ic] * kfwd );
       }
 
     kfwd *= f; //finalize
 
     return;
-  }
-
-
-  template<typename CoeffType, typename FalloffType>
-  inline
-  void FalloffThreeBodyReaction<CoeffType,FalloffType>::set_efficiency( const std::string &,
-                                                     const unsigned int s,
-                                                     const CoeffType efficiency)
-  {
-    antioch_assert_less(s, _efficiencies.size());
-    _efficiencies[s] = efficiency;
-  }
-
-  template<typename CoeffType, typename FalloffType>
-  inline
-  CoeffType FalloffThreeBodyReaction<CoeffType,FalloffType>::efficiency( const unsigned int s ) const
-  {
-     antioch_assert_less(s, _efficiencies.size());
-     return _efficiencies[s];
   }
   
 } // namespace Antioch

--- a/src/kinetics/include/antioch/falloff_threebody_reaction.h
+++ b/src/kinetics/include/antioch/falloff_threebody_reaction.h
@@ -43,7 +43,12 @@ namespace Antioch
   /*!\class FalloffThreeBodyReaction
   * Base class for falloff processes coupled with efficiencies
   *
-  * This class encapsulates a bastard between falloff and three-body reaction.
+  * This class encapsulates a model between falloff and three-body reaction.
+  *
+  * Sylvain: I strongly disapprove using this model, 
+  *   see section ``A twist in the physics: three-body falloff" in section 2.2.2 Kinetics computing
+  *   of the [model documentation](https://github.com/libantioch/model_doc).
+  *
   * It performs the common operations.
   * A falloff rate constant is defined by the equation
   * \f[

--- a/src/kinetics/include/antioch/lindemann_falloff.h
+++ b/src/kinetics/include/antioch/lindemann_falloff.h
@@ -53,21 +53,21 @@ namespace Antioch{
     LindemannFalloff(const unsigned int nspec);
     ~LindemannFalloff();
 
-    template <typename StateType, typename VectorStateType>
+    template <typename StateType>
     StateType value(const StateType &T,
-                    const VectorStateType &molar_densities,
+                    const StateType &M,
                     const StateType &k0, 
                     const StateType &kinf) const;
 
-    template <typename StateType, typename VectorStateType>
+    template <typename StateType>
     StateType operator()(const StateType &T,
-                         const VectorStateType &molar_densities,
+                         const StateType &M,
                          const StateType &k0, 
                          const StateType &kinf) const;
 
     template <typename StateType, typename VectorStateType>
     void F_and_derivatives(const StateType& T, 
-                           const VectorStateType &molar_densities,
+                           const StateType &M,
                            const StateType &k0, 
                            const StateType &dk0_dT, 
                            const StateType &kinf, 
@@ -82,11 +82,11 @@ namespace Antioch{
   };
 
   template<typename CoeffType>
-  template <typename StateType, typename VectorStateType>
+  template <typename StateType>
   inline
   StateType LindemannFalloff<CoeffType>::operator()
     (const StateType& T,
-     const VectorStateType& /* molar_densities */,
+     const StateType& /* M */,
      const StateType& /* k0 */,
      const StateType& /* kinf */) const
   {
@@ -94,11 +94,11 @@ namespace Antioch{
   }
 
   template<typename CoeffType>
-  template <typename StateType, typename VectorStateType>
+  template <typename StateType>
   inline
   StateType LindemannFalloff<CoeffType>::value
     (const StateType& T,
-     const VectorStateType& /* molar_densities */,
+     const StateType& /* M */,
      const StateType& /* k0 */,
      const StateType& /* kinf */) const
   {
@@ -110,7 +110,7 @@ namespace Antioch{
   inline
   void LindemannFalloff<CoeffType>::F_and_derivatives
     (const StateType& T,
-     const VectorStateType& /* molar_densities */,
+     const StateType& /* M */,
      const StateType& /* k0 */,
      const StateType& /* dk0_dT */,
      const StateType& /* kinf */,

--- a/src/kinetics/include/antioch/reaction.h
+++ b/src/kinetics/include/antioch/reaction.h
@@ -814,13 +814,13 @@ namespace Antioch
 
       case(ReactionType::LINDEMANN_FALLOFF_THREE_BODY):
         {
-          return (static_cast<const FalloffThreeBodyReaction<CoeffType,LindemannFalloff<CoeffType> >*>(this))->compute_forward_rate_coefficient(molar_densities,T);
+          return (static_cast<const FalloffThreeBodyReaction<CoeffType,LindemannFalloff<CoeffType> >*>(this))->compute_forward_rate_coefficient(molar_densities,conditions);
         }
         break;
 
       case(ReactionType::TROE_FALLOFF_THREE_BODY):
         {
-          return (static_cast<const FalloffThreeBodyReaction<CoeffType,TroeFalloff<CoeffType> >*>(this))->compute_forward_rate_coefficient(molar_densities,T);
+          return (static_cast<const FalloffThreeBodyReaction<CoeffType,TroeFalloff<CoeffType> >*>(this))->compute_forward_rate_coefficient(molar_densities,conditions);
         }
         break;
 
@@ -889,13 +889,13 @@ namespace Antioch
 
       case(ReactionType::LINDEMANN_FALLOFF_THREE_BODY):
         {
-          (static_cast<const FalloffThreeBodyReaction<CoeffType,LindemannFalloff<CoeffType> >*>(this))->compute_forward_rate_coefficient_and_derivatives(molar_densities,T,kfwd,dkfwd_dT,dkfwd_dX);
+          (static_cast<const FalloffThreeBodyReaction<CoeffType,LindemannFalloff<CoeffType> >*>(this))->compute_forward_rate_coefficient_and_derivatives(molar_densities,conditions,kfwd,dkfwd_dT,dkfwd_dX);
         }
         break;
 
       case(ReactionType::TROE_FALLOFF_THREE_BODY):
         {
-          (static_cast<const FalloffThreeBodyReaction<CoeffType,TroeFalloff<CoeffType> >*>(this))->compute_forward_rate_coefficient_and_derivatives(molar_densities,T,kfwd,dkfwd_dT,dkfwd_dX);
+          (static_cast<const FalloffThreeBodyReaction<CoeffType,TroeFalloff<CoeffType> >*>(this))->compute_forward_rate_coefficient_and_derivatives(molar_densities,conditions,kfwd,dkfwd_dT,dkfwd_dX);
         }
         break;
 

--- a/src/kinetics/include/antioch/reaction.h
+++ b/src/kinetics/include/antioch/reaction.h
@@ -338,6 +338,9 @@ namespace Antioch
     //! The forward reaction rate modified Arrhenius form.
     std::vector<KineticsType<CoeffType,VectorCoeffType>* > _forward_rate;
 
+    //! efficiencies for three body reactions
+    std::vector<CoeffType> _efficiencies;
+
   private:
     Reaction();
 
@@ -557,40 +560,12 @@ namespace Antioch
 
   template<typename CoeffType, typename VectorCoeffType>
   inline
-  void Reaction<CoeffType,VectorCoeffType>::set_efficiency (const std::string & useless, //? where does that come from?
+  void Reaction<CoeffType,VectorCoeffType>::set_efficiency (const std::string & , //? where does that come from?
                                             const unsigned int s,
                                             const CoeffType efficiency)
   {
-    antioch_assert_less(s, this->n_species());
-    switch(_type) 
-    {
-      case ReactionType::THREE_BODY:
-      {
-        static_cast<ThreeBodyReaction<CoeffType>* >(this)->set_efficiency(useless,s,efficiency);
-      }
-      break;
-
-      case ReactionType::LINDEMANN_FALLOFF_THREE_BODY:
-      {
-        (static_cast<FalloffThreeBodyReaction<CoeffType,LindemannFalloff<CoeffType> >*>(this))->set_efficiency(useless,s,efficiency);
-      }
-      break;
-
-      case ReactionType::TROE_FALLOFF_THREE_BODY:
-      {
-        (static_cast<FalloffThreeBodyReaction<CoeffType,TroeFalloff<CoeffType> >*>(this))->set_efficiency(useless,s,efficiency);
-      }
-      break;
-
-      default:
-      {
-        std::cerr << "This model do not include efficiencies: " << _type << std::endl;
-        antioch_assert(0); //so it will not necessarily crash
-      }
-      break;
-
-    }
-    return;
+    antioch_assert_less(s, _efficiencies.size());
+    _efficiencies[s] = efficiency;
   }
 
   template<typename CoeffType, typename VectorCoeffType>
@@ -598,35 +573,8 @@ namespace Antioch
   CoeffType Reaction<CoeffType,VectorCoeffType>::efficiency( const unsigned int s ) const
   {
     
-    switch(_type) 
-    {
-      case ReactionType::THREE_BODY:
-      {
-        return static_cast<const ThreeBodyReaction<CoeffType>* >(this)->efficiency(s);
-      }
-      break;
-
-      case ReactionType::LINDEMANN_FALLOFF_THREE_BODY:
-      {
-        return (static_cast<const FalloffThreeBodyReaction<CoeffType,LindemannFalloff<CoeffType> >*>(this))->efficiency(s);
-      }
-      break;
-
-      case ReactionType::TROE_FALLOFF_THREE_BODY:
-      {
-        return (static_cast<const FalloffThreeBodyReaction<CoeffType,TroeFalloff<CoeffType> >*>(this))->efficiency(s);
-      }
-      break;
-
-      default:
-      {
-        std::cerr << "This model do not include efficiencies: " << _type << std::endl;
-        antioch_assert(0); //so it will not necessarily crash
-      }
-      break;
-
-    }
-    return CoeffType(0.); // keep compiler happy
+    antioch_assert(s < _efficiencies.size()); 
+    return _efficiencies[s];
   }
 
   template<typename CoeffType, typename VectorCoeffType>

--- a/src/kinetics/include/antioch/reaction.h
+++ b/src/kinetics/include/antioch/reaction.h
@@ -761,7 +761,9 @@ namespace Antioch
         os << "\n#   forward rate eqn: " << *_forward_rate[ir];
       }
 
-    if (_type == ReactionType::THREE_BODY)
+    if (_type == ReactionType::THREE_BODY ||
+        _type == ReactionType::LINDEMANN_FALLOFF_THREE_BODY ||
+        _type == ReactionType::TROE_FALLOFF_THREE_BODY)
       {
         os << "\n#   efficiencies: ";
         for (unsigned int s=0; s<this->n_species(); s++)

--- a/src/kinetics/include/antioch/reaction.h
+++ b/src/kinetics/include/antioch/reaction.h
@@ -323,7 +323,9 @@ namespace Antioch
     std::vector<unsigned int> _product_ids;
     std::vector<unsigned int> _reactant_stoichiometry;
     std::vector<unsigned int> _product_stoichiometry;
-    std::vector<CoeffType> _efficiencies;
+    std::vector<unsigned int> _species_reactant_stoichiometry;
+    std::vector<unsigned int> _species_product_stoichiometry;
+    std::vector<int>          _species_delta_stoichiometry;
     int _gamma;
     bool _initialized;
     bool _reversible;
@@ -552,14 +554,13 @@ namespace Antioch
 
   template<typename CoeffType, typename VectorCoeffType>
   inline
-  void Reaction<CoeffType,VectorCoeffType>::set_efficiency (const std::string &,
+  void Reaction<CoeffType,VectorCoeffType>::set_efficiency (const std::string & useless, //? where does that come from?
                                             const unsigned int s,
                                             const CoeffType efficiency)
   {
     antioch_assert_less(s, this->n_species());
-    antioch_assert_less(s, _efficiencies.size());
     antioch_assert_equal_to(_type, ReactionType::THREE_BODY);
-    _efficiencies[s] = efficiency;
+    static_cast<ThreeBodyReaction<CoeffType>* >(this)->set_efficiency(useless,s,efficiency);
     return;
   }
 
@@ -567,9 +568,8 @@ namespace Antioch
   inline
   CoeffType Reaction<CoeffType,VectorCoeffType>::efficiency( const unsigned int s ) const
   {
-    antioch_assert_less(s, _efficiencies.size());
     antioch_assert_equal_to(_type, ReactionType::THREE_BODY);
-    return _efficiencies[s];
+    return static_cast<const ThreeBodyReaction<CoeffType>* >(this)->efficiency(s);
   }
 
   template<typename CoeffType, typename VectorCoeffType>
@@ -611,8 +611,7 @@ namespace Antioch
       _type(type),
       _kintype(kin)
   {
-    _efficiencies.resize(_n_species); 
-    std::fill (_efficiencies.begin(), _efficiencies.end(), 1.);
+     return;
   }
 
 

--- a/src/kinetics/include/antioch/reaction_enum.h
+++ b/src/kinetics/include/antioch/reaction_enum.h
@@ -41,9 +41,6 @@ namespace Antioch
                         THREE_BODY, 
                         LINDEMANN_FALLOFF,
                         TROE_FALLOFF,
-// I'm crying inside... This is to support the
-// alliance of efficiencies and pressure dependance
-// I'm really unhappy about this...
                         LINDEMANN_FALLOFF_THREE_BODY,
                         TROE_FALLOFF_THREE_BODY};
 

--- a/src/kinetics/include/antioch/reaction_enum.h
+++ b/src/kinetics/include/antioch/reaction_enum.h
@@ -40,7 +40,12 @@ namespace Antioch
                         DUPLICATE,
                         THREE_BODY, 
                         LINDEMANN_FALLOFF,
-                        TROE_FALLOFF};
+                        TROE_FALLOFF,
+// I'm crying inside... This is to support the
+// alliance of efficiencies and pressure dependance
+// I'm really unhappy about this...
+                        LINDEMANN_FALLOFF_THREE_BODY,
+                        TROE_FALLOFF_THREE_BODY};
 
   } // end namespace ReactionType
 

--- a/src/kinetics/include/antioch/reaction_parsing.h
+++ b/src/kinetics/include/antioch/reaction_parsing.h
@@ -38,6 +38,7 @@
 #include "antioch/duplicate_reaction.h"
 #include "antioch/threebody_reaction.h"
 #include "antioch/falloff_reaction.h"
+#include "antioch/falloff_threebody_reaction.h"
 
 namespace Antioch
 {
@@ -86,6 +87,16 @@ namespace Antioch
       case(ReactionType::TROE_FALLOFF):
         {
           reaction = new FalloffReaction<CoeffType,TroeFalloff<CoeffType> >(n_species,equation,reversible,type,kin);
+        }
+        break;
+
+      case(ReactionType::LINDEMANN_FALLOFF_THREE_BODY):
+        {
+          reaction = new FalloffThreeBodyReaction<CoeffType,LindemannFalloff<CoeffType> >(n_species,equation,reversible,type,kin);
+        }
+      case(ReactionType::TROE_FALLOFF_THREE_BODY):
+        {
+          reaction = new FalloffThreeBodyReaction<CoeffType,TroeFalloff<CoeffType> >(n_species,equation,reversible,type,kin);
         }
         break;
 

--- a/src/kinetics/include/antioch/reaction_set.h
+++ b/src/kinetics/include/antioch/reaction_set.h
@@ -39,6 +39,7 @@
 #include "antioch/duplicate_reaction.h"
 #include "antioch/threebody_reaction.h"
 #include "antioch/falloff_reaction.h"
+#include "antioch/falloff_threebody_reaction.h"
 #include "antioch/lindemann_falloff.h"
 #include "antioch/troe_falloff.h"
 

--- a/src/kinetics/include/antioch/threebody_reaction.h
+++ b/src/kinetics/include/antioch/threebody_reaction.h
@@ -90,18 +90,6 @@ namespace Antioch
                                                            StateType& dkfwd_dT, 
                                                            VectorStateType& dkfwd_dX) const;
 
-    //!
-    void set_efficiency( const std::string &,
-                         const unsigned int s,
-                         const CoeffType efficiency);
-
-    //!
-    CoeffType efficiency( const unsigned int s ) const;
-
-  private:
-
-    std::vector<CoeffType> _efficiencies;
-    
   };
 
   /* ------------------------- Inline Functions -------------------------*/
@@ -113,8 +101,8 @@ namespace Antioch
                                                    const KineticsModel::KineticsModel kin) 
     :Reaction<CoeffType>(n_species,equation,reversible,ReactionType::THREE_BODY,kin)
   {
-    _efficiencies.resize(n_species); 
-    std::fill (_efficiencies.begin(), _efficiencies.end(), 1.);
+    Reaction<CoeffType>::_efficiencies.resize(n_species); 
+    std::fill (Reaction<CoeffType>::_efficiencies.begin(), Reaction<CoeffType>::_efficiencies.end(), 1.);
     return;
   }
 
@@ -181,24 +169,6 @@ namespace Antioch
     return;
   }
 
-  template <typename CoeffType>
-  inline
-  void ThreeBodyReaction<CoeffType>::set_efficiency( const std::string &,
-                                                     const unsigned int s,
-                                                     const CoeffType efficiency)
-  {
-    antioch_assert_less(s, _efficiencies.size());
-    _efficiencies[s] = efficiency;
-  }
-
-  template <typename CoeffType>
-  inline
-  CoeffType ThreeBodyReaction<CoeffType>::efficiency( const unsigned int s ) const
-  {
-     antioch_assert_less(s, _efficiencies.size());
-     return _efficiencies[s];
-  }
-  
 } // namespace Antioch
 
 #endif // ANTIOCH_ELEMENTARY_REACTION_H

--- a/src/kinetics/include/antioch/threebody_reaction.h
+++ b/src/kinetics/include/antioch/threebody_reaction.h
@@ -90,7 +90,17 @@ namespace Antioch
                                                            StateType& dkfwd_dT, 
                                                            VectorStateType& dkfwd_dX) const;
 
+    //!
+    void set_efficiency( const std::string &,
+                         const unsigned int s,
+                         const CoeffType efficiency);
+
+    //!
+    CoeffType efficiency( const unsigned int s ) const;
+
   private:
+
+    std::vector<CoeffType> _efficiencies;
     
   };
 
@@ -103,6 +113,8 @@ namespace Antioch
                                                    const KineticsModel::KineticsModel kin) 
     :Reaction<CoeffType>(n_species,equation,reversible,ReactionType::THREE_BODY,kin)
   {
+    _efficiencies.resize(n_species); 
+    std::fill (_efficiencies.begin(), _efficiencies.end(), 1.);
     return;
   }
 
@@ -167,6 +179,24 @@ namespace Antioch
       }
 
     return;
+  }
+
+  template <typename CoeffType>
+  inline
+  void ThreeBodyReaction<CoeffType>::set_efficiency( const std::string &,
+                                                     const unsigned int s,
+                                                     const CoeffType efficiency)
+  {
+    antioch_assert_less(s, _efficiencies.size());
+    _efficiencies[s] = efficiency;
+  }
+
+  template <typename CoeffType>
+  inline
+  CoeffType ThreeBodyReaction<CoeffType>::efficiency( const unsigned int s ) const
+  {
+     antioch_assert_less(s, _efficiencies.size());
+     return _efficiencies[s];
   }
   
 } // namespace Antioch

--- a/src/kinetics/include/antioch/troe_falloff.h
+++ b/src/kinetics/include/antioch/troe_falloff.h
@@ -216,7 +216,7 @@ namespace Antioch
     // n = 0.75 - 1.27 * log10(Fcent)
     // Note log10(x) = (1.0/log(10))*log(x)
     ANTIOCH_AUTO(StateType) n = CoeffType(0.75L) - _n_coeff * logFcent;
-    ANTIOCH_AUTO(StateType) d = constant_clone(T,0.14L);
+    ANTIOCH_AUTO(StateType) d = constant_clone(T,CoeffType(0.14L));
 
     StateType log10Pr = Constants::log10_to_log<CoeffType>() * ant_log(Pr);
 

--- a/src/kinetics/include/antioch/troe_falloff.h
+++ b/src/kinetics/include/antioch/troe_falloff.h
@@ -297,7 +297,7 @@ namespace Antioch
     // Compute log(Fcent) once
     StateType logFcent = ant_log(Fcent);
     // n and c and derivatives
-    StateType  d = Antioch::constant_clone(T, 0.14L);
+    StateType  d = Antioch::constant_clone(T, CoeffType(0.14L));
     StateType  c = - CoeffType(0.4L) - _c_coeff * logFcent;
     StateType  n = CoeffType(0.75L) - _n_coeff * logFcent;
     StateType dc_dT = - _c_coeff * dFcent_dT/Fcent;

--- a/src/kinetics/include/antioch/troe_falloff.h
+++ b/src/kinetics/include/antioch/troe_falloff.h
@@ -211,11 +211,11 @@ namespace Antioch
     ANTIOCH_AUTO(StateType) Pr = M * k0/kinf;
     // c = -0.4 - 0.67 * log10(Fcent)
     // Note log10(x) = (1.0/log(10))*log(x)
-    StateType  c = - CoeffType(0.4L) - _c_coeff*logFcent;
+    StateType  c = - CoeffType(0.4L) - _c_coeff * logFcent;
 
     // n = 0.75 - 1.27 * log10(Fcent)
     // Note log10(x) = (1.0/log(10))*log(x)
-    ANTIOCH_AUTO(StateType) n = CoeffType(0.75L) - _n_coeff*logFcent;
+    ANTIOCH_AUTO(StateType) n = CoeffType(0.75L) - _n_coeff * logFcent;
     ANTIOCH_AUTO(StateType) d = constant_clone(T,0.14L);
 
     StateType log10Pr = Constants::log10_to_log<CoeffType>() * ant_log(Pr);
@@ -338,8 +338,8 @@ namespace Antioch
     _T3(T3),
     _T1(T1),
     _T2(T2),
-    _c_coeff( 0.67L * Constants::log10_to_log<CoeffType>() ),
-    _n_coeff( 1.27L * Constants::log10_to_log<CoeffType>() )
+    _c_coeff( CoeffType(0.67L) * Constants::log10_to_log<CoeffType>() ),
+    _n_coeff( CoeffType(1.27L) * Constants::log10_to_log<CoeffType>() )
   {
     return;
   }

--- a/src/kinetics/include/antioch/troe_falloff.h
+++ b/src/kinetics/include/antioch/troe_falloff.h
@@ -109,8 +109,8 @@ namespace Antioch
   class TroeFalloff
   {
   public:
-    TroeFalloff(const unsigned int nspec, const CoeffType alpha=0.,
-                const CoeffType T3 = 0., const CoeffType T1 = 0.,
+    TroeFalloff(const unsigned int nspec, const CoeffType alpha=0,
+                const CoeffType T3 = 0, const CoeffType T1 = 0,
                 const CoeffType T2 = 1e50);
 
     ~TroeFalloff();
@@ -211,19 +211,19 @@ namespace Antioch
     ANTIOCH_AUTO(StateType) Pr = M * k0/kinf;
     // c = -0.4 - 0.67 * log10(Fcent)
     // Note log10(x) = (1.0/log(10))*log(x)
-    StateType  c = - 0.4L - _c_coeff*logFcent;
+    StateType  c = - CoeffType(0.4L) - _c_coeff*logFcent;
 
     // n = 0.75 - 1.27 * log10(Fcent)
     // Note log10(x) = (1.0/log(10))*log(x)
-    ANTIOCH_AUTO(StateType) n = 0.75L - _n_coeff*logFcent;
-    ANTIOCH_AUTO(StateType) d = Antioch::constant_clone(T, 0.14);
+    ANTIOCH_AUTO(StateType) n = CoeffType(0.75L) - _n_coeff*logFcent;
+    ANTIOCH_AUTO(StateType) d = constant_clone(T,0.14L);
 
     StateType log10Pr = Constants::log10_to_log<CoeffType>() * ant_log(Pr);
 
     //log10F =  log10(Fcent) / [1+((log10(Pr) + c)/(n - d*(log10(Pr) + c) ))^2]
     //logF =  log(Fcent) / [1+((log10(Pr) + c)/(n - d*(log10(Pr) + c) ))^2]
     ANTIOCH_AUTO(StateType) logF =
-      logFcent/(1.L + ant_pow(((log10Pr + c)/(n - d*(log10Pr + c) )),2) );
+      logFcent/(1 + ant_pow(((log10Pr + c)/(n - d*(log10Pr + c) )),2) );
 
     return ant_exp(logF);
   }
@@ -236,7 +236,7 @@ namespace Antioch
   {
      
     // Fcent = (1.-alpha)*exp(-T/T***) + alpha * exp(-T/T*) + exp(-T**/T)
-    StateType Fc = (1.L - _alpha) * ant_exp(-T/_T3) + _alpha * ant_exp(-T/_T1);
+    StateType Fc = (1 - _alpha) * ant_exp(-T/_T3) + _alpha * ant_exp(-T/_T1);
 
     if(_T2 != 1e50)Fc += ant_exp(-_T2/T);
 
@@ -250,8 +250,8 @@ namespace Antioch
   {
     
     // Fcent = (1.-alpha)*exp(-T/T***) + alpha * exp(-T/T*) + exp(-T**/T)
-    Fc = (1.L - _alpha) * ant_exp(-T/_T3) + _alpha * ant_exp(-T/_T1);
-    dFc_dT = (_alpha - 1.L)/_T3 * ant_exp(-T/_T3) - _alpha/_T1 * ant_exp(-T/_T1);
+    Fc = (1 - _alpha) * ant_exp(-T/_T3) + _alpha * ant_exp(-T/_T1);
+    dFc_dT = (_alpha - 1)/_T3 * ant_exp(-T/_T3) - _alpha/_T1 * ant_exp(-T/_T1);
 
     if(_T2 != 1e50)
       {
@@ -298,24 +298,24 @@ namespace Antioch
     StateType logFcent = ant_log(Fcent);
     // n and c and derivatives
     StateType  d = Antioch::constant_clone(T, 0.14L);
-    StateType  c = - 0.4L - _c_coeff * logFcent;
-    StateType  n = 0.75L - _n_coeff * logFcent;
+    StateType  c = - CoeffType(0.4L) - _c_coeff * logFcent;
+    StateType  n = CoeffType(0.75L) - _n_coeff * logFcent;
     StateType dc_dT = - _c_coeff * dFcent_dT/Fcent;
     ANTIOCH_AUTO(StateType) dn_dT = - _n_coeff * dFcent_dT/Fcent;
 
     //log10F
-    StateType logF = logFcent/(1.L + ant_pow(((log10Pr + c)/(n - d*(log10Pr + c) )),2));
+    StateType logF = logFcent/(1 + ant_pow(((log10Pr + c)/(n - d*(log10Pr + c) )),2));
     StateType dlogF_dT = logF * (dlog10Fcent_dT / Fcent 
-                                     - 2.L * ant_pow((log10Pr + c)/(n - d * (log10Pr + c)),2)
+                                     - 2 * ant_pow((log10Pr + c)/(n - d * (log10Pr + c)),2)
                                        * ((dlog10Pr_dT + dc_dT)/(log10Pr + c) -
                                           (dn_dT - d * (dlog10Pr_dT + dc_dT))/(n - d * (log10Pr + c))
                                          )
-                                       / (1.L + ant_pow((log10Pr + c)/(n - d * (log10Pr + c)),2))
+                                       / (1 + ant_pow((log10Pr + c)/(n - d * (log10Pr + c)),2))
                                     );
     VectorStateType dlogF_dX = Antioch::zero_clone(dF_dX);
     for(unsigned int ip = 0; ip < dlog10Pr_dX.size(); ip++)
       {//dlogF_dX = - logF^2/log(Fcent) * dlog10Pr_dX * (1 - 1/(n - d * (log10Pr + c))) * (log10Pr + c)
-        dlogF_dX[ip] = - ant_pow(logF,2)/logFcent * dlog10Pr_dX[ip] *(1.L - 1.L/(n - d * (log10Pr + c))) * (log10Pr + c);
+        dlogF_dX[ip] = - ant_pow(logF,2)/logFcent * dlog10Pr_dX[ip] *(1 - 1/(n - d * (log10Pr + c))) * (log10Pr + c);
       }
 
     F = ant_exp(logF);
@@ -338,8 +338,8 @@ namespace Antioch
     _T3(T3),
     _T1(T1),
     _T2(T2),
-    _c_coeff( 0.67L*Constants::log10_to_log<CoeffType>() ),
-    _n_coeff( 1.27L*Constants::log10_to_log<CoeffType>() )
+    _c_coeff( 0.67L * Constants::log10_to_log<CoeffType>() ),
+    _n_coeff( 1.27L * Constants::log10_to_log<CoeffType>() )
   {
     return;
   }

--- a/src/parsing/include/antioch/chemkin_parser.h
+++ b/src/parsing/include/antioch/chemkin_parser.h
@@ -553,7 +553,7 @@ namespace Antioch{
   inline
   bool ChemKinParser<NumericType>::Troe() const
   {
-      return (_chemical_process.find("TroeFalloff"));
+      return (_chemical_process.find("TroeFalloff") != std::string::npos);
   }
 
   template <typename NumericType>

--- a/src/parsing/include/antioch/chemkin_parser.h
+++ b/src/parsing/include/antioch/chemkin_parser.h
@@ -553,7 +553,7 @@ namespace Antioch{
   inline
   bool ChemKinParser<NumericType>::Troe()
   {
-      return (_chemical_process == "TroeFalloff");
+      return (_chemical_process.find("TroeFalloff"));
   }
 
   template <typename NumericType>
@@ -744,7 +744,7 @@ namespace Antioch{
     alpha_unit = _default_unit.at(ParsingKey::TROE_F_ALPHA);
     def_unit = alpha_unit;
     
-    return (_chemical_process == "TroeFalloff");
+    return this->Troe();
   }
 
   template <typename NumericType>
@@ -755,7 +755,7 @@ namespace Antioch{
     T1_unit = _default_unit.at(ParsingKey::TROE_F_TS);
     def_unit = T1_unit;
 
-    return (_chemical_process == "TroeFalloff");
+    return this->Troe();
   }
 
   template <typename NumericType>
@@ -777,7 +777,7 @@ namespace Antioch{
     T3_unit = _default_unit.at(ParsingKey::TROE_F_TSSS);
     def_unit = T3_unit;
 
-    return (_chemical_process == "TroeFalloff");
+    return this->Troe();
   }
 
   template <typename NumericType>
@@ -808,7 +808,8 @@ namespace Antioch{
         _duplicate_process = true;
      }else if(line.find(_spec.parser()) != std::string::npos) // "/"
      {
-        if(_chemical_process.find("Falloff") != std::string::npos)_chemical_process += "ThreeBody";
+        if(_chemical_process.find("Falloff") != std::string::npos && 
+           _chemical_process.find("ThreeBody") == std::string::npos)_chemical_process += "ThreeBody";
         this->parse_coefficients_line(line);
      }else
      {

--- a/src/parsing/include/antioch/chemkin_parser.h
+++ b/src/parsing/include/antioch/chemkin_parser.h
@@ -808,6 +808,7 @@ namespace Antioch{
         _duplicate_process = true;
      }else if(line.find(_spec.parser()) != std::string::npos) // "/"
      {
+        if(_chemical_process.find("Falloff") != std::string::npos)_chemical_process += "ThreeBody";
         this->parse_coefficients_line(line);
      }else
      {
@@ -914,7 +915,7 @@ namespace Antioch{
         }else if(out[i] == _spec.symbol().at(ChemKinDefinitions::TB))
         {
            if(_chemical_process.find("Falloff") != std::string::npos)
-                      antioch_parsing_error("ChemKin parser: it seems you want both a falloff and a three-body reaction:\n" + equation);
+                     std::cerr << "WARNING: ChemKin parser: it seems you want both a falloff and a three-body reaction in your equation:\n" << equation << std::endl;
 
            _chemical_process = "ThreeBody";
 
@@ -944,7 +945,7 @@ namespace Antioch{
      bool real(false);
      for(unsigned int i = 0; i < _reactants.size(); i++)
      {
-        if(this->after_coma_digits((_reactants[i].second)))
+        if(this->after_coma_digits(_reactants[i].second))
         {
            real = true;
            break;
@@ -1033,7 +1034,7 @@ namespace Antioch{
 
         _nrates++;
          
-      }else if(_chemical_process == "ThreeBody")// efficiencies
+      }else if(_chemical_process.find("ThreeBody") != std::string::npos)// efficiencies
  // in case it is superfluous (or we need to redesign pressure-dependance)
       {
         for(unsigned int i = 0; i < out.size(); i++)

--- a/src/parsing/include/antioch/chemkin_parser.h
+++ b/src/parsing/include/antioch/chemkin_parser.h
@@ -130,7 +130,7 @@ namespace Antioch{
          bool rate_constant(const std::string & /* kinetics_model */);
 
          /*! return true if there's a Troe block*/
-         bool Troe();
+         bool Troe() const;
 
          /*! return reaction id, 0 if not provided*/
          const std::string reaction_id() const;
@@ -551,7 +551,7 @@ namespace Antioch{
 
   template <typename NumericType>
   inline
-  bool ChemKinParser<NumericType>::Troe()
+  bool ChemKinParser<NumericType>::Troe() const
   {
       return (_chemical_process.find("TroeFalloff"));
   }

--- a/src/parsing/include/antioch/read_reaction_set_data.h
+++ b/src/parsing/include/antioch/read_reaction_set_data.h
@@ -276,12 +276,14 @@ namespace Antioch
     models.push_back("photochemistry");
 
     std::map<std::string,ReactionType::ReactionType> proc_keyword;
-    proc_keyword["Elementary"]        = ReactionType::ELEMENTARY;
-    proc_keyword["Duplicate"]         = ReactionType::DUPLICATE;
-    proc_keyword["ThreeBody"]         = ReactionType::THREE_BODY;
-    proc_keyword["threeBody"]         = ReactionType::THREE_BODY; // Cantera/backward compatiblity
-    proc_keyword["LindemannFalloff"]  = ReactionType::LINDEMANN_FALLOFF;
-    proc_keyword["TroeFalloff"]       = ReactionType::TROE_FALLOFF;
+    proc_keyword["Elementary"]                 = ReactionType::ELEMENTARY;
+    proc_keyword["Duplicate"]                  = ReactionType::DUPLICATE;
+    proc_keyword["ThreeBody"]                  = ReactionType::THREE_BODY;
+    proc_keyword["threeBody"]                  = ReactionType::THREE_BODY; // Cantera/backward compatiblity
+    proc_keyword["LindemannFalloff"]           = ReactionType::LINDEMANN_FALLOFF;
+    proc_keyword["TroeFalloff"]                = ReactionType::TROE_FALLOFF;
+    proc_keyword["LindemannFalloffThreeBody"]  = ReactionType::LINDEMANN_FALLOFF_THREE_BODY;
+    proc_keyword["TroeFalloffThreeBody"]       = ReactionType::TROE_FALLOFF_THREE_BODY;
 
     while (parser->reaction())
       {
@@ -303,6 +305,8 @@ namespace Antioch
                           << "  ThreeBody\n"
                           << "  LindemannFalloff\n"
                           << "  TroeFalloff\n" 
+                          << "  LindemannFalloffThreeBody\n"
+                          << "  TroeFalloffThreeBody\n" 
                           << "See Antioch documentation for more details."
                           << std::endl;
                 antioch_not_implemented();
@@ -430,7 +434,9 @@ namespace Antioch
           if(my_rxn->type() == ReactionType::THREE_BODY)pow_unit++;
           //falloff for k0
           if(my_rxn->type() == ReactionType::LINDEMANN_FALLOFF ||
-             my_rxn->type() == ReactionType::TROE_FALLOFF)
+             my_rxn->type() == ReactionType::TROE_FALLOFF      ||
+             my_rxn->type() == ReactionType::LINDEMANN_FALLOFF_THREE_BODY ||
+             my_rxn->type() == ReactionType::TROE_FALLOFF_THREE_BODY)
           {
              //k0 is either determined by an explicit name, or is the first of unnamed rate constants
              if(parser->is_k0(my_rxn->n_rate_constants(),reading_kinetics_model))pow_unit++;
@@ -690,8 +696,10 @@ namespace Antioch
         // the first rate constant encountered is the low limit,
         // so we need to change something only if the second rate constant has a "name" attribute
         // of value "k0"
-        if(my_rxn->type() == ReactionType::LINDEMANN_FALLOFF ||
-           my_rxn->type() == ReactionType::TROE_FALLOFF)
+        if(my_rxn->type() == ReactionType::LINDEMANN_FALLOFF            ||
+           my_rxn->type() == ReactionType::TROE_FALLOFF                 ||
+           my_rxn->type() == ReactionType::LINDEMANN_FALLOFF_THREE_BODY ||
+           my_rxn->type() == ReactionType::TROE_FALLOFF_THREE_BODY)
         {
            antioch_assert_equal_to(my_rxn->n_rate_constants(),2);
            if(parser->where_is_k0(reading_kinetics_model) == 1) // second given is k0
@@ -705,7 +713,9 @@ namespace Antioch
         //efficiencies are only for three body reactions
         if(parser->efficiencies(efficiencies))
           {
-             antioch_assert_equal_to (ReactionType::THREE_BODY, my_rxn->type());
+             antioch_assert(ReactionType::THREE_BODY == my_rxn->type()                   || 
+                            ReactionType::LINDEMANN_FALLOFF_THREE_BODY == my_rxn->type() || 
+                            ReactionType::TROE_FALLOFF_THREE_BODY == my_rxn->type());
 
              for(unsigned int p = 0; p < efficiencies.size(); p++)
                {
@@ -728,7 +738,9 @@ namespace Antioch
         //F parameters only for Troe falloff
         if(parser->Troe())
         {
-           antioch_assert_equal_to (ReactionType::TROE_FALLOFF, my_rxn->type());
+           antioch_assert(ReactionType::TROE_FALLOFF == my_rxn->type() ||
+                          ReactionType::TROE_FALLOFF_THREE_BODY == my_rxn->type());
+
            FalloffReaction<NumericType,TroeFalloff<NumericType> > *my_fall_rxn =
                 static_cast<FalloffReaction<NumericType,TroeFalloff<NumericType> > *> (my_rxn);
 

--- a/src/thermal_conduction/include/antioch/kinetics_theory_thermal_conductivity.h
+++ b/src/thermal_conduction/include/antioch/kinetics_theory_thermal_conductivity.h
@@ -109,10 +109,10 @@ namespace Antioch{
   KineticsTheoryThermalConductivity<ThermoEvaluator,CoeffType>::KineticsTheoryThermalConductivity(const ThermoEvaluator & t, const CoeffType & Z_298K, const CoeffType & LJ_depth):
         _thermo(t),
         _rot(Z_298K,LJ_depth),
-        five_over_two(5.L/2.L),
-        five_over_three(5.L/3.L),
-        two_over_pi(2.L/Constants::pi<CoeffType>()),
-        one(1.L)
+        five_over_two(CoeffType(5)/CoeffType(2)),
+        five_over_three(CoeffType(5)/CoeffType(3)),
+        two_over_pi(2/Constants::pi<CoeffType>()),
+        one(1)
   {
       return;
   }

--- a/src/thermal_conduction/include/antioch/rotational_relaxation.h
+++ b/src/thermal_conduction/include/antioch/rotational_relaxation.h
@@ -44,10 +44,12 @@ namespace Antioch
 
         void reset_coeffs(const CoeffType & rot, const CoeffType & depth);
 
+        // \todo
+        // cache _eps_kb / 298
         template <typename StateType>
         ANTIOCH_AUTO(StateType)
           operator()(const StateType & T) const
-        ANTIOCH_AUTOFUNC(StateType, _z_298 * this->F(_eps_kb/CoeffType(298.L)) / this->F(StateType(_eps_kb/T)))
+        ANTIOCH_AUTOFUNC(StateType, _z_298 * this->F(_eps_kb / 298) / this->F(StateType(_eps_kb/T)))
 
         //!
         const CoeffType & Z_298() const;
@@ -76,10 +78,10 @@ namespace Antioch
   RotationalRelaxation<CoeffType>::RotationalRelaxation(const CoeffType & z_298, const CoeffType & eps_kb):
                 _z_298(z_298),
                 _eps_kb(eps_kb),
-                _one((CoeffType)1.L),
-                _pi32_2(ant_pow(Constants::pi<CoeffType>(),1.5) / 2.L),
-                _pi2_4_plus_2(Constants::pi<CoeffType>() * Constants::pi<CoeffType>() / 4.L + 2.L),
-                _pi32(ant_pow(Constants::pi<CoeffType>(),1.5))
+                _one(1),
+                _pi32_2(ant_pow(Constants::pi<CoeffType>(),CoeffType(1.5)) / 2),
+                _pi2_4_plus_2(Constants::pi<CoeffType>() * Constants::pi<CoeffType>() / 4 + 2),
+                _pi32(ant_pow(Constants::pi<CoeffType>(),CoeffType(1.5)))
   {
      return;
   }

--- a/src/viscosity/include/antioch/kinetics_theory_viscosity.h
+++ b/src/viscosity/include/antioch/kinetics_theory_viscosity.h
@@ -174,8 +174,8 @@ namespace Antioch
         _mass(mass),
         _delta_star(CoeffType(1e-7) * ant_pow(Constants::light_celerity<CoeffType>(),2) * // * 1/(4*pi * eps_0) = 10^-7 * c^2
                     ant_pow(_dipole_moment * Units<CoeffType>("D").get_SI_factor(),2) /             
-                     ( _LJ.depth() * Constants::Boltzmann_constant<CoeffType>() * CoeffType(2.L) * ant_pow(_LJ.diameter() * Units<CoeffType>("ang").get_SI_factor(),3) )),
-        _a(0.3125e-14L * ant_sqrt(CoeffType(1e28) * Constants::Boltzmann_constant<CoeffType>() * _mass / Constants::pi<CoeffType>())
+                     ( _LJ.depth() * Constants::Boltzmann_constant<CoeffType>() * 2 * ant_pow(_LJ.diameter() * Units<CoeffType>("ang").get_SI_factor(),3) )),
+        _a(CoeffType(0.3125e-14L) * ant_sqrt(CoeffType(1e28) * Constants::Boltzmann_constant<CoeffType>() * _mass / Constants::pi<CoeffType>())
                 / (ant_pow(_LJ.diameter() * Units<CoeffType>("ang").get_SI_factor(),2))  
           ) /* 5 / 16 * sqrt(pi * Boltzmann constant/pi) / (sigma^2) 
                 ~ 10^-14 float can't take 10^-28 in sqrt*/
@@ -199,8 +199,8 @@ namespace Antioch
         _mass(coeffs[3]),
         _delta_star(CoeffType(1e-7) * ant_pow(Constants::light_celerity<CoeffType>(),2) * // * 1/(4*pi * eps_0) = 10^-7 * c^2
                     ant_pow(_dipole_moment * Units<CoeffType>("D").get_SI_factor(),2) /             
-                     ( _LJ.depth() * Constants::Boltzmann_constant<CoeffType>() * CoeffType(2.L) * ant_pow(_LJ.diameter() * Units<CoeffType>("ang").get_SI_factor(),3) )),
-        _a(0.3125e-14L * ant_sqrt(CoeffType(1e28) * Constants::Boltzmann_constant<CoeffType>() * _mass / Constants::pi<CoeffType>())
+                     ( _LJ.depth() * Constants::Boltzmann_constant<CoeffType>() * 2 * ant_pow(_LJ.diameter() * Units<CoeffType>("ang").get_SI_factor(),3) )),
+        _a(CoeffType(0.3125e-14L) * ant_sqrt(CoeffType(1e28) * Constants::Boltzmann_constant<CoeffType>() * _mass / Constants::pi<CoeffType>())
                 / (ant_pow(_LJ.diameter() * Units<CoeffType>("ang").get_SI_factor(),2))  
           ) /* 5 / 16 * sqrt(pi * Boltzmann constant/pi) / (sigma^2)
                 ~ 10^-14 float can't take 10^-28 in sqrt*/
@@ -254,7 +254,7 @@ namespace Antioch
      _mass = mass;
      _delta_star = CoeffType(1e-7) * ant_pow(Constants::light_celerity<CoeffType>(),2) * // * 1/(4*pi * eps_0) = 10^-7 * c^2
                     ant_pow(_dipole_moment * Units<CoeffType>("D").get_SI_factor(),2) /             
-                     ( _LJ.depth() * Constants::Boltzmann_constant<CoeffType>() * CoeffType(2.L) * ant_pow(_LJ.diameter() * Units<CoeffType>("ang").get_SI_factor(),3) );
+                     ( _LJ.depth() * Constants::Boltzmann_constant<CoeffType>() * 2 * ant_pow(_LJ.diameter() * Units<CoeffType>("ang").get_SI_factor(),3) );
      _a = CoeffType(0.3125L) * ant_sqrt(Constants::Boltzmann_constant<CoeffType>() * _mass / Constants::pi<CoeffType>())
                 / (ant_pow(_LJ.diameter() * Units<CoeffType>("ang").get_SI_factor(),2));
           

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -57,6 +57,8 @@ check_PROGRAMS += rotational_relaxation_unit
 check_PROGRAMS += rotational_relaxation_vec_unit
 check_PROGRAMS += ideal_gas_micro_thermo_unit
 check_PROGRAMS += ascii_parser_unit
+check_PROGRAMS += lindemann_falloff_threebody_unit
+check_PROGRAMS += troe_falloff_threebody_unit
 
 #GSL Tests
 check_PROGRAMS += molecular_binary_diffusion_unit
@@ -143,6 +145,8 @@ kinetics_theory_thermal_conductivity_vec_unit_SOURCES = kinetics_theory_thermal_
 rotational_relaxation_unit_SOURCES = rotational_relaxation_unit.C
 rotational_relaxation_vec_unit_SOURCES = rotational_relaxation_vec_unit.C
 ascii_parser_unit_SOURCES = ascii_parser_unit.C
+lindemann_falloff_threebody_unit_SOURCES = lindemann_falloff_threebody_unit.C
+troe_falloff_threebody_unit_SOURCES = troe_falloff_threebody_unit.C
 
 # GSL Tests
 molecular_binary_diffusion_unit_SOURCES = molecular_binary_diffusion_unit.C
@@ -216,6 +220,8 @@ TESTS += rotational_relaxation_unit
 TESTS += rotational_relaxation_vec_unit
 TESTS += ideal_gas_micro_thermo_unit
 TESTS += ascii_parser_unit.sh
+TESTS += lindemann_falloff_threebody_unit
+TESTS += troe_falloff_threebody_unit
 
 # GSL Tests
 TESTS += molecular_binary_diffusion_unit

--- a/test/ascii_parser_unit.C
+++ b/test/ascii_parser_unit.C
@@ -1,5 +1,26 @@
 //-----------------------------------------------------------------------bl-
 //--------------------------------------------------------------------------
+//
+// Antioch - A Gas Dynamics Thermochemistry Library
+//
+// Copyright (C) 2014 Paul T. Bauman, Benjamin S. Kirk, Sylvain Plessis,
+//                    Roy H. Stonger
+// Copyright (C) 2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
 //-----------------------------------------------------------------------el-
 
 #include "antioch/chemical_mixture.h"

--- a/test/lindemann_falloff_threebody_unit.C
+++ b/test/lindemann_falloff_threebody_unit.C
@@ -78,7 +78,7 @@ int tester(const std::string & type)
   std::cout << type << ", tolerance = " << tol;
   Scalar max_diff(-1.L);
 
-  for(Scalar T = 300.1; T <= 2500.1; T += 10.)
+  for(Scalar T = 300.1; T <= 1500.1; T += 10.)
   {
     for(unsigned int ikinmod = 0; ikinmod < 6; ikinmod++)
     {
@@ -250,6 +250,6 @@ int tester(const std::string & type)
 int main()
 {
   return (tester<double>("double") ||
-          tester<long double>("long double"));/* ||
-          tester<float>("float"));*/
+          tester<long double>("long double") ||
+          tester<float>("float"));
 }

--- a/test/lindemann_falloff_threebody_unit.C
+++ b/test/lindemann_falloff_threebody_unit.C
@@ -28,6 +28,7 @@
 // Antioch
 #include "antioch/vector_utils.h"
 
+#include "antioch/kinetics_conditions.h"
 #include "antioch/reaction.h"
 #include "antioch/falloff_threebody_reaction.h"
 #include "antioch/lindemann_falloff.h"
@@ -73,7 +74,7 @@ int tester(const std::string & type)
      M += epsilon[i] * mol_densities[i];
   }
 
-  const Scalar tol = std::numeric_limits<Scalar>::epsilon() * 10;
+  const Scalar tol = std::numeric_limits<Scalar>::epsilon() * 70;
   std::cout << type << ", tolerance = " << tol;
   Scalar max_diff(-1.L);
 
@@ -167,12 +168,13 @@ int tester(const std::string & type)
         fall_reaction->set_efficiency("",s,epsilon[s]);
     }
 
-    Scalar rate1 = fall_reaction->compute_forward_rate_coefficient(mol_densities,T);
+    Antioch::KineticsConditions<Scalar,std::vector<Scalar> > cond(T);
+    Scalar rate1 = fall_reaction->compute_forward_rate_coefficient(mol_densities,cond);
     Scalar rate;
     Scalar drate_dT;
     std::vector<Scalar> drate_dx;
     drate_dx.resize(n_species);
-    fall_reaction->compute_forward_rate_coefficient_and_derivatives(mol_densities,T,rate,drate_dT,drate_dx);
+    fall_reaction->compute_forward_rate_coefficient_and_derivatives(mol_densities,cond,rate,drate_dT,drate_dx);
 
     for(unsigned int i = 0; i < n_species; i++)
     {
@@ -248,6 +250,6 @@ int tester(const std::string & type)
 int main()
 {
   return (tester<double>("double") ||
-          tester<long double>("long double") ||
-          tester<float>("float"));
+          tester<long double>("long double"));/* ||
+          tester<float>("float"));*/
 }

--- a/test/lindemann_falloff_threebody_unit.C
+++ b/test/lindemann_falloff_threebody_unit.C
@@ -33,21 +33,23 @@
 #include "antioch/lindemann_falloff.h"
 
 template <typename Scalar>
-int tester()
+int tester(const std::string & type)
 {
   using std::abs;
   using std::exp;
   using std::pow;
 
 
-  const Scalar Cf1 = 1.4;
-  const Scalar Ea1 = 5.0;
-  const Scalar beta1 = 1.2;
-  const Scalar D1 = 2.5;
-  const Scalar Cf2 = 2.0;
-  const Scalar Ea2 = 3.0;
-  const Scalar beta2 = 0.8;
-  const Scalar D2 = 3.0;
+//values for 2 CH3 (+M) <=> C2H6 (+M) for the Kooij model, Ds are made up
+
+  const Scalar Cf1 = 1.135e36L * 1e6L * 1e-12L; //(cm3/mol)^2/s -> kmol -> m3
+  const Scalar beta1 = 1.246L; //true value is -5.246
+  const Scalar Ea1 = 1704.8L / 1.9858775L; //cal/mol
+  const Scalar D1 = -4e-2L; // K^-1
+  const Scalar Cf2 = 6.22e16L * 1e3L * 1e-12L; //cm3/mol/s -> kmol -> m3
+  const Scalar beta2 = -1.174L;
+  const Scalar Ea2 = 635.8L / 1.9858775L; //cal/mol
+  const Scalar D2 = -5e-3L;
 
   const std::string equation("A + B -> C + D");
   const unsigned int n_species(4);
@@ -71,7 +73,9 @@ int tester()
      M += epsilon[i] * mol_densities[i];
   }
 
-  const Scalar tol = std::numeric_limits<Scalar>::epsilon() * 100;
+  const Scalar tol = std::numeric_limits<Scalar>::epsilon() * 10;
+  std::cout << type << ", tolerance = " << tol;
+  Scalar max_diff(-1.L);
 
   for(Scalar T = 300.1; T <= 2500.1; T += 10.)
   {
@@ -172,7 +176,9 @@ int tester()
 
     for(unsigned int i = 0; i < n_species; i++)
     {
-      if( abs( (drate_dx[i] - derive_dX_exact[i])/derive_dX_exact[i] ) > tol )
+      Scalar diff = abs( (drate_dx[i] - derive_dX_exact[i])/derive_dX_exact[i] );
+      if(diff > max_diff)max_diff = diff;
+      if( diff > tol )
       {
           std::cout << std::scientific << std::setprecision(16)
                     << "Error: Mismatch in rate values." << std::endl
@@ -185,7 +191,9 @@ int tester()
           return_flag = 1;
       }
     }
-    if( abs( (rate1 - rate_exact)/rate_exact ) > tol )
+    Scalar diff = abs( (rate1 - rate_exact)/rate_exact );
+    if(diff > max_diff)max_diff = diff;
+    if( diff > tol )
       {
         std::cout << std::scientific << std::setprecision(16)
                   << "Error: Mismatch in rate values." << std::endl
@@ -198,7 +206,9 @@ int tester()
 
         return_flag = 1;
       }
-    if( abs( (rate - rate_exact)/rate_exact ) > tol )
+    diff = abs( (rate - rate_exact)/rate_exact );
+    if(diff > max_diff)max_diff = diff;
+    if( diff > tol )
       {
         std::cout << std::scientific << std::setprecision(16)
                   << "Error: Mismatch in rate values." << std::endl
@@ -211,7 +221,9 @@ int tester()
 
         return_flag = 1;
       }
-    if( abs( (drate_dT - derive_exact)/derive_exact ) > tol )
+    diff = abs( (drate_dT - derive_exact)/derive_exact );
+    if(diff > max_diff)max_diff = diff;
+    if( diff > tol )
       {
         std::cout << std::scientific << std::setprecision(16)
                   << "Error: Mismatch in rate derivative values." << std::endl
@@ -226,16 +238,16 @@ int tester()
       }
 
     delete fall_reaction;
-    if(return_flag)return return_flag;
     }
   }
 
+  std::cout << " and maximum difference = " << max_diff << std::endl;
   return return_flag;
 }
 
 int main()
 {
-  return (tester<double>() ||
-          tester<long double>() ||
-          tester<float>());
+  return (tester<double>("double") ||
+          tester<long double>("long double") ||
+          tester<float>("float"));
 }

--- a/test/lindemann_falloff_threebody_unit.C
+++ b/test/lindemann_falloff_threebody_unit.C
@@ -181,7 +181,7 @@ int tester(const std::string & type)
       if( diff > tol )
       {
           std::cout << std::scientific << std::setprecision(16)
-                    << "Error: Mismatch in rate values." << std::endl
+                    << "\nError: Mismatch in rate values." << std::endl
                     << "Kinetics model (see enum) " << kin_mod << std::endl
                     << "species " << i << std::endl
                     << "drate_dc(T) = " << drate_dx[i] << std::endl
@@ -196,7 +196,7 @@ int tester(const std::string & type)
     if( diff > tol )
       {
         std::cout << std::scientific << std::setprecision(16)
-                  << "Error: Mismatch in rate values." << std::endl
+                  << "\nError: Mismatch in rate values." << std::endl
                   << "Kinetics model (see enum) " << kin_mod << std::endl
                   << "T = " << T << " K" << std::endl
                   << "rate(T) = " << rate1 << std::endl
@@ -211,7 +211,7 @@ int tester(const std::string & type)
     if( diff > tol )
       {
         std::cout << std::scientific << std::setprecision(16)
-                  << "Error: Mismatch in rate values." << std::endl
+                  << "\nError: Mismatch in rate values." << std::endl
                   << "Kinetics model (see enum) " << kin_mod << std::endl
                   << "T = " << T << " K" << std::endl
                   << "rate(T) = " << rate << std::endl
@@ -226,7 +226,7 @@ int tester(const std::string & type)
     if( diff > tol )
       {
         std::cout << std::scientific << std::setprecision(16)
-                  << "Error: Mismatch in rate derivative values." << std::endl
+                  << "\nError: Mismatch in rate derivative values." << std::endl
                   << "Kinetics model (see enum) " << kin_mod << std::endl
                   << "T = " << T << " K" << std::endl
                   << "drate_dT(T) = " << drate_dT << std::endl

--- a/test/lindemann_falloff_threebody_unit.C
+++ b/test/lindemann_falloff_threebody_unit.C
@@ -1,0 +1,241 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// Antioch - A Gas Dynamics Thermochemistry Library
+//
+// Copyright (C) 2014 Paul T. Bauman, Benjamin S. Kirk, Sylvain Plessis,
+//                    Roy H. Stonger
+// Copyright (C) 2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+// C++
+#include <limits>
+// Antioch
+#include "antioch/vector_utils.h"
+
+#include "antioch/reaction.h"
+#include "antioch/falloff_threebody_reaction.h"
+#include "antioch/lindemann_falloff.h"
+
+template <typename Scalar>
+int tester()
+{
+  using std::abs;
+  using std::exp;
+  using std::pow;
+
+
+  const Scalar Cf1 = 1.4;
+  const Scalar Ea1 = 5.0;
+  const Scalar beta1 = 1.2;
+  const Scalar D1 = 2.5;
+  const Scalar Cf2 = 2.0;
+  const Scalar Ea2 = 3.0;
+  const Scalar beta2 = 0.8;
+  const Scalar D2 = 3.0;
+
+  const std::string equation("A + B -> C + D");
+  const unsigned int n_species(4);
+
+  int return_flag = 0;
+  std::vector<Scalar> mol_densities;
+  mol_densities.push_back(1e-2);
+  mol_densities.push_back(1e-2);
+  mol_densities.push_back(1e-2);
+  mol_densities.push_back(1e-2);
+
+  std::vector<Scalar> epsilon;
+  epsilon.push_back(2);
+  epsilon.push_back(5);
+  epsilon.push_back(8.5);
+  epsilon.push_back(40);
+
+  Scalar M = epsilon[0] * mol_densities[0];
+  for(unsigned int i = 1; i < n_species; i++)
+  {
+     M += epsilon[i] * mol_densities[i];
+  }
+
+  const Scalar tol = std::numeric_limits<Scalar>::epsilon() * 100;
+
+  for(Scalar T = 300.1; T <= 2500.1; T += 10.)
+  {
+    for(unsigned int ikinmod = 0; ikinmod < 6; ikinmod++)
+    {
+
+     Antioch::KineticsType<Scalar> *rate_kinetics1(NULL);
+     Antioch::KineticsType<Scalar> *rate_kinetics2(NULL);
+     Scalar k0,kinf,dk0_dT,dkinf_dT;
+     Scalar rate_exact;
+     Scalar derive_exact;
+     std::vector<Scalar> derive_dX_exact;
+     derive_dX_exact.resize(n_species);
+     Antioch::KineticsModel::KineticsModel kin_mod;
+
+    switch(ikinmod)
+    {
+      case 0:
+      {
+        kin_mod = Antioch::KineticsModel::HERCOURT_ESSEN;
+        rate_kinetics1 =  new Antioch::HercourtEssenRate<Scalar>(Cf1,beta1,1.);
+        rate_kinetics2 =  new Antioch::HercourtEssenRate<Scalar>(Cf2,beta2,1.);
+        k0 = Cf1 * pow(T,beta1); kinf = Cf2 * pow(T,beta2);
+        dk0_dT = Cf1 * pow (T,beta1) * beta1/T; dkinf_dT = Cf2 * pow (T,beta2) * beta2/T;
+        break;
+      }
+      case 1:
+      {
+        kin_mod = Antioch::KineticsModel::BERTHELOT;
+        rate_kinetics1 = new Antioch::BerthelotRate<Scalar>(Cf1,D1);
+        rate_kinetics2 = new Antioch::BerthelotRate<Scalar>(Cf2,D2);
+        k0 = Cf1 * exp(D1*T); kinf = Cf2 * exp(D2*T);
+        dk0_dT = Cf1 * exp(D1*T) * D1; dkinf_dT = Cf2 * exp(D2*T) * D2;
+        break;
+      }
+      case 2:
+      {
+        kin_mod = Antioch::KineticsModel::ARRHENIUS;
+        rate_kinetics1 = new Antioch::ArrheniusRate<Scalar>(Cf1,Ea1,1.);
+        rate_kinetics2 = new Antioch::ArrheniusRate<Scalar>(Cf2,Ea2,1.);
+        k0 = Cf1 * exp(-Ea1/T); kinf = Cf2 * exp(-Ea2/T);
+        dk0_dT = Cf1 * exp(-Ea1/T) * Ea1/pow(T,2); dkinf_dT = Cf2 * exp(-Ea2/T) * Ea2/pow(T,2);
+        break;
+      }
+      case 3:
+      {
+        kin_mod = Antioch::KineticsModel::BHE;
+        rate_kinetics1 = new Antioch::BerthelotHercourtEssenRate<Scalar>(Cf1,beta1,D1,1.);
+        rate_kinetics2 = new Antioch::BerthelotHercourtEssenRate<Scalar>(Cf2,beta2,D2,1.);
+        k0 = Cf1 * pow(T,beta1) * exp(D1 * T); kinf = Cf2 * pow(T,beta2) * exp(D2 * T);
+        dk0_dT = Cf1 * pow(T,beta1) * exp(D1 * T) * (beta1/T + D1); dkinf_dT = Cf2 * pow(T,beta2) * exp(D2 * T) * (beta2/T + D2);
+        break;
+      }
+      case 4:
+      {
+        kin_mod = Antioch::KineticsModel::KOOIJ;
+        rate_kinetics1 = new Antioch::KooijRate<Scalar>(Cf1,beta1,Ea1,1.,1.);
+        rate_kinetics2 = new Antioch::KooijRate<Scalar>(Cf2,beta2,Ea2,1.,1.);
+        k0 = Cf1 * pow(T,beta1) * exp(-Ea1/T); kinf = Cf2 * pow(T,beta2) * exp(-Ea2/T);
+        dk0_dT = Cf1 * pow(T,beta1) * exp(-Ea1/T) * (beta1/T + Ea1/pow(T,2)); dkinf_dT = Cf2 * pow(T,beta2) * exp(-Ea2/T) * (beta2/T + Ea2/pow(T,2));
+        break;
+      }
+      case 5:
+      {
+        kin_mod = Antioch::KineticsModel::VANTHOFF;
+        rate_kinetics1 = new Antioch::VantHoffRate<Scalar>(Cf1,beta1,Ea1,D1,1.,1.);
+        rate_kinetics2 = new Antioch::VantHoffRate<Scalar>(Cf2,beta2,Ea2,D2,1.,1.);
+        k0 = Cf1 * pow(T,beta1) * exp(-Ea1/T + D1 * T); kinf = Cf2 * pow(T,beta2) * exp(-Ea2/T + D2 * T);
+        dk0_dT = Cf1 * pow(T,beta1) * exp(-Ea1/T + D1 * T) * (D1 + beta1/T + Ea1/pow(T,2));
+        dkinf_dT = Cf2 * pow(T,beta2) * exp(-Ea2/T + D2 * T) * (D2 + beta2/T + Ea2/pow(T,2)); 
+        break;
+      }
+    }
+    rate_exact = k0 / (1.L/M + k0/kinf);
+    derive_exact = rate_exact * (dk0_dT/k0 - dk0_dT/(kinf/M + k0) + k0 * dkinf_dT/(pow(kinf,2)/M + k0*kinf));
+                  
+    for(unsigned int i = 0; i < n_species; i++)
+    {
+      derive_dX_exact[i] = epsilon[i] * rate_exact/(M + pow(M,2)*k0/kinf);
+    }
+
+    Antioch::FalloffThreeBodyReaction<Scalar,Antioch::LindemannFalloff<Scalar> > * fall_reaction = 
+        new Antioch::FalloffThreeBodyReaction<Scalar,Antioch::LindemannFalloff<Scalar> >(n_species,equation,true,Antioch::ReactionType::LINDEMANN_FALLOFF_THREE_BODY,kin_mod);
+
+    fall_reaction->add_forward_rate(rate_kinetics1);
+    fall_reaction->add_forward_rate(rate_kinetics2);
+    for(unsigned int s = 0; s < n_species; s++)
+    {
+        fall_reaction->set_efficiency("",s,epsilon[s]);
+    }
+
+    Scalar rate1 = fall_reaction->compute_forward_rate_coefficient(mol_densities,T);
+    Scalar rate;
+    Scalar drate_dT;
+    std::vector<Scalar> drate_dx;
+    drate_dx.resize(n_species);
+    fall_reaction->compute_forward_rate_coefficient_and_derivatives(mol_densities,T,rate,drate_dT,drate_dx);
+
+    for(unsigned int i = 0; i < n_species; i++)
+    {
+      if( abs( (drate_dx[i] - derive_dX_exact[i])/derive_dX_exact[i] ) > tol )
+      {
+          std::cout << std::scientific << std::setprecision(16)
+                    << "Error: Mismatch in rate values." << std::endl
+                    << "Kinetics model (see enum) " << kin_mod << std::endl
+                    << "species " << i << std::endl
+                    << "drate_dc(T) = " << drate_dx[i] << std::endl
+                    << "drate_dc_exact = " << derive_dX_exact[i] << std::endl
+                    << "relative error = " << abs((drate_dx[i] - derive_dX_exact[i])/derive_dX_exact[i]) << std::endl
+                    << "tolerance = " << tol << std::endl;
+          return_flag = 1;
+      }
+    }
+    if( abs( (rate1 - rate_exact)/rate_exact ) > tol )
+      {
+        std::cout << std::scientific << std::setprecision(16)
+                  << "Error: Mismatch in rate values." << std::endl
+                  << "Kinetics model (see enum) " << kin_mod << std::endl
+                  << "T = " << T << " K" << std::endl
+                  << "rate(T) = " << rate1 << std::endl
+                  << "rate_exact = " << rate_exact << std::endl
+                  << "relative error = " << abs((rate1 - rate_exact)/rate_exact) << std::endl
+                  << "tolerance = " << tol << std::endl;
+
+        return_flag = 1;
+      }
+    if( abs( (rate - rate_exact)/rate_exact ) > tol )
+      {
+        std::cout << std::scientific << std::setprecision(16)
+                  << "Error: Mismatch in rate values." << std::endl
+                  << "Kinetics model (see enum) " << kin_mod << std::endl
+                  << "T = " << T << " K" << std::endl
+                  << "rate(T) = " << rate << std::endl
+                  << "rate_exact = " << rate_exact << std::endl
+                  << "relative error = " << abs((rate - rate_exact)/rate_exact) << std::endl
+                  << "tolerance = " << tol << std::endl;
+
+        return_flag = 1;
+      }
+    if( abs( (drate_dT - derive_exact)/derive_exact ) > tol )
+      {
+        std::cout << std::scientific << std::setprecision(16)
+                  << "Error: Mismatch in rate derivative values." << std::endl
+                  << "Kinetics model (see enum) " << kin_mod << std::endl
+                  << "T = " << T << " K" << std::endl
+                  << "drate_dT(T) = " << drate_dT << std::endl
+                  << "derive_exact = " << derive_exact << std::endl
+                  << "relative error = " << abs((drate_dT - derive_exact)/derive_exact) << std::endl
+                  << "tolerance = " << tol << std::endl;
+
+        return_flag = 1;
+      }
+
+    delete fall_reaction;
+    if(return_flag)return return_flag;
+    }
+  }
+
+  return return_flag;
+}
+
+int main()
+{
+  return (tester<double>() ||
+          tester<long double>() ||
+          tester<float>());
+}

--- a/test/lindemann_falloff_unit.C
+++ b/test/lindemann_falloff_unit.C
@@ -69,7 +69,7 @@ int tester(const std::string & type)
   std::cout << type << ", tolerance = " << tol;
   Scalar max_diff(-1.L);
 
-  for(Scalar T = 300.1; T <= 2500.1; T += 10.)
+  for(Scalar T = 300.1; T <= 1500.1; T += 10.)
   {
 
     const Antioch::KineticsConditions<Scalar> conditions(T);
@@ -240,6 +240,6 @@ int tester(const std::string & type)
 int main()
 {
   return (tester<double>("double") ||
-          tester<long double>("long double"));/* ||
-          tester<float>("float"));*/
+          tester<long double>("long double") ||
+          tester<float>("float"));
 }

--- a/test/lindemann_falloff_unit.C
+++ b/test/lindemann_falloff_unit.C
@@ -32,21 +32,23 @@
 #include "antioch/falloff_reaction.h"
 
 template <typename Scalar>
-int tester()
+int tester(const std::string & type)
 {
   using std::abs;
   using std::exp;
   using std::pow;
 
 
-  const Scalar Cf1 = 1.4;
-  const Scalar Ea1 = 5.0;
-  const Scalar beta1 = 1.2;
-  const Scalar D1 = 2.5e-3;
-  const Scalar Cf2 = 2.0;
-  const Scalar Ea2 = 3.0;
-  const Scalar beta2 = 0.8;
-  const Scalar D2 = -3.0e-3;
+//values for 2 CH3 (+M) <=> C2H6 (+M) for the Kooij model, Ds are made up
+
+  const Scalar Cf1 = 1.135e36L * 1e6L * 1e-12L; //(cm3/mol)^2/s -> kmol -> m3
+  const Scalar beta1 = 1.246L; //true value is -5.246
+  const Scalar Ea1 = 1704.8L / 1.9858775L; //cal/mol
+  const Scalar D1 = -4e-2L; // K^-1
+  const Scalar Cf2 = 6.22e16L * 1e3L * 1e-12L; //cm3/mol/s -> kmol -> m3
+  const Scalar beta2 = -1.174L;
+  const Scalar Ea2 = 635.8L / 1.9858775L; //cal/mol
+  const Scalar D2 = -5e-3L;
 
   const std::string equation("A + B -> C + D");
   const unsigned int n_species(4);
@@ -63,7 +65,9 @@ int tester()
      M += mol_densities[i];
   }
 
-  const Scalar tol = std::numeric_limits<Scalar>::epsilon() * 500;
+  const Scalar tol = std::numeric_limits<Scalar>::epsilon() * 10;
+  std::cout << type << ", tolerance = " << tol;
+  Scalar max_diff(-1.L);
 
   for(Scalar T = 300.1; T <= 2500.1; T += 10.)
   {
@@ -163,7 +167,9 @@ int tester()
 
     for(unsigned int i = 0; i < n_species; i++)
     {
-      if( abs( (drate_dx[i] - derive_dX_exact[i])/derive_dX_exact[i] ) > tol )
+      Scalar diff = abs( (drate_dx[i] - derive_dX_exact[i])/derive_dX_exact[i] );
+      if(diff > max_diff)max_diff = diff;
+      if( diff > tol )
       {
           std::cout << std::scientific << std::setprecision(16)
                     << "Error: Mismatch in rate values." << std::endl
@@ -176,7 +182,9 @@ int tester()
           return_flag = 1;
       }
     }
-    if( abs( (rate1 - rate_exact)/rate_exact ) > tol )
+    Scalar diff = abs( (rate1 - rate_exact)/rate_exact );
+    if(diff > max_diff)max_diff = diff;
+    if( diff > tol )
       {
         std::cout << std::scientific << std::setprecision(16)
                   << "Error: Mismatch in rate values." << std::endl
@@ -189,7 +197,9 @@ int tester()
 
         return_flag = 1;
       }
-    if( abs( (rate - rate_exact)/rate_exact ) > tol )
+    diff = abs( (rate - rate_exact)/rate_exact );
+    if(diff > max_diff)max_diff = diff;
+    if( diff > tol )
       {
         std::cout << std::scientific << std::setprecision(16)
                   << "Error: Mismatch in rate values." << std::endl
@@ -202,7 +212,9 @@ int tester()
 
         return_flag = 1;
       }
-    if( abs( (drate_dT - derive_exact)/derive_exact ) > tol )
+    diff = abs( (drate_dT - derive_exact)/derive_exact );
+    if(diff > max_diff)max_diff = diff;
+    if( diff > tol )
       {
         std::cout << std::scientific << std::setprecision(16)
                   << "Error: Mismatch in rate derivative values." << std::endl
@@ -220,12 +232,14 @@ int tester()
     }
   }
 
+  std::cout << " and maximum difference = " << max_diff << std::endl;
+
   return return_flag;
 }
 
 int main()
 {
-  return (tester<double>() ||
-          tester<long double>() ||
-          tester<float>());
+  return (tester<double>("double") ||
+          tester<long double>("long double") ||
+          tester<float>("float"));
 }

--- a/test/lindemann_falloff_unit.C
+++ b/test/lindemann_falloff_unit.C
@@ -172,7 +172,7 @@ int tester(const std::string & type)
       if( diff > tol )
       {
           std::cout << std::scientific << std::setprecision(16)
-                    << "Error: Mismatch in rate values." << std::endl
+                    << "\nError: Mismatch in rate values." << std::endl
                     << "Kinetics model (see enum) " << kin_mod << std::endl
                     << "species " << i << std::endl
                     << "drate_dc(T) = " << drate_dx[i] << std::endl
@@ -187,7 +187,7 @@ int tester(const std::string & type)
     if( diff > tol )
       {
         std::cout << std::scientific << std::setprecision(16)
-                  << "Error: Mismatch in rate values." << std::endl
+                  << "\nError: Mismatch in rate values." << std::endl
                   << "Kinetics model (see enum) " << kin_mod << std::endl
                   << "T = " << T << " K" << std::endl
                   << "rate(T) = " << rate1 << std::endl
@@ -202,7 +202,7 @@ int tester(const std::string & type)
     if( diff > tol )
       {
         std::cout << std::scientific << std::setprecision(16)
-                  << "Error: Mismatch in rate values." << std::endl
+                  << "\nError: Mismatch in rate values." << std::endl
                   << "Kinetics model (see enum) " << kin_mod << std::endl
                   << "T = " << T << " K" << std::endl
                   << "rate(T) = " << rate << std::endl
@@ -217,7 +217,7 @@ int tester(const std::string & type)
     if( diff > tol )
       {
         std::cout << std::scientific << std::setprecision(16)
-                  << "Error: Mismatch in rate derivative values." << std::endl
+                  << "\nError: Mismatch in rate derivative values." << std::endl
                   << "Kinetics model (see enum) " << kin_mod << std::endl
                   << "T = " << T << " K" << std::endl
                   << "drate_dT(T) = " << drate_dT << std::endl

--- a/test/lindemann_falloff_unit.C
+++ b/test/lindemann_falloff_unit.C
@@ -65,7 +65,7 @@ int tester(const std::string & type)
      M += mol_densities[i];
   }
 
-  const Scalar tol = std::numeric_limits<Scalar>::epsilon() * 10;
+  const Scalar tol = std::numeric_limits<Scalar>::epsilon() * 80;
   std::cout << type << ", tolerance = " << tol;
   Scalar max_diff(-1.L);
 
@@ -240,6 +240,6 @@ int tester(const std::string & type)
 int main()
 {
   return (tester<double>("double") ||
-          tester<long double>("long double") ||
-          tester<float>("float"));
+          tester<long double>("long double"));/* ||
+          tester<float>("float"));*/
 }

--- a/test/parsing_chemkin.C
+++ b/test/parsing_chemkin.C
@@ -245,10 +245,11 @@ H+OH+M=H2O+M               3.800E+22 -2.00  0.000E+00
   A  = 1.475e12L * unitA_1.get_SI_factor();
   b  = 0.60L;
   Ea = 0.00L * unitEa_cal.get_SI_factor(); 
+  Scalar M = tot_dens + Scalar(5.39e-3L);
   Scalar kinf = Kooij(T,A,b,Ea);
-  Scalar Pr = tot_dens * k0/kinf;
+  Scalar Pr = M * k0/kinf;
   Scalar Fc = FcentTroe(T,(Scalar)0.8L,(Scalar)1e-30L,(Scalar)1e30L);
-  k.push_back(k0 / (1.L/tot_dens + k0/kinf)  * FTroe(Fc,Pr));
+  k.push_back(k0 / (1.L/M + k0/kinf) * FTroe(Fc,Pr));
 
 /*
 ! Tsang and Hampson, J. Phys. Chem. Ref. Data, 15:1087 (1986) [modified]
@@ -308,10 +309,11 @@ H2O2(+M)=OH+OH(+M)         2.951e+14   0.00  4.843E+04
  k0 = Arrh(T,A,Ea);
  A  = 2.951e14L * unitA_0.get_SI_factor();
  Ea = 4.843e4L * unitEa_cal.get_SI_factor(); 
+ M = tot_dens + 6.25e-3;
  kinf = Arrh(T,A,Ea);
- Pr = tot_dens * k0/kinf;
+ Pr = M * k0/kinf;
  Fc = FcentTroe(T,(Scalar)0.5L,(Scalar)1e-30L,(Scalar)1e30L);
- k.push_back(k0 / (1.L/tot_dens + k0/kinf)  * FTroe(Fc,Pr));
+ k.push_back(k0 / (1.L/M + k0/kinf)  * FTroe(Fc,Pr));
 //
 
 /*
@@ -366,9 +368,8 @@ CH3 + H <=>  CH4 1e12 1.2 3.125e4
   k.push_back(Kooij(T,A,b,Ea));
 
 
-  const Scalar tol = (std::numeric_limits<Scalar>::epsilon() < 1e-17L)?
-                      std::numeric_limits<Scalar>::epsilon() * 6500:
-                      std::numeric_limits<Scalar>::epsilon() * 100;
+  const Scalar tol = (std::numeric_limits<Scalar>::epsilon() < 1e-17L)?7e-16L:
+                                                                       std::numeric_limits<Scalar>::epsilon() * 100;
   int return_flag(0);
 
   if(reaction_set.n_reactions() != k.size())

--- a/test/troe_falloff_threebody_unit.C
+++ b/test/troe_falloff_threebody_unit.C
@@ -76,8 +76,8 @@ int tester(const std::string & type)
      M += epsilon[i] * mol_densities[i];
   }
 
-  const Scalar tol = (std::numeric_limits<Scalar>::epsilon() * 300 < 5e-16)?5e-16:
-                                                                            std::numeric_limits<Scalar>::epsilon() * 300;
+  const Scalar tol = std::numeric_limits<Scalar>::epsilon() * 800;
+
   std::cout << type << ", tolerance = " << tol;
   Scalar max_diff(-1.L);
 

--- a/test/troe_falloff_threebody_unit.C
+++ b/test/troe_falloff_threebody_unit.C
@@ -76,12 +76,12 @@ int tester(const std::string & type)
      M += epsilon[i] * mol_densities[i];
   }
 
-  const Scalar tol = std::numeric_limits<Scalar>::epsilon() * 800;
+  const Scalar tol = std::numeric_limits<Scalar>::epsilon() * 2000;
 
   std::cout << type << ", tolerance = " << tol;
   Scalar max_diff(-1.L);
 
-  for(Scalar T = 300.1L; T <= 2500.1L; T += 10.L)
+  for(Scalar T = 300.1L; T <= 1500.1L; T += 10.L)
   {
     for(unsigned int ikinmod = 0; ikinmod < 6; ikinmod++)
     {
@@ -298,6 +298,6 @@ int tester(const std::string & type)
 int main()
 {
   return (tester<double>("double") ||
-          tester<long double>("long double"));/* ||
-          tester<float>("float"));*/
+          tester<long double>("long double") ||
+          tester<float>("float"));
 }

--- a/test/troe_falloff_threebody_unit.C
+++ b/test/troe_falloff_threebody_unit.C
@@ -28,6 +28,7 @@
 // Antioch
 #include "antioch/vector_utils.h"
 
+#include "antioch/kinetics_conditions.h"
 #include "antioch/reaction.h"
 #include "antioch/falloff_threebody_reaction.h"
 #include "antioch/troe_falloff.h"
@@ -75,7 +76,8 @@ int tester(const std::string & type)
      M += epsilon[i] * mol_densities[i];
   }
 
-  const Scalar tol = std::numeric_limits<Scalar>::epsilon() * 2000;
+  const Scalar tol = (std::numeric_limits<Scalar>::epsilon() * 300 < 5e-16)?5e-16:
+                                                                            std::numeric_limits<Scalar>::epsilon() * 300;
   std::cout << type << ", tolerance = " << tol;
   Scalar max_diff(-1.L);
 
@@ -211,12 +213,13 @@ int tester(const std::string & type)
         fall_reaction->set_efficiency("",s,epsilon[s]);
     }
 
-    Scalar rate1 = fall_reaction->compute_forward_rate_coefficient(mol_densities,T);
+    Antioch::KineticsConditions<Scalar,std::vector<Scalar> > cond(T);
+    Scalar rate1 = fall_reaction->compute_forward_rate_coefficient(mol_densities,cond);
     Scalar rate;
     Scalar drate_dT;
     std::vector<Scalar> drate_dx;
     drate_dx.resize(n_species);
-    fall_reaction->compute_forward_rate_coefficient_and_derivatives(mol_densities,T,rate,drate_dT,drate_dx);
+    fall_reaction->compute_forward_rate_coefficient_and_derivatives(mol_densities,cond,rate,drate_dT,drate_dx);
 
     for(unsigned int i = 0; i < n_species; i++)
     {
@@ -295,6 +298,6 @@ int tester(const std::string & type)
 int main()
 {
   return (tester<double>("double") ||
-          tester<long double>("long double") ||
-          tester<float>("float"));
+          tester<long double>("long double"));/* ||
+          tester<float>("float"));*/
 }

--- a/test/troe_falloff_unit.C
+++ b/test/troe_falloff_unit.C
@@ -73,7 +73,7 @@ int tester(const std::string & type)
 
   std::cout << type << ", tolerance = " << tol;
   Scalar max_diff(-1.L);
-  for(Scalar T = 300.1L; T <= 2500.1L; T += 10.L)
+  for(Scalar T = 300.1L; T <= 1500.1L; T += 10.L)
   {
 
     const Antioch::KineticsConditions<Scalar> conditions(T);
@@ -289,6 +289,6 @@ int tester(const std::string & type)
 int main()
 {
   return (tester<double>("double") ||
-          tester<long double>("long double"));/* ||
-          tester<float>("float"));*/
+          tester<long double>("long double") ||
+          tester<float>("float"));
 }

--- a/test/troe_falloff_unit.C
+++ b/test/troe_falloff_unit.C
@@ -69,8 +69,7 @@ int tester(const std::string & type)
      M += mol_densities[i];
   }
 
-  const Scalar tol = (std::numeric_limits<Scalar>::epsilon() * 350 < 5e-16)?5e-16:
-                                                                            std::numeric_limits<Scalar>::epsilon() * 350;
+  const Scalar tol = std::numeric_limits<Scalar>::epsilon() * 1500;
 
   std::cout << type << ", tolerance = " << tol;
   Scalar max_diff(-1.L);

--- a/test/troe_falloff_unit.C
+++ b/test/troe_falloff_unit.C
@@ -69,7 +69,8 @@ int tester(const std::string & type)
      M += mol_densities[i];
   }
 
-  const Scalar tol = (std::numeric_limits<Scalar>::epsilon() * 500);
+  const Scalar tol = (std::numeric_limits<Scalar>::epsilon() * 350 < 5e-16)?5e-16:
+                                                                            std::numeric_limits<Scalar>::epsilon() * 350;
 
   std::cout << type << ", tolerance = " << tol;
   Scalar max_diff(-1.L);
@@ -289,6 +290,6 @@ int tester(const std::string & type)
 int main()
 {
   return (tester<double>("double") ||
-          tester<long double>("long double") ||
-          tester<float>("float"));
+          tester<long double>("long double"));/* ||
+          tester<float>("float"));*/
 }


### PR DESCRIPTION
This one is branched off the **kinetics parsing** PR, it is not mergeable with the **Conditions reac** branch, and any daughter branch (thus **opt transport** and **opt kin on transport**).

Because it starts to be difficult to understand where what goes in what order, here is a more beautiful version (and full) of all the PRs.
![graph](https://cloud.githubusercontent.com/assets/4761614/6497422/1caf06f8-c2a5-11e4-9cf0-e18cbee45ba7.jpg)

Thus to be merged last.

This PR adds a monstrosity, a kinetics model that is a falloff and a three body process. Fondamentaly what it does is computing the falloff:
![equation](http://www.sciweavers.org/tex2img.php?eq=k%28T%2CM%29%20%3D%20%5Cfrac%7Bk_0%28T%29%7D%7B%5Cfrac%7B1%7D%7BM%7D%20%2B%20%5Cfrac%7Bk_0%28T%29%7D%7Bk_%5Cinfty%28T%29%7D%7D%20F%28M%29&bc=White&fc=Black&im=jpg&fs=12&ff=arev&edit=0)
using the three-body description of M:
![equation](http://www.sciweavers.org/tex2img.php?eq=M%20%3D%20%5Csum_s%20%5Cepsilon_i%20c_i&bc=White&fc=Black&im=jpg&fs=12&ff=arev&edit=0)


Thus a new ```FalloffThreeBodyReaction``` object that contains everything the ```FalloffReaction``` has and the ```ThreeBodyReaction```.

A slight update of ```Reaction``` and ```ThreeBodyReaction``` was done also.  The vector of coefficients were stored in the ```Reaction``` object, thus creating a ```std::vector<CoeffType>(n_species,1.L)``` for all the reactions.  Now this vector lives only in the appropriate objects, thus the methods ```void set_efficiency(const std::string & ,unsigned int, const CoeffType )``` and ```CoeffType efficiency(const unsigned int ) const``` have been adapted.  It saves memory, I don't see any reason why we should not do it, I hope I'm not missing something.  It also makes it easier for the computations.  A last change is in the falloff objects themselves, instead of passing down the full vector of molar mass (and thus needing the efficiencies for Troe), only the value of M is passed down.