### PR TITLE
Parser/const

### DIFF
--- a/src/kinetics/include/antioch/reaction.h
+++ b/src/kinetics/include/antioch/reaction.h
@@ -263,7 +263,7 @@ namespace Antioch
 
     template <typename StateType, typename VectorStateType>
     void compute_rate_of_progress_and_derivatives( const VectorStateType &molar_densities,
-                                                   const ChemicalMixture<CoeffType>& chem_mixture,
+                                                   const ChemicalMixture<CoeffType>& /*chem_mixture*/, // fully useless, why is it here?
                                                    const KineticsConditions<StateType,VectorStateType>& conditions,
                                                    const StateType &P0_RT,
                                                    const VectorStateType &h_RT_minus_s_R,
@@ -987,7 +987,7 @@ namespace Antioch
   template <typename StateType, typename VectorStateType>
   inline
   void Reaction<CoeffType,VectorCoeffType>::compute_rate_of_progress_and_derivatives( const VectorStateType &molar_densities,
-                                                                      const ChemicalMixture<CoeffType>& chem_mixture,
+                                                                      const ChemicalMixture<CoeffType>& /*chem_mixture*/,
                                                                       const KineticsConditions<StateType,VectorStateType>& conditions,
                                                                       const StateType &P0_RT,
                                                                       const VectorStateType &h_RT_minus_s_R,

--- a/src/parsing/include/antioch/chemkin_parser.h
+++ b/src/parsing/include/antioch/chemkin_parser.h
@@ -106,17 +106,25 @@ namespace Antioch{
 ////////////////// thermo
 
 //global overload
+// it seems that they're all linked in
+// a way so they shadow themselves
+// => we need to implement all or nothing
+
         //! reads the thermo, NASA generalist, no templates for virtual
         void read_thermodynamic_data(NASAThermoMixture<NumericType, NASA7CurveFit<NumericType> >& thermo)
                 {this->read_thermodynamic_data_root(thermo);}
 
         //! reads the thermo, NASA generalist, no templates for virtual
         void read_thermodynamic_data(NASAThermoMixture<NumericType, NASA9CurveFit<NumericType> >& thermo)
-                {this->read_thermodynamic_data_root(thermo);}
+                {ParserBase<NumericType>::not_implemented(11);}
 
         //! reads the thermo, NASA generalist, no templates for virtual
         void read_thermodynamic_data(NASAThermoMixture<NumericType, CEACurveFit<NumericType> >& thermo)  
-                {this->read_thermodynamic_data_root(thermo);}
+                {ParserBase<NumericType>::not_implemented(12);}
+
+        //! reads the thermo, CEA deprecated 
+        void read_thermodynamic_data(CEAThermodynamics<NumericType >& thermo)  
+                {ParserBase<NumericType>::not_implemented(13);}
 
 ///////////////// kinetics
 

--- a/src/parsing/include/antioch/chemkin_parser.h
+++ b/src/parsing/include/antioch/chemkin_parser.h
@@ -116,15 +116,15 @@ namespace Antioch{
 
         //! reads the thermo, NASA generalist, no templates for virtual
         void read_thermodynamic_data(NASAThermoMixture<NumericType, NASA9CurveFit<NumericType> >& thermo)
-                {ParserBase<NumericType>::not_implemented(11);}
+                {antioch_not_implemented_msg(ParserBase<NumericType>::_not_implemented);}
 
         //! reads the thermo, NASA generalist, no templates for virtual
         void read_thermodynamic_data(NASAThermoMixture<NumericType, CEACurveFit<NumericType> >& thermo)  
-                {ParserBase<NumericType>::not_implemented(12);}
+                {antioch_not_implemented_msg(ParserBase<NumericType>::_not_implemented);}
 
         //! reads the thermo, CEA deprecated 
         void read_thermodynamic_data(CEAThermodynamics<NumericType >& thermo)  
-                {ParserBase<NumericType>::not_implemented(13);}
+                {antioch_not_implemented_msg(ParserBase<NumericType>::_not_implemented);}
 
 ///////////////// kinetics
 

--- a/src/parsing/include/antioch/parser_base.h
+++ b/src/parsing/include/antioch/parser_base.h
@@ -117,16 +117,16 @@ namespace Antioch
 
 /// species
         //! reads the species set
-        virtual const std::vector<std::string> species_list() {not_implemented(); return std::vector<std::string>();}
+        virtual const std::vector<std::string> species_list() {not_implemented(0); return std::vector<std::string>();}
 
         //! reads the mandatory data, not valid in xml && chemkin
-        virtual void read_chemical_species(ChemicalMixture<NumericType> & /*chem_mixture*/)  {not_implemented();}
+        virtual void read_chemical_species(ChemicalMixture<NumericType> & /*chem_mixture*/)  {not_implemented(1);}
 
         //! reads the vibrational data, not valid in xml && chemkin
-        virtual void read_vibrational_data(ChemicalMixture<NumericType> & /*chem_mixture*/)  {not_implemented();}
+        virtual void read_vibrational_data(ChemicalMixture<NumericType> & /*chem_mixture*/)  {not_implemented(2);}
 
         //! reads the electronic data, not valid in xml && chemkin
-        virtual void read_electronic_data(ChemicalMixture<NumericType> & /*chem_mixture*/)  {not_implemented();}
+        virtual void read_electronic_data(ChemicalMixture<NumericType> & /*chem_mixture*/)  {not_implemented(3);}
 
 // transport, the thermo is explicit...
 
@@ -135,21 +135,21 @@ namespace Antioch
         virtual void read_transport_data(TransportMixture< ThermoHandler < NumericType, 
                                                                            NASAEvaluator<NumericType,NASA7CurveFit<NumericType> >,
                                                                            StatMechThermodynamics<NumericType> >,
-                                                           NumericType > & /*transport_mixture*/)  {not_implemented();}
+                                                           NumericType > & /*transport_mixture*/)  {not_implemented(4);}
 
         //! reads the transport data, not valid in xml && chemkin
         //  NASA9 + StatMech
         virtual void read_transport_data(TransportMixture< ThermoHandler < NumericType, 
                                                                            NASAEvaluator<NumericType,NASA9CurveFit<NumericType> >,
                                                                            StatMechThermodynamics<NumericType> >,
-                                                           NumericType > & /*transport_mixture*/)  {not_implemented();}
+                                                           NumericType > & /*transport_mixture*/)  {not_implemented(5);}
 
         //! reads the transport data, not valid in xml && chemkin
         //  CEA + StatMech for backward compat
         virtual void read_transport_data(TransportMixture< ThermoHandler < NumericType, 
                                                                            CEAEvaluator<NumericType>,
                                                                            StatMechThermodynamics<NumericType> >,
-                                                           NumericType > & /*transport_mixture*/)  {not_implemented();}
+                                                           NumericType > & /*transport_mixture*/)  {not_implemented(6);}
 
         //! reads the transport data, not valid in xml && chemkin
         //  NASA7 + Ideal Gas
@@ -157,7 +157,7 @@ namespace Antioch
                                                                            NASAEvaluator<NumericType,NASA7CurveFit<NumericType> >,
                                                                            IdealGasMicroThermo<NASAEvaluator<NumericType,NASA7CurveFit<NumericType> >, NumericType> 
                                                                          >,
-                                                           NumericType > & /*transport_mixture*/)  {not_implemented();}
+                                                           NumericType > & /*transport_mixture*/)  {not_implemented(7);}
 
         //! reads the transport data, not valid in xml && chemkin
         //  NASA9 + Ideal Gas
