### PR TITLE
EGlib correction to vanishing molar concentrations

### DIFF
--- a/src/diffusion/include/antioch/molecular_binary_diffusion_utils.h
+++ b/src/diffusion/include/antioch/molecular_binary_diffusion_utils.h
@@ -223,7 +223,7 @@ namespace Antioch
 // (iii) use perturbed values to evaluate the transport properties [ (1 - y_s) / sum_i x_i / D_{is} ]
        for(unsigned int s = 0; s < ds.size(); s++)
        {
-          ds[s] = StateType(1) - mixture.M(s) / M_tr * molar_fractions[s];
+          ds[s] = constant_clone(mass_fractions[0],1) - mixture.M(s) / M_tr * molar_fractions[s];
           StateType denom = zero_clone(mass_fractions[0]);
           for(unsigned int j = 0; j < ds.size(); j++)
           {

--- a/src/diffusion/include/antioch/molecular_binary_diffusion_utils.h
+++ b/src/diffusion/include/antioch/molecular_binary_diffusion_utils.h
@@ -201,7 +201,7 @@ namespace Antioch
 // EGlib traces management, see doc: http://blanche.polytechnique.fr/www.eglib/manual.ps
 // page 5
 // EGlib uses eps = 1e-16
-       typename raw_type<StateType>::type eps(std::numeric_limits<StateType>::epsilon() * 10);
+       typename raw_value_type<StateType>::type eps(std::numeric_limits<StateType>::epsilon() * 10);
        StateType mol_frac_sum = zero_clone(mass_fractions[0]);
        for(unsigned int s = 0; s < molar_fractions.size(); s++)
        {


### PR DESCRIPTION
This concerns the diffusion calculations, it computes modified diffusion terms to ensure computational stability with respect to vanishing concentrations.

This is the EG lib way of doing it, documentation of EG lib is [here](http://blanche.polytechnique.fr/www.eglib/).

I'd like some agreement on the choice of the value of epsilon before merging.

```
// EGlib traces management, see doc: http://blanche.polytechnique.fr/www.eglib/manual.ps
// page 5
// EGlib uses eps = 1e-16
       typename raw_value_type<StateType>::type eps(std::numeric_limits<StateType>::epsilon() * 10);
```