### PR TITLE
capability to remove a reaction

### DIFF
--- a/src/kinetics/include/antioch/reaction_set.h
+++ b/src/kinetics/include/antioch/reaction_set.h
@@ -79,6 +79,11 @@ namespace Antioch
     // object, they are deleted in the desctructor.
     void add_reaction(Reaction<CoeffType>* reaction);
 
+    //! remove a reaction from the system.
+    //
+    // The corresponding pointer is deleted
+    void remove_reaction(unsigned int nr);
+
     //! \returns a constant reference to reaction \p r.
     const Reaction<CoeffType>& reaction(const unsigned int r) const;
 
@@ -176,6 +181,19 @@ namespace Antioch
     _reactions.back()->initialize(_reactions.size() - 1);
 
     return;
+  }
+
+  template<typename CoeffType>
+  inline
+  void ReactionSet<CoeffType>::remove_reaction(unsigned int nr)
+  {
+     antioch_assert_less(nr,_reactions.size());
+
+     //first clear the memory
+     delete _reactions[nr];
+
+     //second, release the spot
+     _reactions.erase(_reactions.begin() + nr);
   }
   
   template<typename CoeffType>


### PR DESCRIPTION
it decreases the index of all following reactions.

If for some reason you have a map of the reactions, this method requires to
update it, Antioch doesn't, so we're cool here.

This is the commit message, says pretty much all.

This method is needed for any purging of reactions.  For instance in PINC I want some system to be in stationary state, thus I need every molecule to have a chemical loss and a chemical production rate. This method enable to automatically modify by pruning the reaction set to avoid well species.