@@ -165,7 +165,7 @@ namespace Antioch
                                                                            NASAEvaluator<NumericType,NASA9CurveFit<NumericType> >,
                                                                            IdealGasMicroThermo<NASAEvaluator<NumericType,NASA9CurveFit<NumericType> >, NumericType> 
                                                                          >,
-                                                           NumericType > & /*transport_mixture*/)  {not_implemented();}
+                                                           NumericType > & /*transport_mixture*/)  {not_implemented(8);}
 
         //! reads the transport data, not valid in xml && chemkin
         //  CEA + Ideal Gas for backward compat
@@ -173,100 +173,99 @@ namespace Antioch
                                                                            CEAEvaluator<NumericType>,
                                                                            IdealGasMicroThermo<CEAEvaluator<NumericType>,NumericType> 
                                                                          >,
-                                                           NumericType > & /*transport_mixture*/)  {not_implemented();}
+                                                           NumericType > & /*transport_mixture*/)  {not_implemented(9);}
 
 
 /// thermo
 
         //! reads the thermo, NASA generalist, no templates for virtual
-        virtual void read_thermodynamic_data(NASAThermoMixture<NumericType, NASA7CurveFit<NumericType> >& /*thermo*/)  {not_implemented();}
+        virtual void read_thermodynamic_data(NASAThermoMixture<NumericType, NASA7CurveFit<NumericType> >& /*thermo*/)  {not_implemented(10);}
 
         //! reads the thermo, NASA generalist, no templates for virtual
-        virtual void read_thermodynamic_data(NASAThermoMixture<NumericType, NASA9CurveFit<NumericType> >& /*thermo*/)  {not_implemented();}
+        virtual void read_thermodynamic_data(NASAThermoMixture<NumericType, NASA9CurveFit<NumericType> >& /*thermo*/)  {not_implemented(11);}
 
         //! reads the thermo, NASA generalist, no templates for virtual
-        virtual void read_thermodynamic_data(NASAThermoMixture<NumericType, CEACurveFit<NumericType> >& /*thermo*/)  {not_implemented();}
+        virtual void read_thermodynamic_data(NASAThermoMixture<NumericType, CEACurveFit<NumericType> >& /*thermo*/)  {not_implemented(12);}
 
         //! reads the thermo, CEA deprecated
-        virtual void read_thermodynamic_data(CEAThermodynamics<NumericType >& /*thermo*/)  {not_implemented();}
-
+        virtual void read_thermodynamic_data(CEAThermodynamics<NumericType >& /*thermo*/)  {not_implemented(13);}
 
 /// reaction
 
          /*! read & store current reaction and go to next reaction*/
-         virtual bool reaction() {not_implemented(); return false;}
+         virtual bool reaction() {not_implemented(14); return false;}
 
          /*! go to next rate constant*/
-         virtual bool rate_constant(const std::string & /*kinetics_model*/) {not_implemented(); return false;}
+         virtual bool rate_constant(const std::string & /*kinetics_model*/) {not_implemented(15); return false;}
 
          /*! \return true if there's a Troe block*/
-         virtual bool Troe() const {not_implemented(); return false;}
+         virtual bool Troe() const {not_implemented(16); return false;}
 
          /*! \return reaction id, 0 if not provided*/
