### PR TITLE
Kinetics/opt

### DIFF
--- a/src/core/include/antioch/kinetics_conditions.h
+++ b/src/core/include/antioch/kinetics_conditions.h
@@ -29,6 +29,7 @@
 // Antioch
 #include "antioch/antioch_asserts.h"
 #include "antioch/particle_flux.h"
+#include "antioch/temp_cache.h"
 
 // C++
 #include <vector>
@@ -69,14 +70,19 @@ namespace Antioch{
           void add_particle_flux(const ParticleFlux<VectorStateType> & pf, unsigned int nr);
 
           const StateType & T() const;
+ 
+          const StateType & Tvib() const;
+
+          const TempCache<StateType> & temp_cache() const;
 
           const ParticleFlux<VectorStateType> & particle_flux(int nr) const;
 
         private:
 
           KineticsConditions();
-        // const temperature is
-          const StateType & _temperature; 
+
+          TempCache<StateType> _temperature; 
+
         // pointer's not const, particle flux is
           std::map<unsigned int,ParticleFlux<VectorStateType> const * const > _map_pf; 
 
@@ -109,7 +115,14 @@ namespace Antioch{
   inline
   const StateType & KineticsConditions<StateType,VectorStateType>::T() const
   {
-     return _temperature;
+     return _temperature.T;
+  }
+
+  template <typename StateType, typename VectorStateType>
+  inline
+  const StateType & KineticsConditions<StateType,VectorStateType>::Tvib() const
+  {
+     return _temperature.T;
   }
 
   template <typename StateType, typename VectorStateType>
@@ -120,6 +133,12 @@ namespace Antioch{
      return *(_map_pf.at(nr));
   }
 
+  template <typename StateType, typename VectorStateType>
+  inline
+  const TempCache<StateType> & KineticsConditions<StateType,VectorStateType>::temp_cache() const
+  {
+     return _temperature;
+  }
 
 } //end namespace Antioch
 

--- a/src/kinetics/include/antioch/berthelothercourtessen_rate.h
+++ b/src/kinetics/include/antioch/berthelothercourtessen_rate.h
@@ -114,6 +114,30 @@ namespace Antioch
     template <typename StateType>
     void rate_and_derivative(const StateType& T, StateType& rate, StateType& drate_dT) const;
 
+//KineticsConditions overloads
+
+    //! \return the rate evaluated at \p T.
+    template <typename StateType, typename VectorStateType>
+    ANTIOCH_AUTO(StateType)
+    rate(const KineticsConditions<StateType,VectorStateType>& T) const
+    ANTIOCH_AUTOFUNC(StateType, _Cf * ant_exp(_eta * T.temp_cache().lnT + _D*T.T()))
+
+    //! \return the rate evaluated at \p T.
+    template <typename StateType, typename VectorStateType>
+    ANTIOCH_AUTO(StateType)
+    operator()(const KineticsConditions<StateType,VectorStateType>& T) const
+    ANTIOCH_AUTOFUNC(StateType, this->rate(T))
+
+    //! \return the derivative with respect to temperature evaluated at \p T.
+    template <typename StateType, typename VectorStateType>
+    ANTIOCH_AUTO(StateType)
+    derivative( const KineticsConditions<StateType,VectorStateType>& T ) const
+    ANTIOCH_AUTOFUNC(StateType, (*this)(T)*(_eta/T.T() + _D))
+
+    //! Simultaneously evaluate the rate and its derivative at \p T.
+    template <typename StateType,typename VectorStateType>
+    void rate_and_derivative(const KineticsConditions<StateType,VectorStateType>& T, StateType& rate, StateType& drate_dT) const;
+
     //! print equation
     const std::string numeric() const;
 
@@ -130,7 +154,6 @@ namespace Antioch
       _D(D),
       _Tref(Tref)
   {
-    using std::pow;
     this->compute_cf();
     return;
   }
@@ -231,6 +254,18 @@ namespace Antioch
   {
     rate     = (*this)(T);
     drate_dT = rate*(_eta/T + _D);
+    return;
+  }
+
+  template<typename CoeffType>
+  template<typename StateType, typename VectorStateType>
+  inline
+  void BerthelotHercourtEssenRate<CoeffType>::rate_and_derivative( const KineticsConditions<StateType,VectorStateType>& T,
+                                                                   StateType& rate,
+                                                                   StateType& drate_dT) const
+  {
+    rate     = (*this)(T);
+    drate_dT = rate*(_eta/T.T() + _D);
     return;
   }
 

--- a/src/kinetics/include/antioch/kinetics_type.h
+++ b/src/kinetics/include/antioch/kinetics_type.h
@@ -202,19 +202,19 @@ namespace Antioch{
 
       case(KineticsModel::BHE):
         {
-          return (static_cast<const BerthelotHercourtEssenRate<CoeffType>*>(this))->rate(conditions.T());
+          return (static_cast<const BerthelotHercourtEssenRate<CoeffType>*>(this))->rate(conditions);
         }
         break;
 
       case(KineticsModel::KOOIJ):
         {
-          return (static_cast<const KooijRate<CoeffType>*>(this))->rate(conditions.T());
+          return (static_cast<const KooijRate<CoeffType>*>(this))->rate(conditions);
         }
         break;
 
       case(KineticsModel::VANTHOFF):
         {
-          return (static_cast<const VantHoffRate<CoeffType>*>(this))->rate(conditions.T());
+          return (static_cast<const VantHoffRate<CoeffType>*>(this))->rate(conditions);
         }
         break;
 
@@ -279,19 +279,19 @@ namespace Antioch{
 
       case(KineticsModel::BHE):
         {
-          return (static_cast<const BerthelotHercourtEssenRate<CoeffType>*>(this))->derivative(conditions.T());
+          return (static_cast<const BerthelotHercourtEssenRate<CoeffType>*>(this))->derivative(conditions);
         }
         break;
 
       case(KineticsModel::KOOIJ):
         {
-          return (static_cast<const KooijRate<CoeffType>*>(this))->derivative(conditions.T());
+          return (static_cast<const KooijRate<CoeffType>*>(this))->derivative(conditions);
         }
         break;
 
       case(KineticsModel::VANTHOFF):
         {
-          return (static_cast<const VantHoffRate<CoeffType>*>(this))->derivative(conditions.T());
+          return (static_cast<const VantHoffRate<CoeffType>*>(this))->derivative(conditions);
         }
         break;
 
@@ -357,19 +357,19 @@ namespace Antioch{
 
       case(KineticsModel::BHE):
         {
-          (static_cast<const BerthelotHercourtEssenRate<CoeffType>*>(this))->rate_and_derivative(conditions.T(),rate,drate_dT);
+          (static_cast<const BerthelotHercourtEssenRate<CoeffType>*>(this))->rate_and_derivative(conditions,rate,drate_dT);
         }
         break;
 
       case(KineticsModel::KOOIJ):
         {
-          (static_cast<const KooijRate<CoeffType>*>(this))->rate_and_derivative(conditions.T(),rate,drate_dT);
+          (static_cast<const KooijRate<CoeffType>*>(this))->rate_and_derivative(conditions,rate,drate_dT);
         }
         break;
 
       case(KineticsModel::VANTHOFF):
         {
-          (static_cast<const VantHoffRate<CoeffType>*>(this))->rate_and_derivative(conditions.T(),rate,drate_dT);
+          (static_cast<const VantHoffRate<CoeffType>*>(this))->rate_and_derivative(conditions,rate,drate_dT);
         }
         break;
 

--- a/src/kinetics/include/antioch/vanthoff_rate.h
+++ b/src/kinetics/include/antioch/vanthoff_rate.h
@@ -126,6 +126,30 @@ namespace Antioch
     template <typename StateType>
     void rate_and_derivative(const StateType& T, StateType& rate, StateType& drate_dT) const;
 
+// KineticsConditions overloads
+
+    //! \return the rate evaluated at \p T.
+    template <typename StateType, typename VectorStateType>
+    ANTIOCH_AUTO(StateType) 
+    rate(const KineticsConditions<StateType,VectorStateType>& T) const
+    ANTIOCH_AUTOFUNC(StateType, _Cf * ant_exp(_eta * T.temp_cache().lnT - _Ea/T.T() + _D*T.T()))
+
+    //! \return the rate evaluated at \p T.
+    template <typename StateType, typename VectorStateType>
+    ANTIOCH_AUTO(StateType) 
+    operator()(const KineticsConditions<StateType,VectorStateType>& T) const
+    ANTIOCH_AUTOFUNC(StateType, this->rate(T))
+
+    //! \return the derivative with respect to temperature evaluated at \p T.
+    template <typename StateType, typename VectorStateType>
+    ANTIOCH_AUTO(StateType) 
+    derivative( const KineticsConditions<StateType,VectorStateType>& T ) const
+    ANTIOCH_AUTOFUNC(StateType, (*this)(T)*(_D + _eta/T.T() + _Ea/(T.temp_cache().T2)))
+
+    //! Simultaneously evaluate the rate and its derivative at \p T.
+    template <typename StateType, typename VectorStateType>
+    void rate_and_derivative(const KineticsConditions<StateType,VectorStateType>& T, StateType& rate, StateType& drate_dT) const;
+
     //! print equation
     const std::string numeric() const;
 
@@ -285,6 +309,18 @@ namespace Antioch
   {
     rate     = (*this)(T);
     drate_dT = rate*(_D + _eta/T + _Ea/(T*T));
+    return;
+  }
+
+  template<typename CoeffType>
+  template<typename StateType, typename VectorStateType>
+  inline
+  void VantHoffRate<CoeffType>::rate_and_derivative( const KineticsConditions<StateType,VectorStateType>& T,
+                                                     StateType& rate,
+                                                     StateType& drate_dT) const
+  {
+    rate     = (*this)(T);
+    drate_dT = rate*(_D + _eta/T.T() + _Ea/(T.temp_cache().T2));
     return;
   }
 

--- a/src/thermo/include/antioch/temp_cache.h
+++ b/src/thermo/include/antioch/temp_cache.h
@@ -31,6 +31,9 @@
 #ifndef ANTIOCH_TEMP_CACHE_H
 #define ANTIOCH_TEMP_CACHE_H
 
+// Antioch
+#include "antioch/cmath_shims.h"
+
 namespace Antioch
 {
   template<typename StateType=double>
@@ -62,9 +65,8 @@ namespace Antioch
   TempCache<StateType>::TempCache(const StateType& T_in)
     : T(T_in), T2(T*T), T3(T2*T), T4(T2*T2), lnT(T_in)
   {
-    using std::log;
 
-    lnT = log(T);
+    lnT = ant_log(T);
     return;
   }
 

--- a/src/transport/include/antioch/wilke_transport_evaluator.h
+++ b/src/transport/include/antioch/wilke_transport_evaluator.h
@@ -34,7 +34,7 @@
 // Antioch
 #include "antioch/metaprogramming.h"
 #include "antioch/physics_metaprogramming_decl.h"
-#include "antioch/temp_cache.h"
+#include "antioch/kinetics_conditions.h"
 #include "antioch/wilke_mixture.h"
 
 namespace Antioch
@@ -56,43 +56,45 @@ namespace Antioch
     ~WilkeTransportEvaluator();
 
     //! mixture level diffusion, array of values
-    template <typename StateType, typename VectorStateType>
-    void D( const StateType& T, const StateType & rho, const StateType & cTot,
+    template <typename TC, typename StateType, typename VectorStateType>
+    void D( const TC& cond, const StateType & rho, const StateType & cTot,
             const VectorStateType& mass_fractions, const VectorStateType& mu,
             VectorStateType & ds) const;
 
     //! mixture level viscosity, one value
-    template <typename StateType, typename VectorStateType>
-    StateType mu( const StateType& T,
+    template <typename TC, typename VectorStateType>
+    typename value_type<VectorStateType>::type
+         mu( const TC& conditions,
                   const VectorStateType& mass_fractions ) const;
 
     //! mixture level thermal conduction, one value
-    template <typename StateType, typename VectorStateType>
-    StateType k( const StateType& T,
+    template <typename TC, typename VectorStateType>
+    typename value_type<VectorStateType>::type 
+        k( const TC & conditions,
                  const VectorStateType& mass_fractions ) const;
 
     //! mixture level thermal conduction and viscosity, one value
-    template <typename StateType, typename VectorStateType>
-    void mu_and_k( const StateType& T,
+    template <typename TC, typename StateType, typename VectorStateType>
+    void mu_and_k( const TC& conditions,
                    const VectorStateType& mass_fractions,
                    StateType& mu, StateType& k ) const;
 
     //! Thermal conduction and diffusion, helper function
-    template <typename StateType, typename VectorStateType>
-    void D_and_k(const VectorStateType & mu, const StateType & T, const StateType & rho, 
-                 const VectorStateType & mass_fractions, VectorStateType & k, VectorStateType & D) const;
+    template <typename TC, typename StateType, typename VectorStateType>
+    void D_and_k(const VectorStateType & mu, const TC& conditions, const StateType & rho, 
+                 const VectorStateType & mass_fractions, VectorStateType & k, VectorStateType & ds) const;
 
     //! mixture level thermal conduction, viscosity (one value) and diffusion (array of values)
-    template <typename StateType, typename VectorStateType>
-    void mu_and_k_and_D( const StateType& T, const StateType & rho,
+    template <typename TC,typename StateType, typename VectorStateType>
+    void mu_and_k_and_D( const TC& conditions, const StateType & rho,
                    const VectorStateType& mass_fractions,
                    StateType& mu, StateType& k, VectorStateType & Ds ) const;
 
     //! Helper function to reduce code duplication.
     /*! Populates species viscosities and the intermediate \chi variable
         needed for Wilke's mixing rule. */
-    template <typename StateType, typename VectorStateType>
-    void compute_mu_chi( const StateType& T,
+    template <typename TC, typename VectorStateType>
+    void compute_mu_chi( const TC& conditions,
                          const VectorStateType& mass_fractions,
                          VectorStateType& mu,
                          VectorStateType& chi ) const;
@@ -142,47 +144,56 @@ namespace Antioch
   }
 
   template<class Diffusion, class Viscosity, class ThermalConductivity, class Mixture, class CoeffType>
-  template <typename StateType, typename VectorStateType>
-  void WilkeTransportEvaluator<Diffusion,Viscosity,ThermalConductivity,Mixture,CoeffType>::D( const StateType& T,
+  template <typename TC, typename StateType, typename VectorStateType>
+  void WilkeTransportEvaluator<Diffusion,Viscosity,ThermalConductivity,Mixture,CoeffType>::D( const TC& conditions,
                                                                                         const StateType & rho, const StateType & cTot,
                                                                                         const VectorStateType& mass_fractions,
                                                                                         const VectorStateType& mu,
                                                                                               VectorStateType & ds) const
   {
+
+    typename constructor_or_reference<const KineticsConditions<StateType,VectorStateType>, const TC>::type  //either (KineticsConditions<> &) or (KineticsConditions<>)
+                transport_conditions(conditions);
+
 // first way
 // \todo: if not needed, find a way to supress Ds building
 // \todo: initialization as full squared matrix, even though half is needed and used
      typename rebind<VectorStateType,VectorStateType>::type Ds(ds.size());
      init_constant(Ds,ds);
-     _diffusion.compute_binary_diffusion_matrix(T,cTot,Ds );
+     _diffusion.compute_binary_diffusion_matrix(transport_conditions,cTot,Ds );
      wilke_diffusion_rule(_mixture().transport_mixture().chemical_mixture(), mass_fractions, Ds, ds, typename physical_tag<typename Diffusion::model>::diffusion_species_type ());
 
 // second way
 // \todo: if not needed, find a way to supress k building
 // \todo: Ds[s][s] not needed here
-     StateType k = zero_clone(T);
+     StateType k = zero_clone(transport_conditions.T());
      for(unsigned int s = 0; s < _mixture.transport_mixture().n_species(); s++)
      {
-        _conductivity.compute_thermal_conductivity(s,mu[s],Ds[s][s],T,cTot * _mixture().transport_mixture().chemical_mixture().M(s),k);
-        _diffusion.compute_diffusivity(_mixture.thermo_evaluator().cp(TempCache<StateType>(T),s), k, ds[s]); // \todo, solve this by KineticsConditions
+        _conductivity.compute_thermal_conductivity(s,mu[s],Ds[s][s],transport_conditions,cTot * _mixture().transport_mixture().chemical_mixture().M(s),k);
+        _diffusion.compute_diffusivity(_mixture.thermo_evaluator().cp(transport_conditions.temp_cache(),s), k, ds[s]); // \todo, solve this by KineticsConditions
      }
   }
 
   template<class Diffusion, class Viscosity, class ThermalConductivity, class Mixture, class CoeffType>
-  template <typename StateType, typename VectorStateType>
-  StateType WilkeTransportEvaluator<Diffusion,Viscosity,ThermalConductivity,Mixture,CoeffType>::mu( const StateType& T,
+  template <typename TC, typename VectorStateType>
+  typename value_type<VectorStateType>::type
+         WilkeTransportEvaluator<Diffusion,Viscosity,ThermalConductivity,Mixture,CoeffType>::mu( const TC& conditions,
                                                                          const VectorStateType& mass_fractions ) const
   {
-    StateType mu_mix = zero_clone(T);
+
+    typename constructor_or_reference<const KineticsConditions<typename value_type<VectorStateType>::type,VectorStateType>, const TC>::type  //either (KineticsConditions<> &) or (KineticsConditions<>)
+                transport_conditions(conditions);
+
+    typename value_type<VectorStateType>::type mu_mix = zero_clone(transport_conditions.T());
     
     VectorStateType mu  = zero_clone(mass_fractions);
     VectorStateType chi = zero_clone(mass_fractions);
     
-    this->compute_mu_chi( T, mass_fractions, mu, chi );
+    this->compute_mu_chi( transport_conditions, mass_fractions, mu, chi );
 
     for( unsigned int s = 0; s < _mixture.chem_mixture().n_species(); s++ )
       {
-        StateType phi_s = this->compute_phi( mu, chi, s );
+        typename value_type<VectorStateType>::type phi_s = this->compute_phi( mu, chi, s );
         
         mu_mix += mu[s]*chi[s]/phi_s;
       }
@@ -191,25 +202,29 @@ namespace Antioch
   }
 
   template<class Diffusion, class Viscosity, class ThermalConductivity, class Mixture, class CoeffType>
-  template <typename StateType, typename VectorStateType>
-  StateType WilkeTransportEvaluator<Diffusion,Viscosity,ThermalConductivity,Mixture,CoeffType>::k( const StateType& T,
+  template <typename TC, typename VectorStateType>
+  typename value_type<VectorStateType>::type
+        WilkeTransportEvaluator<Diffusion,Viscosity,ThermalConductivity,Mixture,CoeffType>::k( const TC& conditions,
                                                                         const VectorStateType& mass_fractions ) const
   {
     antioch_assert_equal_to(mass_fractions.size(), _mixture.chem_mixture().n_species());
 
-    StateType k_mix = zero_clone(T);
+    typename constructor_or_reference<const KineticsConditions<typename value_type<VectorStateType>::type,VectorStateType>, const TC>::type  //either (KineticsConditions<> &) or (KineticsConditions<>)
+                transport_conditions(conditions);
+
+    typename value_type<VectorStateType>::type k_mix = zero_clone(transport_conditions.T());
 
     VectorStateType mu  = zero_clone(mass_fractions);
     VectorStateType chi = zero_clone(mass_fractions);
 
-    this->compute_mu_chi( T, mass_fractions, mu, chi );
+    this->compute_mu_chi( transport_conditions, mass_fractions, mu, chi );
 
     for( unsigned int s = 0; s < _mixture.chem_mixture().n_species(); s++ )
       {
-        StateType phi_s = this->compute_phi( mu, chi, s );
+        typename value_type<VectorStateType>::type  phi_s = this->compute_phi( mu, chi, s );
         
-        StateType k_s = zero_clone(T);
-        _conductivity.compute_thermal_conductivity( s, mu[s], zero_clone(T),T, zero_clone(T), k_s); //\todo, better management
+        typename value_type<VectorStateType>::type  k_s = zero_clone(transport_conditions.T());
+        _conductivity.compute_thermal_conductivity( s, mu[s], zero_clone(transport_conditions.T()),transport_conditions, zero_clone(transport_conditions.T()), k_s); //\todo, better management
 
         k_mix += k_s*chi[s]/phi_s;
       }
@@ -218,26 +233,29 @@ namespace Antioch
   }
 
   template<class Diffusion, class Viscosity, class ThermalConductivity, class Mixture, class CoeffType>
-  template <typename StateType, typename VectorStateType>
-  void WilkeTransportEvaluator<Diffusion,Viscosity,ThermalConductivity,Mixture,CoeffType>::mu_and_k( const StateType& T,
+  template <typename TC, typename StateType, typename VectorStateType>
+  void WilkeTransportEvaluator<Diffusion,Viscosity,ThermalConductivity,Mixture,CoeffType>::mu_and_k( const TC& conditions,
                                                                           const VectorStateType& mass_fractions,
                                                                           StateType& mu_mix,
                                                                           StateType& k_mix ) const
   {
-    mu_mix = zero_clone(T);
-    k_mix  = zero_clone(T);
+    typename constructor_or_reference<const KineticsConditions<StateType,VectorStateType>, const TC>::type  //either (KineticsConditions<> &) or (KineticsConditions<>)
+                transport_conditions(conditions);
+
+    mu_mix = zero_clone(transport_conditions.T());
+    k_mix  = zero_clone(transport_conditions.T());
 
     VectorStateType mu  = zero_clone(mass_fractions);
     VectorStateType chi = zero_clone(mass_fractions);
 
-    this->compute_mu_chi( T, mass_fractions, mu, chi );
+    this->compute_mu_chi( transport_conditions, mass_fractions, mu, chi );
 
     for( unsigned int s = 0; s < _mixture.transport_mixture().n_species(); s++ )
       {
         StateType phi_s = this->compute_phi( mu, chi, s );
         
-        StateType k_s = zero_clone(T);
-        _conductivity.compute_thermal_conductivity( s, mu[s], zero_clone(T),T, zero_clone(T), k_s); //\todo, better management
+        StateType k_s = zero_clone(transport_conditions.T());
+        _conductivity.compute_thermal_conductivity( s, mu[s], zero_clone(transport_conditions.T()),transport_conditions, zero_clone(transport_conditions.T()), k_s); //\todo, better management
 
         mu_mix += mu[s]*chi[s]/phi_s;
         k_mix += k_s*chi[s]/phi_s;
@@ -247,13 +265,17 @@ namespace Antioch
   }
 
   template<class Diffusion, class Viscosity, class ThermalConductivity, class Mixture, class CoeffType>
-  template <typename StateType, typename VectorStateType>
-  void WilkeTransportEvaluator<Diffusion,Viscosity,ThermalConductivity,Mixture,CoeffType>::D_and_k(const VectorStateType & mu, const StateType & T, const StateType & rho, 
+  template <typename TC, typename StateType, typename VectorStateType>
+  void WilkeTransportEvaluator<Diffusion,Viscosity,ThermalConductivity,Mixture,CoeffType>::D_and_k(const VectorStateType & mu, const TC & conditions, const StateType & rho, 
                                                                                   const VectorStateType & mass_fractions, VectorStateType & k, VectorStateType & ds) const
   {
      antioch_assert_equal_to(ds.size(),mass_fractions.size());
      antioch_assert_equal_to(ds.size(),_mixture.transport_mixture().n_species());
      antioch_assert_equal_to(mu.size(),_mixture.transport_mixture().n_species());
+
+    typename constructor_or_reference<const KineticsConditions<StateType,VectorStateType>, const TC>::type  //either (KineticsConditions<> &) or (KineticsConditions<>)
+                transport_conditions(conditions);
+
      const StateType n_molar_mixture = rho / _mixture.transport_mixture().chemical_mixture().M(mass_fractions); // total molar density
 
 // diffusion comes first
@@ -261,40 +283,44 @@ namespace Antioch
 // \todo: initialization as full squared matrix, even though half is needed and used
      typename Antioch::rebind<VectorStateType,VectorStateType>::type Ds(mass_fractions.size());
      init_constant(Ds,ds);
-     _diffusion.compute_binary_diffusion_matrix(T, n_molar_mixture, Ds);
+     _diffusion.compute_binary_diffusion_matrix(transport_conditions, n_molar_mixture, Ds);
      wilke_diffusion_rule(_mixture.transport_mixture().chemical_mixture(), mass_fractions, Ds, ds, typename physical_tag<typename Diffusion::model>::diffusion_species_type ());
 
 // thermal conduction
     for(unsigned int s = 0; s < _mixture.transport_mixture().n_species(); s++)
     {
-      _diffusion.compute_self_diffusion(s,T,n_molar_mixture,Ds[s][s]);
-      _conductivity.compute_thermal_conductivity(s,mu[s],Ds[s][s],T,n_molar_mixture * _mixture.transport_mixture().chemical_mixture().M(s),k[s]);
+      _diffusion.compute_self_diffusion(s,transport_conditions,n_molar_mixture,Ds[s][s]);
+      _conductivity.compute_thermal_conductivity(s,mu[s],Ds[s][s],transport_conditions,n_molar_mixture * _mixture.transport_mixture().chemical_mixture().M(s),k[s]);
     }
 
 // diffusion comes last
     for(unsigned int s = 0; s < _mixture.transport_mixture().n_species(); s++)
-        _diffusion.compute_diffusivity(rho, _mixture.thermo_evaluator().cp(TempCache<StateType>(T),s), k[s], ds[s] );
+        _diffusion.compute_diffusivity(rho, _mixture.thermo_evaluator().cp(transport_conditions.temp_cache(),s), k[s], ds[s] );
   }
 
   template<class Diffusion, class Viscosity, class ThermalConductivity, class Mixture, class CoeffType>
-  template <typename StateType, typename VectorStateType>
-  void WilkeTransportEvaluator<Diffusion,Viscosity,ThermalConductivity,Mixture,CoeffType>::mu_and_k_and_D( const StateType& T, const StateType & rho,
+  template <typename TC, typename StateType, typename VectorStateType>
+  void WilkeTransportEvaluator<Diffusion,Viscosity,ThermalConductivity,Mixture,CoeffType>::mu_and_k_and_D( const TC& conditions, const StateType & rho,
                                                                                           const VectorStateType& mass_fractions,
                                                                                                 StateType& mu_mix,
                                                                                                 StateType& k_mix,
                                                                                                 VectorStateType & ds ) const
   {
-    mu_mix = zero_clone(T);
-    k_mix  = zero_clone(T);
+
+    typename constructor_or_reference<const KineticsConditions<StateType,VectorStateType>, const TC>::type  //either (KineticsConditions<> &) or (KineticsConditions<>)
+                transport_conditions(conditions);
+
+    mu_mix = zero_clone(transport_conditions.T());
+    k_mix  = zero_clone(transport_conditions.T());
     ds = zero_clone(mass_fractions);
 
     VectorStateType mu  = zero_clone(mass_fractions);
     VectorStateType k  = zero_clone(mass_fractions);
     VectorStateType chi = zero_clone(mass_fractions);
 
-    this->compute_mu_chi( T, mass_fractions, mu, chi );
+    this->compute_mu_chi( transport_conditions, mass_fractions, mu, chi );
 
-    this->D_and_k(mu, T, rho , mass_fractions, k, ds );
+    this->D_and_k(mu, transport_conditions, rho , mass_fractions, k, ds );
 
     for( unsigned int s = 0; s < _mixture.transport_mixture().n_species(); s++ )
       {
@@ -308,19 +334,23 @@ namespace Antioch
   }
 
   template<class Diffusion, class Viscosity, class ThermalConductivity, class Mixture, class CoeffType>
-  template <typename StateType, typename VectorStateType>
-  void WilkeTransportEvaluator<Diffusion,Viscosity,ThermalConductivity,Mixture,CoeffType>::compute_mu_chi( const StateType& T,
+  template <typename TC, typename VectorStateType>
+  void WilkeTransportEvaluator<Diffusion,Viscosity,ThermalConductivity,Mixture,CoeffType>::compute_mu_chi( const TC& conditions,
                                                                                 const VectorStateType& mass_fractions,
                                                                                 VectorStateType& mu,
                                                                                 VectorStateType& chi ) const
   {
-    const StateType M = _viscosity.mixture().M(mass_fractions);
+
+    typename constructor_or_reference<const KineticsConditions<typename value_type<VectorStateType>::type,VectorStateType>, const TC>::type  //either (KineticsConditions<> &) or (KineticsConditions<>)
+                transport_conditions(conditions);
+
+    const typename value_type<VectorStateType>::type M = _viscosity.mixture().M(mass_fractions);
 
     // Precompute needed quantities
     // chi_s = w_s*M/M_s
     for( unsigned int s = 0; s < _mixture.chem_mixture().n_species(); s++ )
       {
-        _viscosity.compute_viscosity(s,T,mu[s]);
+        _viscosity.compute_viscosity(s,transport_conditions,mu[s]);
         chi[s] = mass_fractions[s]*M/_viscosity.mixture().M(s);
       }
 

--- a/test/duplicate_process_unit.C
+++ b/test/duplicate_process_unit.C
@@ -42,11 +42,11 @@ int tester()
   const Scalar Cf1 = 1.4;
   const Scalar Ea1 = 5.0;
   const Scalar beta1 = 1.2;
-  const Scalar D1 = 2.5;
+  const Scalar D1 = 2.5e-2;
   const Scalar Cf2 = 2.0;
   const Scalar Ea2 = 3.0;
   const Scalar beta2 = 0.8;
-  const Scalar D2 = 3.0;
+  const Scalar D2 = 3.0e-2;
 
   const std::string equation("A + B -> C + D");
   const unsigned int n_species(4);

--- a/test/elementary_process_unit.C
+++ b/test/elementary_process_unit.C
@@ -38,20 +38,20 @@ int tester()
   using std::exp;
   using std::pow;
 
-  const Scalar Cf = 1.4;
-  const Scalar Ea = 5.0;
-  const Scalar beta = 1.2;
-  const Scalar D = 2.5;
+  const Scalar Cf = 1.4L;
+  const Scalar Ea = 5.0L;
+  const Scalar beta = 1.2L;
+  const Scalar D = 2.5e-2L;
 
   const std::string equation("A + B -> C + D");
   const unsigned int n_species(4);
 
   int return_flag = 0;
   std::vector<Scalar> mol_densities;
-  mol_densities.push_back(1e-2);
-  mol_densities.push_back(1e-2);
-  mol_densities.push_back(1e-2);
-  mol_densities.push_back(1e-2);
+  mol_densities.push_back(1e-2L);
+  mol_densities.push_back(1e-2L);
+  mol_densities.push_back(1e-2L);
+  mol_densities.push_back(1e-2L);
 
   const Scalar tol = std::numeric_limits<Scalar>::epsilon() * 100;
 

--- a/test/kinetics_settings_unit.C
+++ b/test/kinetics_settings_unit.C
@@ -212,7 +212,7 @@ int tester()
 
 //// reset
   Scalar Cf_reset = 1e-7L;
-  Scalar eta_reset = 0.8L;
+  Scalar eta_reset = 1.5L;
   Scalar Ea_reset = 36000.L;
   Scalar D_reset = -5.e-2L;
   Scalar Tref_reset = 298.;

--- a/test/lindemann_falloff_unit.C
+++ b/test/lindemann_falloff_unit.C
@@ -42,11 +42,11 @@ int tester()
   const Scalar Cf1 = 1.4;
   const Scalar Ea1 = 5.0;
   const Scalar beta1 = 1.2;
-  const Scalar D1 = 2.5;
+  const Scalar D1 = 2.5e-3;
   const Scalar Cf2 = 2.0;
   const Scalar Ea2 = 3.0;
   const Scalar beta2 = 0.8;
-  const Scalar D2 = 3.0;
+  const Scalar D2 = -3.0e-3;
 
   const std::string equation("A + B -> C + D");
   const unsigned int n_species(4);
@@ -63,7 +63,7 @@ int tester()
      M += mol_densities[i];
   }
 
-  const Scalar tol = std::numeric_limits<Scalar>::epsilon() * 100;
+  const Scalar tol = std::numeric_limits<Scalar>::epsilon() * 500;
 
   for(Scalar T = 300.1; T <= 2500.1; T += 10.)
   {
@@ -100,6 +100,7 @@ int tester()
         rate_kinetics2 = new Antioch::BerthelotRate<Scalar>(Cf2,D2);
         k0 = Cf1 * exp(D1*T); kinf = Cf2 * exp(D2*T);
         dk0_dT = Cf1 * exp(D1*T) * D1; dkinf_dT = Cf2 * exp(D2*T) * D2;
+
         break;
       }
       case 2:
@@ -216,7 +217,6 @@ int tester()
       }
 
     delete fall_reaction;
-    if(return_flag)return return_flag;
     }
   }
 

--- a/test/threebody_process_unit.C
+++ b/test/threebody_process_unit.C
@@ -41,7 +41,7 @@ int tester()
   const Scalar Cf = 1.4;
   const Scalar Ea = 5.0;
   const Scalar beta = 1.2;
-  const Scalar D = 2.5;
+  const Scalar D = 2.5e-2;
 
   const std::string equation("A + B -> C + D");
   const unsigned int n_species(4);


### PR DESCRIPTION
Supersedes PR #96.

![graph](https://cloud.githubusercontent.com/assets/4761614/6497422/1caf06f8-c2a5-11e4-9cf0-e18cbee45ba7.jpg)

It overloads the rate constant calculations for all the models having a ```T^\beta * exp(-Ea/T)``` part with a ```KineticsConditions``` objects to compute instead ```exp(\beta * lnT - Ea/T```.