### PR TITLE
Bugfix.

### DIFF
--- a/src/parsing/include/antioch/read_reaction_set_data.h
+++ b/src/parsing/include/antioch/read_reaction_set_data.h
@@ -173,7 +173,7 @@ namespace Antioch
         bool found(false);
         for(unsigned int i = 0; i < accepted_unit.size(); i++)
         {
-           if(default_unit.is_homogeneous(provided_unit))
+           if(Units<NumericType>(accepted_unit[i]).is_homogeneous(provided_unit))
            {
               found = true;
               break;

--- a/test/input_files/test_parsing.xml
+++ b/test/input_files/test_parsing.xml
@@ -126,14 +126,14 @@
     </reaction>
     
     
-    <!-- reaction 0006    -->
+    <!-- reaction 0006 <E units="cal/mol"> 138812.8</E>, computed with bc    -->
     <reaction reversible="yes" type="Elementary" id="0006">
       <equation>C2 [=] 2 C </equation>
       <rateCoeff>
         <ModifiedArrhenius>
            <A>3.7e+11</A>
            <b>-0.42</b>
-           <E units="cal/mol">138812.8</E>
+           <E units="K">69900</E>
         </ModifiedArrhenius>
       </rateCoeff>
       <reactants>C2:1</reactants>

--- a/test/parsing_xml.C
+++ b/test/parsing_xml.C
@@ -247,8 +247,9 @@ int tester(const std::string &root_name)
 //C2 -> 2 C
   A = 3.7e11 * unitA_0.get_SI_factor();
   beta = -0.42;
-  Ea = 138812.8;
-  k.push_back(Kooij(T,A,beta,Ea,Tr,Rcal));
+//  Ea = 138812.8; // cal/mol
+  Ea = 69900; // K
+  k.push_back(Kooij(T,A,beta,Ea,Tr,Scalar(1)));
 
 //CN -> C + N
   A = 2.5e11 * unitA_0.get_SI_factor();


### PR DESCRIPTION
  The unit was tested against the default unit, and this default
  unit is only for message purpose...

The *default_unit* is only to print the desired type of unit is none is provided, and I used it to compare...

Well it fixes the bug of issue #122.