-         virtual const std::string reaction_id() const  {not_implemented(); return std::string();}
+         virtual const std::string reaction_id() const  {not_implemented(17); return std::string();}
 
          /*! \return reaction equation */
-         virtual const std::string reaction_equation() const {not_implemented(); return std::string();}
+         virtual const std::string reaction_equation() const {not_implemented(18); return std::string();}
 
          /*! \return reaction chemical process*/
-         virtual const std::string reaction_chemical_process() const {not_implemented(); return std::string();}
+         virtual const std::string reaction_chemical_process() const {not_implemented(19); return std::string();}
 
          /*! \return reaction kinetics model*/
-         virtual const std::string reaction_kinetics_model(const std::vector<std::string> & /*kinetics_models*/) const  {not_implemented(); return std::string();}
+         virtual const std::string reaction_kinetics_model(const std::vector<std::string> & /*kinetics_models*/) const  {not_implemented(20); return std::string();}
 
          /*! \return reversible state*/
-         virtual bool reaction_reversible() const {not_implemented(); return false;}
+         virtual bool reaction_reversible() const {not_implemented(21); return false;}
 
          /*! \return pairs of reactants and stoichiometric coefficients*/
-         virtual bool reactants_pairs(std::vector<std::pair<std::string,int> > & /*reactants_pair*/) const  {not_implemented(); return false;}
+         virtual bool reactants_pairs(std::vector<std::pair<std::string,int> > & /*reactants_pair*/) const  {not_implemented(22); return false;}
 
          /*! \return pairs of products and stoichiometric coefficients*/
-         virtual bool products_pairs(std::vector<std::pair<std::string,int> > & /*products_pair*/) const {not_implemented(); return false;}
+         virtual bool products_pairs(std::vector<std::pair<std::string,int> > & /*products_pair*/) const {not_implemented(23); return false;}
 
          /*! \return true if "name" attribute is found with value "k0"*/
-         virtual bool is_k0(unsigned int /*nrc*/, const std::string & /*kin_model*/) const {not_implemented(); return false;}
+         virtual bool is_k0(unsigned int /*nrc*/, const std::string & /*kin_model*/) const {not_implemented(24); return false;}
 
          /*! \return index of k0 (0 or 1)*/
-         virtual unsigned int where_is_k0(const std::string & /*kin_model*/) const {not_implemented(); return -1;}
+         virtual unsigned int where_is_k0(const std::string & /*kin_model*/) const {not_implemented(25); return -1;}
 
          /*! \return true if pre exponentiel coefficient*/
-         virtual bool rate_constant_preexponential_parameter(NumericType & /*A*/, std::string & /*A_unit*/, std::string & /*def_unit*/) const {not_implemented(); return false;}
+         virtual bool rate_constant_preexponential_parameter(NumericType & /*A*/, std::string & /*A_unit*/, std::string & /*def_unit*/) const {not_implemented(26); return false;}
 
          /*! \return true if beta coefficient*/
-         virtual bool rate_constant_power_parameter(NumericType & /*b*/, std::string & /*b_unit*/, std::string & /*def_unit*/) const {not_implemented(); return false;}
+         virtual bool rate_constant_power_parameter(NumericType & /*b*/, std::string & /*b_unit*/, std::string & /*def_unit*/) const {not_implemented(27); return false;}
 
          /*! \return true if activation energie*/
-         virtual bool rate_constant_activation_energy_parameter(NumericType & /*Ea*/, std::string & /*Ea_unit*/, std::string & /*def_unit*/) const {not_implemented(); return false;}
+         virtual bool rate_constant_activation_energy_parameter(NumericType & /*Ea*/, std::string & /*Ea_unit*/, std::string & /*def_unit*/) const {not_implemented(28); return false;}
 
          /*! \return true if D coefficient*/
-         virtual bool rate_constant_Berthelot_coefficient_parameter(NumericType & /*D*/, std::string & /*D_unit*/, std::string & /*def_unit*/) const {not_implemented(); return false;}
+         virtual bool rate_constant_Berthelot_coefficient_parameter(NumericType & /*D*/, std::string & /*D_unit*/, std::string & /*def_unit*/) const {not_implemented(29); return false;}
 
          /*! \return true if Tref*/
-         virtual bool rate_constant_Tref_parameter( NumericType & /*Tref*/, std::string & /*Tref_unit*/, std::string & /*def_unit*/) const {not_implemented(); return false;}
+         virtual bool rate_constant_Tref_parameter( NumericType & /*Tref*/, std::string & /*Tref_unit*/, std::string & /*def_unit*/) const {not_implemented(30); return false;}
 
          /*! \return true if lambda*/
-         virtual bool rate_constant_lambda_parameter(std::vector<NumericType> & /*lambda*/, std::string & /*lambda_unit*/, std::string & /*def_unit*/) const {not_implemented(); return false;}
+         virtual bool rate_constant_lambda_parameter(std::vector<NumericType> & /*lambda*/, std::string & /*lambda_unit*/, std::string & /*def_unit*/) const {not_implemented(31); return false;}
 
          /*! \return true if sigma*/
-         virtual bool rate_constant_cross_section_parameter(std::vector<NumericType> & /*sigma*/,  std::string & /*sigma_unit*/, std::string & /*def_unit*/) const {not_implemented(); return false;}
+         virtual bool rate_constant_cross_section_parameter(std::vector<NumericType> & /*sigma*/,  std::string & /*sigma_unit*/, std::string & /*def_unit*/) const {not_implemented(32); return false;}
 
          /*! \return true if a Kooij is called Arrhenuis*/
