### PR TITLE
Xml header fix

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -58,6 +58,7 @@ pkginclude_HEADERS += kinetics/include/antioch/kinetics_evaluator.h
 pkginclude_HEADERS += parsing/include/antioch/tinyxml2.h
 pkginclude_HEADERS += parsing/include/antioch/tinyxml2_imp.h
 pkginclude_HEADERS += parsing/include/antioch/read_reaction_set_data.h
+pkginclude_HEADERS += parsing/include/antioch/read_reaction_set_data_xml.h
 pkginclude_HEADERS += parsing/include/antioch/blottner_parsing.h
 pkginclude_HEADERS += parsing/include/antioch/sutherland_parsing.h
 pkginclude_HEADERS += parsing/include/antioch/cea_thermo_ascii_parsing.h

--- a/src/parsing/include/antioch/read_reaction_set_data.h
+++ b/src/parsing/include/antioch/read_reaction_set_data.h
@@ -28,8 +28,8 @@
 //--------------------------------------------------------------------------
 //--------------------------------------------------------------------------
 
-#ifndef ANTIOCH_REACTION_SET_DATA_XML_H
-#define ANTIOCH_REACTION_SET_DATA_XML_H
+#ifndef ANTIOCH_READ_REACTION_SET_DATA_H
+#define ANTIOCH_READ_REACTION_SET_DATA_H
 
 // Antioch
 #include "antioch/antioch_asserts.h"
@@ -768,4 +768,4 @@ namespace Antioch
  
 } // end namespace Antioch
 
-#endif // ANTIOCH_REACTION_SET_DATA_XML_H
+#endif // ANTIOCH_READ_REACTION_SET_DATA_H

--- a/src/parsing/include/antioch/read_reaction_set_data_xml.h
+++ b/src/parsing/include/antioch/read_reaction_set_data_xml.h
@@ -1,0 +1,33 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// Antioch - A Gas Dynamics Thermochemistry Library
+//
+// Copyright (C) 2014 Paul T. Bauman, Benjamin S. Kirk, Sylvain Plessis,
+//                    Roy H. Stonger
+// Copyright (C) 2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef ANTIOCH_READ_REACTION_SET_DATA_XML_H
+#define ANTIOCH_READ_REACTION_SET_DATA_XML_H
+
+#warning "ANTIOCH WARNING: The read_reaction_set_data_xml.h header file is deprecated. Use read_reaction_set_data.h instead."
+
+#include "antioch/read_reaction_set_data.h"
+
+#endif // ANTIOCH_READ_REACTION_SET_DATA_XML_H


### PR DESCRIPTION
This header got removed in #72 and we need it for backward compatibility. Note I've used the `#warning` is not standard, but seems to be accepted, so far. We'll see what clang says. Would also like to see what Intel says. I'm open to other suggestions, but at least wanted a warning printed at compile time to clue the user in as to what the not-deprecated header is.