### PR TITLE
Sanity check was bugged, not switchable

### DIFF
--- a/src/parsing/include/antioch/species_ascii_parsing.h
+++ b/src/parsing/include/antioch/species_ascii_parsing.h
@@ -190,22 +190,26 @@ namespace Antioch
     in.close();
 
     // sanity check, we require these informations
-    if(chem_mixture.chemical_species().size() != chem_mixture.species_list().size())
+    bool fail(false);
+    for(unsigned int s = 0; s < chem_mixture.chemical_species().size(); s++)
     {
-       std::cerr << "Molecule(s) is(are) missing.  Please update the information."
-                 << "  Currently using file " << filename << ".\n"
-                 << "Missing molecule(s) is(are):" << std::endl;
-       for(unsigned int i = 0; i < chem_mixture.species_list().size(); i++)
-       {
-         unsigned int s;
-         for(s = 0; s < chem_mixture.chemical_species().size(); s++)
-         {
-             if(chem_mixture.chemical_species()[s]->species() == chem_mixture.species_inverse_name_map().at(i))break;
-         }
-         if(s == chem_mixture.species_list().size())
-         {
-             std::cerr << chem_mixture.species_inverse_name_map().at(i) << std::endl;
-         }
+        if(!chem_mixture.chemical_species()[s])
+        {
+            fail = true;
+            break;
+        }
+    }
+    if(fail)
+    {
+      std::cerr << "Molecule(s) is(are) missing.  Please update the information."
+                << "  Currently using file " << filename << ".\n"
+                << "Missing molecule(s) is(are):" << std::endl;
+      for(unsigned int i = 0; i < chem_mixture.species_list().size(); i++)
+      {
+        if(!chem_mixture.chemical_species()[i])
+        {
+           std::cerr << chem_mixture.species_inverse_name_map().at(i) << std::endl;
+        }
       }
       antioch_error();
     }


### PR DESCRIPTION
A small bug with very embarrassing consequences.  The required informations sanity check was never triggered...

Let's note that the very same fix will be inserted in PR #88, as the name of the files are changed.

This PR will be merged tonight.