-         virtual bool verify_Kooij_in_place_of_Arrhenius() const {not_implemented(); return false;}
+         virtual bool verify_Kooij_in_place_of_Arrhenius() const {not_implemented(33); return false;}
 
          /*! \return true if efficiencies are found*/
-         virtual bool efficiencies(std::vector<std::pair<std::string,NumericType> > & /*par_values*/) const {not_implemented(); return false;}
+         virtual bool efficiencies(std::vector<std::pair<std::string,NumericType> > & /*par_values*/) const {not_implemented(34); return false;}
 
          /*! \return true is alpha*/
-         virtual bool Troe_alpha_parameter(NumericType & /*alpha*/, std::string & /*alpha_unit*/, std::string & /*def_unit*/) const {not_implemented(); return false;}
+         virtual bool Troe_alpha_parameter(NumericType & /*alpha*/, std::string & /*alpha_unit*/, std::string & /*def_unit*/) const {not_implemented(35); return false;}
 
          /*! \return true is alpha*/
-         virtual bool Troe_T1_parameter(NumericType & /*T1*/, std::string & /*T1_unit*/, std::string & /*def_unit*/) const {not_implemented(); return false;}
+         virtual bool Troe_T1_parameter(NumericType & /*T1*/, std::string & /*T1_unit*/, std::string & /*def_unit*/) const {not_implemented(36); return false;}
 
          /*! \return true is alpha*/
-         virtual bool Troe_T2_parameter(NumericType & /*T2*/, std::string & /*T2_unit*/, std::string & /*def_unit*/) const {not_implemented(); return false;}
+         virtual bool Troe_T2_parameter(NumericType & /*T2*/, std::string & /*T2_unit*/, std::string & /*def_unit*/) const {not_implemented(37); return false;}
 
          /*! \return true is alpha*/
-         virtual bool Troe_T3_parameter(NumericType & /*T3*/, std::string & /*T3_unit*/, std::string & /*def_unit*/) const {not_implemented(); return false;}
+         virtual bool Troe_T3_parameter(NumericType & /*T3*/, std::string & /*T3_unit*/, std::string & /*def_unit*/) const {not_implemented(38); return false;}
 
          /*! \return name of file*/
         const std::string file() const {return _file;}
@@ -290,7 +289,7 @@ namespace Antioch
         bool        _verbose;
         std::string _comments;
 
-        void not_implemented() const;
+        void not_implemented(unsigned int i) const;
 
      private:
         ParserBase();
@@ -343,14 +342,15 @@ namespace Antioch
   }
 
   template <typename NumericType>
-  void ParserBase<NumericType>::not_implemented() const
+  void ParserBase<NumericType>::not_implemented(unsigned int i) const
   {
       std::cerr << "\n*********************************************************\n"
                 << "This method is not available with a " << _type << " parser.\n"
                 << "Parsing file " << _file << ".\n"
                 << "No format has been defined yet.  Maybe contribute?\n"
                 << "https://github.com/libantioch/antioch\n" 
-                << "\n*********************************************************\n"
+                << "\nMethod code: " << i
+                << "\n\n*********************************************************\n"
                 << std::endl;
   }
 

--- a/src/parsing/include/antioch/parser_base.h
+++ b/src/parsing/include/antioch/parser_base.h
@@ -192,11 +192,15 @@ namespace Antioch
 
 /// reaction
 
+// non const
+
          /*! read & store current reaction and go to next reaction*/
          virtual bool reaction() {not_implemented(14); return false;}
 
          /*! go to next rate constant*/
          virtual bool rate_constant(const std::string & /*kinetics_model*/) {not_implemented(15); return false;}
+
+// const
 
          /*! \return true if there's a Troe block*/
          virtual bool Troe() const {not_implemented(16); return false;}

--- a/src/parsing/include/antioch/parser_base.h
+++ b/src/parsing/include/antioch/parser_base.h
@@ -193,14 +193,14 @@ namespace Antioch
 
 /// reaction
 
-         /*! go to next reaction*/
+         /*! read & store current reaction and go to next reaction*/
          virtual bool reaction() {not_implemented(); return false;}
 
          /*! go to next rate constant*/
          virtual bool rate_constant(const std::string & /*kinetics_model*/) {not_implemented(); return false;}
 
          /*! \return true if there's a Troe block*/
-         virtual bool Troe()  {not_implemented(); return false;}
+         virtual bool Troe() const {not_implemented(); return false;}
 
          /*! \return reaction id, 0 if not provided*/
          virtual const std::string reaction_id() const  {not_implemented(); return std::string();}

--- a/src/parsing/include/antioch/parser_base.h
+++ b/src/parsing/include/antioch/parser_base.h
@@ -117,16 +117,16 @@ namespace Antioch
 
 /// species
         //! reads the species set
-        virtual const std::vector<std::string> species_list() {not_implemented(0); return std::vector<std::string>();}
+        virtual const std::vector<std::string> species_list() {antioch_not_implemented_msg(_not_implemented); return std::vector<std::string>();}
 
         //! reads the mandatory data, not valid in xml && chemkin
-        virtual void read_chemical_species(ChemicalMixture<NumericType> & /*chem_mixture*/)  {not_implemented(1);}
+        virtual void read_chemical_species(ChemicalMixture<NumericType> & /*chem_mixture*/)  {antioch_not_implemented_msg(_not_implemented);}
 
         //! reads the vibrational data, not valid in xml && chemkin
-        virtual void read_vibrational_data(ChemicalMixture<NumericType> & /*chem_mixture*/)  {not_implemented(2);}
+        virtual void read_vibrational_data(ChemicalMixture<NumericType> & /*chem_mixture*/)  {antioch_not_implemented_msg(_not_implemented);}
 
         //! reads the electronic data, not valid in xml && chemkin
-        virtual void read_electronic_data(ChemicalMixture<NumericType> & /*chem_mixture*/)  {not_implemented(3);}
+        virtual void read_electronic_data(ChemicalMixture<NumericType> & /*chem_mixture*/)  {antioch_not_implemented_msg(_not_implemented);}
 
 // transport, the thermo is explicit...
 
@@ -135,21 +135,21 @@ namespace Antioch
         virtual void read_transport_data(TransportMixture< ThermoHandler < NumericType, 
                                                                            NASAEvaluator<NumericType,NASA7CurveFit<NumericType> >,
                                                                            StatMechThermodynamics<NumericType> >,
-                                                           NumericType > & /*transport_mixture*/)  {not_implemented(4);}
+                                                           NumericType > & /*transport_mixture*/)  {antioch_not_implemented_msg(_not_implemented);}
 
         //! reads the transport data, not valid in xml && chemkin
         //  NASA9 + StatMech
         virtual void read_transport_data(TransportMixture< ThermoHandler < NumericType, 
                                                                            NASAEvaluator<NumericType,NASA9CurveFit<NumericType> >,
                                                                            StatMechThermodynamics<NumericType> >,
-                                                           NumericType > & /*transport_mixture*/)  {not_implemented(5);}
+                                                           NumericType > & /*transport_mixture*/)  {antioch_not_implemented_msg(_not_implemented);}
 
         //! reads the transport data, not valid in xml && chemkin
         //  CEA + StatMech for backward compat
         virtual void read_transport_data(TransportMixture< ThermoHandler < NumericType, 
                                                                            CEAEvaluator<NumericType>,
                                                                            StatMechThermodynamics<NumericType> >,
-                                                           NumericType > & /*transport_mixture*/)  {not_implemented(6);}
+                                                           NumericType > & /*transport_mixture*/)  {antioch_not_implemented_msg(_not_implemented);}
 
         //! reads the transport data, not valid in xml && chemkin
         //  NASA7 + Ideal Gas
@@ -157,7 +157,7 @@ namespace Antioch
                                                                            NASAEvaluator<NumericType,NASA7CurveFit<NumericType> >,
                                                                            IdealGasMicroThermo<NASAEvaluator<NumericType,NASA7CurveFit<NumericType> >, NumericType> 
                                                                          >,
-                                                           NumericType > & /*transport_mixture*/)  {not_implemented(7);}
+                                                           NumericType > & /*transport_mixture*/)  {antioch_not_implemented_msg(_not_implemented);}
 
         //! reads the transport data, not valid in xml && chemkin
         //  NASA9 + Ideal Gas
@@ -165,7 +165,7 @@ namespace Antioch
                                                                            NASAEvaluator<NumericType,NASA9CurveFit<NumericType> >,
                                                                            IdealGasMicroThermo<NASAEvaluator<NumericType,NASA9CurveFit<NumericType> >, NumericType> 
                                                                          >,
-                                                           NumericType > & /*transport_mixture*/)  {not_implemented(8);}
+                                                           NumericType > & /*transport_mixture*/)  {antioch_not_implemented_msg(_not_implemented);}
 
         //! reads the transport data, not valid in xml && chemkin
         //  CEA + Ideal Gas for backward compat
@@ -173,103 +173,103 @@ namespace Antioch
                                                                            CEAEvaluator<NumericType>,
                                                                            IdealGasMicroThermo<CEAEvaluator<NumericType>,NumericType> 
                                                                          >,
-                                                           NumericType > & /*transport_mixture*/)  {not_implemented(9);}
+                                                           NumericType > & /*transport_mixture*/)  {antioch_not_implemented_msg(_not_implemented);}
 
 
 /// thermo
 
         //! reads the thermo, NASA generalist, no templates for virtual
-        virtual void read_thermodynamic_data(NASAThermoMixture<NumericType, NASA7CurveFit<NumericType> >& /*thermo*/)  {not_implemented(10);}
+        virtual void read_thermodynamic_data(NASAThermoMixture<NumericType, NASA7CurveFit<NumericType> >& /*thermo*/)  {antioch_not_implemented_msg(_not_implemented);}
 
         //! reads the thermo, NASA generalist, no templates for virtual
-        virtual void read_thermodynamic_data(NASAThermoMixture<NumericType, NASA9CurveFit<NumericType> >& /*thermo*/)  {not_implemented(11);}
+        virtual void read_thermodynamic_data(NASAThermoMixture<NumericType, NASA9CurveFit<NumericType> >& /*thermo*/)  {antioch_not_implemented_msg(_not_implemented);}
 
         //! reads the thermo, NASA generalist, no templates for virtual
-        virtual void read_thermodynamic_data(NASAThermoMixture<NumericType, CEACurveFit<NumericType> >& /*thermo*/)  {not_implemented(12);}
+        virtual void read_thermodynamic_data(NASAThermoMixture<NumericType, CEACurveFit<NumericType> >& /*thermo*/)  {antioch_not_implemented_msg(_not_implemented);}
 
         //! reads the thermo, CEA deprecated
-        virtual void read_thermodynamic_data(CEAThermodynamics<NumericType >& /*thermo*/)  {not_implemented(13);}
+        virtual void read_thermodynamic_data(CEAThermodynamics<NumericType >& /*thermo*/)  {antioch_not_implemented_msg(_not_implemented);}
 
 /// reaction
 
 // non const
 
          /*! read & store current reaction and go to next reaction*/
-         virtual bool reaction() {not_implemented(14); return false;}
+         virtual bool reaction() {antioch_not_implemented_msg(_not_implemented); return false;}
 
          /*! go to next rate constant*/
-         virtual bool rate_constant(const std::string & /*kinetics_model*/) {not_implemented(15); return false;}
+         virtual bool rate_constant(const std::string & /*kinetics_model*/) {antioch_not_implemented_msg(_not_implemented); return false;}
 
 // const
 
          /*! \return true if there's a Troe block*/
-         virtual bool Troe() const {not_implemented(16); return false;}
+         virtual bool Troe() const {antioch_not_implemented_msg(_not_implemented); return false;}
 
          /*! \return reaction id, 0 if not provided*/
-         virtual const std::string reaction_id() const  {not_implemented(17); return std::string();}
+         virtual const std::string reaction_id() const  {antioch_not_implemented_msg(_not_implemented); return std::string();}
 
          /*! \return reaction equation */
-         virtual const std::string reaction_equation() const {not_implemented(18); return std::string();}
+         virtual const std::string reaction_equation() const {antioch_not_implemented_msg(_not_implemented); return std::string();}
 
          /*! \return reaction chemical process*/
-         virtual const std::string reaction_chemical_process() const {not_implemented(19); return std::string();}
+         virtual const std::string reaction_chemical_process() const {antioch_not_implemented_msg(_not_implemented); return std::string();}
 
          /*! \return reaction kinetics model*/
-         virtual const std::string reaction_kinetics_model(const std::vector<std::string> & /*kinetics_models*/) const  {not_implemented(20); return std::string();}
+         virtual const std::string reaction_kinetics_model(const std::vector<std::string> & /*kinetics_models*/) const  {antioch_not_implemented_msg(_not_implemented); return std::string();}
 
          /*! \return reversible state*/
-         virtual bool reaction_reversible() const {not_implemented(21); return false;}
+         virtual bool reaction_reversible() const {antioch_not_implemented_msg(_not_implemented); return false;}
 
          /*! \return pairs of reactants and stoichiometric coefficients*/
-         virtual bool reactants_pairs(std::vector<std::pair<std::string,int> > & /*reactants_pair*/) const  {not_implemented(22); return false;}
+         virtual bool reactants_pairs(std::vector<std::pair<std::string,int> > & /*reactants_pair*/) const  {antioch_not_implemented_msg(_not_implemented); return false;}
 
          /*! \return pairs of products and stoichiometric coefficients*/
-         virtual bool products_pairs(std::vector<std::pair<std::string,int> > & /*products_pair*/) const {not_implemented(23); return false;}
+         virtual bool products_pairs(std::vector<std::pair<std::string,int> > & /*products_pair*/) const {antioch_not_implemented_msg(_not_implemented); return false;}
 
          /*! \return true if "name" attribute is found with value "k0"*/
-         virtual bool is_k0(unsigned int /*nrc*/, const std::string & /*kin_model*/) const {not_implemented(24); return false;}
+         virtual bool is_k0(unsigned int /*nrc*/, const std::string & /*kin_model*/) const {antioch_not_implemented_msg(_not_implemented); return false;}
 
          /*! \return index of k0 (0 or 1)*/
-         virtual unsigned int where_is_k0(const std::string & /*kin_model*/) const {not_implemented(25); return -1;}
+         virtual unsigned int where_is_k0(const std::string & /*kin_model*/) const {antioch_not_implemented_msg(_not_implemented); return -1;}
 
          /*! \return true if pre exponentiel coefficient*/
-         virtual bool rate_constant_preexponential_parameter(NumericType & /*A*/, std::string & /*A_unit*/, std::string & /*def_unit*/) const {not_implemented(26); return false;}
+         virtual bool rate_constant_preexponential_parameter(NumericType & /*A*/, std::string & /*A_unit*/, std::string & /*def_unit*/) const {antioch_not_implemented_msg(_not_implemented); return false;}
 
          /*! \return true if beta coefficient*/
-         virtual bool rate_constant_power_parameter(NumericType & /*b*/, std::string & /*b_unit*/, std::string & /*def_unit*/) const {not_implemented(27); return false;}
+         virtual bool rate_constant_power_parameter(NumericType & /*b*/, std::string & /*b_unit*/, std::string & /*def_unit*/) const {antioch_not_implemented_msg(_not_implemented); return false;}
 
          /*! \return true if activation energie*/
-         virtual bool rate_constant_activation_energy_parameter(NumericType & /*Ea*/, std::string & /*Ea_unit*/, std::string & /*def_unit*/) const {not_implemented(28); return false;}
+         virtual bool rate_constant_activation_energy_parameter(NumericType & /*Ea*/, std::string & /*Ea_unit*/, std::string & /*def_unit*/) const {antioch_not_implemented_msg(_not_implemented); return false;}
 
          /*! \return true if D coefficient*/
-         virtual bool rate_constant_Berthelot_coefficient_parameter(NumericType & /*D*/, std::string & /*D_unit*/, std::string & /*def_unit*/) const {not_implemented(29); return false;}
+         virtual bool rate_constant_Berthelot_coefficient_parameter(NumericType & /*D*/, std::string & /*D_unit*/, std::string & /*def_unit*/) const {antioch_not_implemented_msg(_not_implemented); return false;}
 
          /*! \return true if Tref*/
-         virtual bool rate_constant_Tref_parameter( NumericType & /*Tref*/, std::string & /*Tref_unit*/, std::string & /*def_unit*/) const {not_implemented(30); return false;}
+         virtual bool rate_constant_Tref_parameter( NumericType & /*Tref*/, std::string & /*Tref_unit*/, std::string & /*def_unit*/) const {antioch_not_implemented_msg(_not_implemented); return false;}
 
          /*! \return true if lambda*/
-         virtual bool rate_constant_lambda_parameter(std::vector<NumericType> & /*lambda*/, std::string & /*lambda_unit*/, std::string & /*def_unit*/) const {not_implemented(31); return false;}
+         virtual bool rate_constant_lambda_parameter(std::vector<NumericType> & /*lambda*/, std::string & /*lambda_unit*/, std::string & /*def_unit*/) const {antioch_not_implemented_msg(_not_implemented); return false;}
 
          /*! \return true if sigma*/
-         virtual bool rate_constant_cross_section_parameter(std::vector<NumericType> & /*sigma*/,  std::string & /*sigma_unit*/, std::string & /*def_unit*/) const {not_implemented(32); return false;}
+         virtual bool rate_constant_cross_section_parameter(std::vector<NumericType> & /*sigma*/,  std::string & /*sigma_unit*/, std::string & /*def_unit*/) const {antioch_not_implemented_msg(_not_implemented); return false;}
 
          /*! \return true if a Kooij is called Arrhenuis*/
-         virtual bool verify_Kooij_in_place_of_Arrhenius() const {not_implemented(33); return false;}
+         virtual bool verify_Kooij_in_place_of_Arrhenius() const {antioch_not_implemented_msg(_not_implemented); return false;}
 
          /*! \return true if efficiencies are found*/
-         virtual bool efficiencies(std::vector<std::pair<std::string,NumericType> > & /*par_values*/) const {not_implemented(34); return false;}
+         virtual bool efficiencies(std::vector<std::pair<std::string,NumericType> > & /*par_values*/) const {antioch_not_implemented_msg(_not_implemented); return false;}
 
          /*! \return true is alpha*/
-         virtual bool Troe_alpha_parameter(NumericType & /*alpha*/, std::string & /*alpha_unit*/, std::string & /*def_unit*/) const {not_implemented(35); return false;}
+         virtual bool Troe_alpha_parameter(NumericType & /*alpha*/, std::string & /*alpha_unit*/, std::string & /*def_unit*/) const {antioch_not_implemented_msg(_not_implemented); return false;}
 
          /*! \return true is alpha*/
-         virtual bool Troe_T1_parameter(NumericType & /*T1*/, std::string & /*T1_unit*/, std::string & /*def_unit*/) const {not_implemented(36); return false;}
+         virtual bool Troe_T1_parameter(NumericType & /*T1*/, std::string & /*T1_unit*/, std::string & /*def_unit*/) const {antioch_not_implemented_msg(_not_implemented); return false;}
 
          /*! \return true is alpha*/
-         virtual bool Troe_T2_parameter(NumericType & /*T2*/, std::string & /*T2_unit*/, std::string & /*def_unit*/) const {not_implemented(37); return false;}
+         virtual bool Troe_T2_parameter(NumericType & /*T2*/, std::string & /*T2_unit*/, std::string & /*def_unit*/) const {antioch_not_implemented_msg(_not_implemented); return false;}
 
          /*! \return true is alpha*/
-         virtual bool Troe_T3_parameter(NumericType & /*T3*/, std::string & /*T3_unit*/, std::string & /*def_unit*/) const {not_implemented(38); return false;}
+         virtual bool Troe_T3_parameter(NumericType & /*T3*/, std::string & /*T3_unit*/, std::string & /*def_unit*/) const {antioch_not_implemented_msg(_not_implemented); return false;}
 
          /*! \return name of file*/
         const std::string file() const {return _file;}
@@ -293,7 +293,7 @@ namespace Antioch
         bool        _verbose;
         std::string _comments;
 
-        void not_implemented(unsigned int i) const;
+        std::string _not_implemented;
 
      private:
         ParserBase();
@@ -306,6 +306,13 @@ namespace Antioch
         _verbose(verbose),
         _comments(comments)
   {
+      _not_implemented =   "\n*********************************************************\n"
+                         + "This method is not available with a " << _type << " parser.\n"
+                         + "Parsing file " << _file << ".\n"
+                         + "No format has been defined yet.  Maybe contribute?\n"
+                         + "https://github.com/libantioch/antioch\n" 
+                         + "\n\n*********************************************************\n\n";
+                        
       return;
   }
 
@@ -344,20 +351,6 @@ namespace Antioch
       }
       return PType;
   }
-
-  template <typename NumericType>
-  void ParserBase<NumericType>::not_implemented(unsigned int i) const
-  {
-      std::cerr << "\n*********************************************************\n"
-                << "This method is not available with a " << _type << " parser.\n"
-                << "Parsing file " << _file << ".\n"
-                << "No format has been defined yet.  Maybe contribute?\n"
-                << "https://github.com/libantioch/antioch\n" 
-                << "\nMethod code: " << i
-                << "\n\n*********************************************************\n"
-                << std::endl;
-  }
-
 
 } // end namespace Antioch
 

--- a/src/parsing/include/antioch/parser_base.h
+++ b/src/parsing/include/antioch/parser_base.h
@@ -33,6 +33,7 @@
 //C++
 #include <vector>
 #include <string>
+#include <sstream>
 
 namespace Antioch
 {
@@ -306,12 +307,15 @@ namespace Antioch
         _verbose(verbose),
         _comments(comments)
   {
-      _not_implemented =   "\n*********************************************************\n"
-                         + "This method is not available with a " << _type << " parser.\n"
-                         + "Parsing file " << _file << ".\n"
-                         + "No format has been defined yet.  Maybe contribute?\n"
-                         + "https://github.com/libantioch/antioch\n" 
-                         + "\n\n*********************************************************\n\n";
+       std::stringstream os;
+       os <<  "\n*********************************************************\n"
+          << "This method is not available with a " << _type << " parser.\n"
+          << "Parsing file " << _file << ".\n"
+          << "No format has been defined yet.  Maybe contribute?\n"
+          << "https://github.com/libantioch/antioch\n" 
+          << "\n\n*********************************************************\n\n";
+
+      _not_implemented = os.str();
                         
       return;
   }

--- a/src/parsing/include/antioch/xml_parser.h
+++ b/src/parsing/include/antioch/xml_parser.h
@@ -104,6 +104,10 @@ namespace Antioch{
 ////////////////// thermo
 
 //global overload
+// it seems that they're all linked in
+// a way so they shadow themselves
+// => we need to implement all or nothing
+
         //! reads the thermo, NASA generalist, no templates for virtual
         void read_thermodynamic_data(NASAThermoMixture<NumericType, NASA7CurveFit<NumericType> >& thermo)
                 {this->read_thermodynamic_data_root(thermo);}
@@ -114,6 +118,10 @@ namespace Antioch{
 
         //! reads the thermo, NASA generalist, no templates for virtual
         void read_thermodynamic_data(NASAThermoMixture<NumericType, CEACurveFit<NumericType> >& thermo)  
+                {this->read_thermodynamic_data_root(thermo);}
+
+        //! reads the thermo, CEA deprecated 
+        void read_thermodynamic_data(CEAThermodynamics<NumericType >& thermo)
                 {this->read_thermodynamic_data_root(thermo);}
 
 /// reaction

--- a/src/parsing/include/antioch/xml_parser.h
+++ b/src/parsing/include/antioch/xml_parser.h
@@ -204,8 +204,8 @@ namespace Antioch{
         private:
 
          //! reads the thermo, NASA generalist
-         template <typename CurveType>
-         void read_thermodynamic_data_root(NASAThermoMixture<NumericType, CurveType >& thermo);
+         template <typename ThermoType>
+         void read_thermodynamic_data_root(ThermoType & thermo);
 
          /*! return pairs of molecules and stoichiometric coefficients*/
          bool molecules_pairs(tinyxml2::XMLElement * molecules, std::vector<std::pair<std::string,int> > & products_pair) const;
@@ -779,9 +779,9 @@ namespace Antioch{
 
 
   template <typename NumericType>
-  template <typename CurveType>
+  template <typename ThermoType>
   inline
-  void XMLParser<NumericType>::read_thermodynamic_data_root(NASAThermoMixture<NumericType, CurveType >& thermo)
+  void XMLParser<NumericType>::read_thermodynamic_data_root(ThermoType & thermo)
   {
      if(!_thermo_block)
      {

--- a/src/thermo/include/antioch/cea_thermo.h
+++ b/src/thermo/include/antioch/cea_thermo.h
@@ -94,6 +94,10 @@ namespace Antioch
     
     void add_curve_fit( const std::string& species_name, const std::vector<CoeffType>& coeffs );
 
+    // ! compatibility for parsers
+    void add_curve_fit( const std::string& species_name, const std::vector<CoeffType>& coeffs, const std::vector<CoeffType> & /*temps */ )
+                        {this->add_curve_fit(species_name,coeffs);}
+
     //! Checks that curve fits have been specified for all species in the mixture.
     bool check() const;
 

--- a/src/utilities/include/antioch/antioch_asserts.h
+++ b/src/utilities/include/antioch/antioch_asserts.h
@@ -102,5 +102,8 @@
 #define antioch_deprecated() \
           do  {std::cerr << "\n*** Warning, This code is deprecated, and likely to be removed in future library versions!\n" \
                          << __FILE__ << ", line " << __LINE__ << ", compiled " << __DATE__ << " at " << __TIME__ << " ***" << std::endl;} while(0)
+// Just outputing to std::cerr
+#define antioch_msg_error(errmsg)           do { std::cerr << errmsg << std::endl; }                   while(0)
+#define antioch_not_implemented_msg(errmsg) do {antioch_msg_error(errmsg); antioch_not_implemented();} while(0) 
 
 #endif // ANTIOCH_ASSERTS_H


### PR DESCRIPTION
```XMLParser::Troe()``` and ```ParserBase::Troe()``` are ```const```'ified.

It finally required little changes as the only thing that really needed to be stored was the Troe environment pointer.

Also added an id to the virtual methods of the base object to know which one is asked for and not available.