### PR TITLE
Resetting a specific parameter declared in input file

### DIFF
--- a/src/kinetics/include/antioch/arrhenius_rate.h
+++ b/src/kinetics/include/antioch/arrhenius_rate.h
@@ -76,10 +76,15 @@ namespace Antioch
     ~ArrheniusRate();
     
     void set_Cf(     const CoeffType Cf );
+    //! set Ea, rescale the value, unit is known
     void set_Ea(     const CoeffType Ea );
+    //! set Ea, no rescaling, unit is K
+    void reset_Ea(     const CoeffType Ea );
     void set_rscale( const CoeffType rscale );
 
     //! set one parameter, characterized by enum
+    //
+    // Beware of the Ea parameter, it \e must be in Kelvin
     void set_parameter(KineticsModel::Parameters parameter, CoeffType new_value);
 
     //! for compatibility purpose with photochemistry (particle flux reactions)
@@ -179,6 +184,15 @@ namespace Antioch
 
   template<typename CoeffType>
   inline
+  void ArrheniusRate<CoeffType>::reset_Ea( const CoeffType Ea )
+  {
+    _Ea = Ea;
+    _raw_Ea = _Ea * _rscale;
+    return;
+  }
+
+  template<typename CoeffType>
+  inline
   void ArrheniusRate<CoeffType>::set_rscale( const CoeffType rscale )
   {
     _rscale = rscale;
@@ -211,7 +225,7 @@ namespace Antioch
           break;
         case KineticsModel::Parameters::E:
         {
-         this->set_Ea(new_value);
+         this->reset_Ea(new_value);
         }
           break;
         default:

--- a/src/kinetics/include/antioch/arrhenius_rate.h
+++ b/src/kinetics/include/antioch/arrhenius_rate.h
@@ -79,6 +79,9 @@ namespace Antioch
     void set_Ea(     const CoeffType Ea );
     void set_rscale( const CoeffType rscale );
 
+    //! set one parameter, characterized by enum
+    void set_parameter(KineticsModel::Parameters parameter, const CoeffType & new_value);
+
     /*! reset the coeffs
      *
      * Two ways of modifying your rate:
@@ -187,6 +190,30 @@ namespace Antioch
      if(coefficients.size() == 3)this->set_rscale(coefficients[2]);
      this->set_Cf(coefficients[0]);
      this->set_Ea(coefficients[1]);
+  }
+
+  template<typename CoeffType>
+  inline
+  void ArrheniusRate<CoeffType>::set_parameter(KineticsModel::Parameters parameter, const CoeffType & new_value)
+  {
+      switch(parameter)
+      {
+        case KineticsModel::Parameters::A:
+        {
+          this->set_Cf(new_value);
+        }
+          break;
+        case KineticsModel::Parameters::E:
+        {
+         this->set_Ea(new_value);
+        }
+          break;
+        default:
+        {
+          antioch_error();
+        }
+        break;
+      }
   }
 
   template<typename CoeffType>

--- a/src/kinetics/include/antioch/arrhenius_rate.h
+++ b/src/kinetics/include/antioch/arrhenius_rate.h
@@ -87,6 +87,9 @@ namespace Antioch
     // Beware of the Ea parameter, it \e must be in Kelvin
     void set_parameter(KineticsModel::Parameters parameter, CoeffType new_value);
 
+    //! get one parameter, characterized by enum
+    CoeffType get_parameter(KineticsModel::Parameters parameter) const;
+
     //! for compatibility purpose with photochemistry (particle flux reactions)
     //
     // \todo, solve this
@@ -108,6 +111,7 @@ namespace Antioch
 
     CoeffType Cf()     const;
     CoeffType Ea()     const;
+    CoeffType Ea_K()   const;
     CoeffType rscale() const;
 
     //! \return the rate evaluated at \p T.
@@ -228,6 +232,11 @@ namespace Antioch
          this->reset_Ea(new_value);
         }
           break;
+        case KineticsModel::Parameters::R_SCALE:
+        {
+         this->set_rscale(new_value);
+        }
+          break;
         default:
         {
           antioch_error();
@@ -238,12 +247,47 @@ namespace Antioch
 
   template<typename CoeffType>
   inline
+  CoeffType ArrheniusRate<CoeffType>::get_parameter(KineticsModel::Parameters parameter) const
+  {
+      switch(parameter)
+      {
+        case KineticsModel::Parameters::A:
+        {
+          return this->Cf();
+        }
+          break;
+        case KineticsModel::Parameters::E:
+        {
+         return this->Ea();
+        }
+          break;
+        case KineticsModel::Parameters::R_SCALE:
+        {
+         return this->rscale();
+        }
+          break;
+        default:
+        {
+          antioch_error();
+        }
+        break;
+      }
+      return 0;
+  }
+
+  template<typename CoeffType>
+  inline
   CoeffType ArrheniusRate<CoeffType>::Cf() const
   { return _Cf; }
 
   template<typename CoeffType>
   inline
   CoeffType ArrheniusRate<CoeffType>::Ea() const
+  { return _raw_Ea; }
+
+  template<typename CoeffType>
+  inline
+  CoeffType ArrheniusRate<CoeffType>::Ea_K() const
   { return _Ea; }
 
   template<typename CoeffType>

--- a/src/kinetics/include/antioch/arrhenius_rate.h
+++ b/src/kinetics/include/antioch/arrhenius_rate.h
@@ -82,6 +82,12 @@ namespace Antioch
     //! set one parameter, characterized by enum
     void set_parameter(KineticsModel::Parameters parameter, CoeffType new_value);
 
+    //! for compatibility purpose with photochemistry (particle flux reactions)
+    //
+    // \todo, solve this
+    template <typename VectorCoeffType>
+    void set_parameter(KineticsModel::Parameters parameter, VectorCoeffType new_value){antioch_error();}
+
     /*! reset the coeffs
      *
      * Two ways of modifying your rate:

--- a/src/kinetics/include/antioch/arrhenius_rate.h
+++ b/src/kinetics/include/antioch/arrhenius_rate.h
@@ -80,7 +80,7 @@ namespace Antioch
     void set_rscale( const CoeffType rscale );
 
     //! set one parameter, characterized by enum
-    void set_parameter(KineticsModel::Parameters parameter, const CoeffType & new_value);
+    void set_parameter(KineticsModel::Parameters parameter, CoeffType new_value);
 
     /*! reset the coeffs
      *
@@ -194,7 +194,7 @@ namespace Antioch
 
   template<typename CoeffType>
   inline
-  void ArrheniusRate<CoeffType>::set_parameter(KineticsModel::Parameters parameter, const CoeffType & new_value)
+  void ArrheniusRate<CoeffType>::set_parameter(KineticsModel::Parameters parameter, CoeffType new_value)
   {
       switch(parameter)
       {

--- a/src/kinetics/include/antioch/berthelot_rate.h
+++ b/src/kinetics/include/antioch/berthelot_rate.h
@@ -70,6 +70,12 @@ namespace Antioch
     //! set one parameter, characterized by enum
     void set_parameter(KineticsModel::Parameters parameter, CoeffType new_value);
 
+    //! for compatibility purpose with photochemistry (particle flux reactions)
+    //
+    // \todo, solve this
+    template <typename VectorCoeffType>
+    void set_parameter(KineticsModel::Parameters parameter, VectorCoeffType new_value){antioch_error();}
+
     /*! reset the coeffs
      *
      * You require exactly two parameters, the order assumed is Cf, D

--- a/src/kinetics/include/antioch/berthelot_rate.h
+++ b/src/kinetics/include/antioch/berthelot_rate.h
@@ -70,6 +70,9 @@ namespace Antioch
     //! set one parameter, characterized by enum
     void set_parameter(KineticsModel::Parameters parameter, CoeffType new_value);
 
+    //! get one parameter, characterized by enum
+    CoeffType get_parameter(KineticsModel::Parameters parameter) const;
+
     //! for compatibility purpose with photochemistry (particle flux reactions)
     //
     // \todo, solve this
@@ -191,6 +194,30 @@ namespace Antioch
      }
   }
 
+  template<typename CoeffType>
+  inline
+  CoeffType BerthelotRate<CoeffType>::get_parameter(KineticsModel::Parameters parameter) const
+  {
+     switch(parameter)
+     {
+       case KineticsModel::Parameters::A:
+       {
+         return this->Cf();
+       }
+         break;
+       case KineticsModel::Parameters::D:
+       {
+         return this->D();
+       }
+         break;
+       default:
+       {
+         antioch_error();
+       }
+        break;
+     }
+     return 0;
+  }
 
   template<typename CoeffType>
   inline

--- a/src/kinetics/include/antioch/berthelot_rate.h
+++ b/src/kinetics/include/antioch/berthelot_rate.h
@@ -67,6 +67,9 @@ namespace Antioch
     void set_Cf( const CoeffType Cf );
     void set_D( const CoeffType D );
 
+    //! set one parameter, characterized by enum
+    void set_parameter(KineticsModel::Parameters parameter, const CoeffType & new_value);
+
     /*! reset the coeffs
      *
      * You require exactly two parameters, the order assumed is Cf, D
@@ -157,6 +160,31 @@ namespace Antioch
      this->set_Cf(coefficients[0]);
      this->set_D(coefficients[1]);
   }
+
+  template<typename CoeffType>
+  inline
+  void BerthelotRate<CoeffType>::set_parameter(KineticsModel::Parameters parameter, const CoeffType & new_value)
+  {
+     switch(parameter)
+     {
+       case KineticsModel::Parameters::A:
+       {
+         this->set_Cf(new_value);
+       }
+         break;
+       case KineticsModel::Parameters::D:
+       {
+         this->set_D(new_value);
+       }
+         break;
+       default:
+       {
+         antioch_error();
+       }
+        break;
+     }
+  }
+
 
   template<typename CoeffType>
   inline

--- a/src/kinetics/include/antioch/berthelot_rate.h
+++ b/src/kinetics/include/antioch/berthelot_rate.h
@@ -68,7 +68,7 @@ namespace Antioch
     void set_D( const CoeffType D );
 
     //! set one parameter, characterized by enum
-    void set_parameter(KineticsModel::Parameters parameter, const CoeffType & new_value);
+    void set_parameter(KineticsModel::Parameters parameter, CoeffType new_value);
 
     /*! reset the coeffs
      *
@@ -163,7 +163,7 @@ namespace Antioch
 
   template<typename CoeffType>
   inline
-  void BerthelotRate<CoeffType>::set_parameter(KineticsModel::Parameters parameter, const CoeffType & new_value)
+  void BerthelotRate<CoeffType>::set_parameter(KineticsModel::Parameters parameter, CoeffType new_value)
   {
      switch(parameter)
      {

--- a/src/kinetics/include/antioch/berthelothercourtessen_rate.h
+++ b/src/kinetics/include/antioch/berthelothercourtessen_rate.h
@@ -77,6 +77,12 @@ namespace Antioch
     //! set one parameter, characterized by enum
     void set_parameter(KineticsModel::Parameters parameter, CoeffType new_value);
 
+    //! for compatibility purpose with photochemistry (particle flux reactions)
+    //
+    // \todo, solve this
+    template <typename VectorCoeffType>
+    void set_parameter(KineticsModel::Parameters parameter, VectorCoeffType new_value){antioch_error();}
+
     /*! reset the coeffs
      *
      * Two ways of modifying your rate:

--- a/src/kinetics/include/antioch/berthelothercourtessen_rate.h
+++ b/src/kinetics/include/antioch/berthelothercourtessen_rate.h
@@ -75,7 +75,7 @@ namespace Antioch
     void set_Tref(const CoeffType Tref );
 
     //! set one parameter, characterized by enum
-    void set_parameter(KineticsModel::Parameters parameter, const CoeffType & new_value);
+    void set_parameter(KineticsModel::Parameters parameter, CoeffType new_value);
 
     /*! reset the coeffs
      *
@@ -230,7 +230,7 @@ namespace Antioch
 
   template<typename CoeffType>
   inline
-  void BerthelotHercourtEssenRate<CoeffType>::set_parameter(KineticsModel::Parameters parameter, const CoeffType & new_value)
+  void BerthelotHercourtEssenRate<CoeffType>::set_parameter(KineticsModel::Parameters parameter, CoeffType new_value)
   {
     switch(parameter)
     {

--- a/src/kinetics/include/antioch/berthelothercourtessen_rate.h
+++ b/src/kinetics/include/antioch/berthelothercourtessen_rate.h
@@ -77,6 +77,9 @@ namespace Antioch
     //! set one parameter, characterized by enum
     void set_parameter(KineticsModel::Parameters parameter, CoeffType new_value);
 
+    //! get one parameter, characterized by enum
+    CoeffType get_parameter(KineticsModel::Parameters parameter) const;
+
     //! for compatibility purpose with photochemistry (particle flux reactions)
     //
     // \todo, solve this
@@ -255,12 +258,52 @@ namespace Antioch
        this->set_D(new_value);
      }
       break;
+     case KineticsModel::Parameters::T_REF:
+     {
+       this->set_Tref(new_value);
+     }
+      break;
      default:
      {
        antioch_error();
      }
       break;
      }
+  }
+
+  template<typename CoeffType>
+  inline
+  CoeffType BerthelotHercourtEssenRate<CoeffType>::get_parameter(KineticsModel::Parameters parameter) const
+  {
+    switch(parameter)
+    {
+     case KineticsModel::Parameters::A:
+     {
+       return this->Cf();
+     }
+      break;
+     case KineticsModel::Parameters::B:
+     {
+       return this->eta();
+     }
+      break;
+     case KineticsModel::Parameters::D:
+     {
+       return this->D();
+     }
+      break;
+     case KineticsModel::Parameters::T_REF:
+     {
+       return this->Tref();
+     }
+      break;
+     default:
+     {
+       antioch_error();
+     }
+      break;
+     }
+     return 0;
   }
 
   template<typename CoeffType>

--- a/src/kinetics/include/antioch/berthelothercourtessen_rate.h
+++ b/src/kinetics/include/antioch/berthelothercourtessen_rate.h
@@ -74,6 +74,9 @@ namespace Antioch
     void set_D(   const CoeffType D );
     void set_Tref(const CoeffType Tref );
 
+    //! set one parameter, characterized by enum
+    void set_parameter(KineticsModel::Parameters parameter, const CoeffType & new_value);
+
     /*! reset the coeffs
      *
      * Two ways of modifying your rate:
@@ -223,6 +226,35 @@ namespace Antioch
     this->set_Cf(coefficients[0]);
     this->set_eta(coefficients[1]);
     this->set_D(coefficients[2]);
+  }
+
+  template<typename CoeffType>
+  inline
+  void BerthelotHercourtEssenRate<CoeffType>::set_parameter(KineticsModel::Parameters parameter, const CoeffType & new_value)
+  {
+    switch(parameter)
+    {
+     case KineticsModel::Parameters::A:
+     {
+       this->set_Cf(new_value);
+     }
+      break;
+     case KineticsModel::Parameters::B:
+     {
+       this->set_eta(new_value);
+     }
+      break;
+     case KineticsModel::Parameters::D:
+     {
+       this->set_D(new_value);
+     }
+      break;
+     default:
+     {
+       antioch_error();
+     }
+      break;
+     }
   }
 
   template<typename CoeffType>

--- a/src/kinetics/include/antioch/constant_rate.h
+++ b/src/kinetics/include/antioch/constant_rate.h
@@ -77,6 +77,9 @@ namespace Antioch
     //! set one parameter, characterized by enum
     void set_parameter(KineticsModel::Parameters parameter, CoeffType new_value);
 
+    //! get one parameter, characterized by enum
+    CoeffType get_parameter(KineticsModel::Parameters parameter) const;
+
     //! for compatibility purpose with photochemistry (particle flux reactions)
     //
     // \todo, solve this
@@ -152,6 +155,15 @@ namespace Antioch
     this->set_Cf(new_value);
 
     return;
+  }
+
+  template<typename CoeffType>
+  inline
+  CoeffType ConstantRate<CoeffType>::get_parameter(KineticsModel::Parameters parameter) const
+  {
+    antioch_assert_equal_to(parameter,KineticsModel::Parameters::A);
+
+    return this->Cf();
   }
 
   template<typename CoeffType>

--- a/src/kinetics/include/antioch/constant_rate.h
+++ b/src/kinetics/include/antioch/constant_rate.h
@@ -74,6 +74,9 @@ namespace Antioch
 
     CoeffType Cf()   const;
 
+    //! set one parameter, characterized by enum
+    void set_parameter(KineticsModel::Parameters parameter, const CoeffType & new_value);
+
     //! \return the rate evaluated at \p T.
     template <typename StateType>
     ANTIOCH_AUTO(StateType) 
@@ -130,6 +133,17 @@ namespace Antioch
   void ConstantRate<CoeffType>::set_Cf( const CoeffType Cf )
   {
     _Cf = Cf;
+
+    return;
+  }
+
+  template<typename CoeffType>
+  inline
+  void ConstantRate<CoeffType>::set_parameter(KineticsModel::Parameters parameter, const CoeffType & new_value)
+  {
+    antioch_assert_equal_to(parameter,KineticsModel::Parameters::A);
+
+    this->set_Cf(new_value);
 
     return;
   }

--- a/src/kinetics/include/antioch/constant_rate.h
+++ b/src/kinetics/include/antioch/constant_rate.h
@@ -75,7 +75,7 @@ namespace Antioch
     CoeffType Cf()   const;
 
     //! set one parameter, characterized by enum
-    void set_parameter(KineticsModel::Parameters parameter, const CoeffType & new_value);
+    void set_parameter(KineticsModel::Parameters parameter, CoeffType new_value);
 
     //! \return the rate evaluated at \p T.
     template <typename StateType>
@@ -139,7 +139,7 @@ namespace Antioch
 
   template<typename CoeffType>
   inline
-  void ConstantRate<CoeffType>::set_parameter(KineticsModel::Parameters parameter, const CoeffType & new_value)
+  void ConstantRate<CoeffType>::set_parameter(KineticsModel::Parameters parameter, CoeffType new_value)
   {
     antioch_assert_equal_to(parameter,KineticsModel::Parameters::A);
 

--- a/src/kinetics/include/antioch/constant_rate.h
+++ b/src/kinetics/include/antioch/constant_rate.h
@@ -77,6 +77,12 @@ namespace Antioch
     //! set one parameter, characterized by enum
     void set_parameter(KineticsModel::Parameters parameter, CoeffType new_value);
 
+    //! for compatibility purpose with photochemistry (particle flux reactions)
+    //
+    // \todo, solve this
+    template <typename VectorCoeffType>
+    void set_parameter(KineticsModel::Parameters parameter, VectorCoeffType new_value){antioch_error();}
+
     //! \return the rate evaluated at \p T.
     template <typename StateType>
     ANTIOCH_AUTO(StateType) 

--- a/src/kinetics/include/antioch/hercourtessen_rate.h
+++ b/src/kinetics/include/antioch/hercourtessen_rate.h
@@ -75,6 +75,9 @@ namespace Antioch
     //! set one parameter, characterized by enum
     void set_parameter(KineticsModel::Parameters parameter, CoeffType new_value);
 
+    //! get one parameter, characterized by enum
+    CoeffType get_parameter(KineticsModel::Parameters parameter) const;
+
     //! for compatibility purpose with photochemistry (particle flux reactions)
     //
     // \todo, solve this
@@ -226,6 +229,37 @@ namespace Antioch
         }
         break;
      }
+  }
+
+  template<typename CoeffType>
+  inline
+  CoeffType HercourtEssenRate<CoeffType>::get_parameter(KineticsModel::Parameters parameter) const
+  {
+     switch(parameter)
+     {
+        case KineticsModel::Parameters::A:
+        {
+          return this->Cf();
+        }
+          break;
+        case KineticsModel::Parameters::B:
+        {
+          return this->eta();
+        }
+          break;
+        case KineticsModel::Parameters::T_REF:
+        {
+          return this->Tref();
+        }
+          break;
+        default:
+        {
+          antioch_error();
+        }
+        break;
+     }
+
+     return 0;
   }
 
   template<typename CoeffType>

--- a/src/kinetics/include/antioch/hercourtessen_rate.h
+++ b/src/kinetics/include/antioch/hercourtessen_rate.h
@@ -75,6 +75,12 @@ namespace Antioch
     //! set one parameter, characterized by enum
     void set_parameter(KineticsModel::Parameters parameter, CoeffType new_value);
 
+    //! for compatibility purpose with photochemistry (particle flux reactions)
+    //
+    // \todo, solve this
+    template <typename VectorCoeffType>
+    void set_parameter(KineticsModel::Parameters parameter, VectorCoeffType new_value){antioch_error();}
+
     /*! reset the coeffs
      *
      * Two ways of modifying your rate:

--- a/src/kinetics/include/antioch/hercourtessen_rate.h
+++ b/src/kinetics/include/antioch/hercourtessen_rate.h
@@ -72,6 +72,9 @@ namespace Antioch
     void set_eta( const CoeffType eta );
     void set_Tref(const CoeffType Tref );
 
+    //! set one parameter, characterized by enum
+    void set_parameter(KineticsModel::Parameters parameter, const CoeffType & new_value);
+
     /*! reset the coeffs
      *
      * Two ways of modifying your rate:
@@ -188,6 +191,35 @@ namespace Antioch
       if(coefficients.size() == 3)this->set_Tref(coefficients[2]);
       this->set_Cf(coefficients[0]);
       this->set_eta(coefficients[1]);
+  }
+
+  template<typename CoeffType>
+  inline
+  void HercourtEssenRate<CoeffType>::set_parameter(KineticsModel::Parameters parameter, const CoeffType & new_value)
+  {
+     switch(parameter)
+     {
+        case KineticsModel::Parameters::A:
+        {
+          this->set_Cf(new_value);
+        }
+          break;
+        case KineticsModel::Parameters::B:
+        {
+          this->set_eta(new_value);
+        }
+          break;
+        case KineticsModel::Parameters::T_REF:
+        {
+          this->set_Tref(new_value);
+        }
+          break;
+        default:
+        {
+          antioch_error();
+        }
+        break;
+     }
   }
 
   template<typename CoeffType>

--- a/src/kinetics/include/antioch/hercourtessen_rate.h
+++ b/src/kinetics/include/antioch/hercourtessen_rate.h
@@ -73,7 +73,7 @@ namespace Antioch
     void set_Tref(const CoeffType Tref );
 
     //! set one parameter, characterized by enum
-    void set_parameter(KineticsModel::Parameters parameter, const CoeffType & new_value);
+    void set_parameter(KineticsModel::Parameters parameter, CoeffType new_value);
 
     /*! reset the coeffs
      *
@@ -195,7 +195,7 @@ namespace Antioch
 
   template<typename CoeffType>
   inline
-  void HercourtEssenRate<CoeffType>::set_parameter(KineticsModel::Parameters parameter, const CoeffType & new_value)
+  void HercourtEssenRate<CoeffType>::set_parameter(KineticsModel::Parameters parameter, CoeffType new_value)
   {
      switch(parameter)
      {

--- a/src/kinetics/include/antioch/kinetics_enum.h
+++ b/src/kinetics/include/antioch/kinetics_enum.h
@@ -68,6 +68,16 @@ namespace Antioch
       return 1.0; // this HAS to stay this way because it is hard-coded for performances (see eq. above)
     }
 
+    enum Parameters{ A = 0,
+                     B,
+                     E,
+                     D,
+                     T_REF,
+                     R_SCALE,
+                     SIGMA,
+                     LAMBDA
+                   };
+
   } // end namespace KineticsModel
 
 } // end namespace Antioch

--- a/src/kinetics/include/antioch/kinetics_enum.h
+++ b/src/kinetics/include/antioch/kinetics_enum.h
@@ -76,7 +76,11 @@ namespace Antioch
                      T_REF,
                      R_SCALE,
                      SIGMA,
-                     LAMBDA
+                     LAMBDA,
+        // now for the falloff, we need to know if we want
+        // the low-pressure limit or HIGH
+                     LOW_PRESSURE,
+                     HIGH_PRESSURE
                    };
 
   } // end namespace KineticsModel

--- a/src/kinetics/include/antioch/kinetics_enum.h
+++ b/src/kinetics/include/antioch/kinetics_enum.h
@@ -68,7 +68,8 @@ namespace Antioch
       return 1.0; // this HAS to stay this way because it is hard-coded for performances (see eq. above)
     }
 
-    enum Parameters{ A = 0,
+    enum Parameters{ NOT_FOUND = 0,
+                     A,
                      B,
                      E,
                      D,

--- a/src/kinetics/include/antioch/kinetics_parsing.h
+++ b/src/kinetics/include/antioch/kinetics_parsing.h
@@ -55,7 +55,7 @@ namespace Antioch
   template <typename CoeffType, typename VectorCoeffType, typename ParamType>
   void reset_parameter_of_rate(KineticsType<CoeffType,VectorCoeffType> & rate,
                                KineticsModel::Parameters parameter,
-                               const ParamType & new_value);
+                               const ParamType new_value);
 
 
 //----------------------------------------
@@ -216,7 +216,7 @@ namespace Antioch
   template <typename CoeffType, typename VectorCoeffType, typename ParamType>
   void reset_parameter_of_rate(KineticsType<CoeffType,VectorCoeffType> & rate,
                                KineticsModel::Parameters parameter,
-                               const ParamType & new_value)
+                               const ParamType new_value)
   {
     switch(rate.type())
       {

--- a/src/kinetics/include/antioch/kinetics_parsing.h
+++ b/src/kinetics/include/antioch/kinetics_parsing.h
@@ -28,6 +28,7 @@
 
 //Antioch
 #include "antioch/antioch_asserts.h"
+#include "antioch/metaprogramming_decl.h"
 #include "antioch/kinetics_type.h"
 #include "antioch/constant_rate.h"
 #include "antioch/hercourtessen_rate.h"
@@ -55,7 +56,7 @@ namespace Antioch
   template <typename CoeffType, typename VectorCoeffType, typename ParamType>
   void reset_parameter_of_rate(KineticsType<CoeffType,VectorCoeffType> & rate,
                                KineticsModel::Parameters parameter,
-                               const ParamType new_value);
+                               const ParamType new_value, const std::string & unit = "SI");
 
 
 //----------------------------------------
@@ -216,55 +217,63 @@ namespace Antioch
   template <typename CoeffType, typename VectorCoeffType, typename ParamType>
   void reset_parameter_of_rate(KineticsType<CoeffType,VectorCoeffType> & rate,
                                KineticsModel::Parameters parameter,
-                               const ParamType new_value)
+                               const ParamType new_value, const std::string & unit)
   {
+
+// this is crude at the moment, no test
+// this will be replaced by a unit manager
+// at some point, to be able to have an explicit
+// custom internal unit system with appropriate testing
+    ParamType new_coef = (unit == "SI")?new_value:
+                                        new_value * Units<typename value_type<ParamType>::type>(unit).get_SI_factor();
+
     switch(rate.type())
       {
       case(KineticsModel::CONSTANT):
         {
-          static_cast<ConstantRate<CoeffType>*>(&rate)->set_parameter(parameter,new_value);
+          static_cast<ConstantRate<CoeffType>*>(&rate)->set_parameter(parameter,new_coef);
         }
         break;
 
       case(KineticsModel::HERCOURT_ESSEN):
         {
-          static_cast< HercourtEssenRate<CoeffType>*>(&rate)->set_parameter(parameter,new_value);
+          static_cast< HercourtEssenRate<CoeffType>*>(&rate)->set_parameter(parameter,new_coef);
         }
         break;
 
       case(KineticsModel::BERTHELOT):
         {
-          static_cast< BerthelotRate<CoeffType>*>(&rate)->set_parameter(parameter,new_value);
+          static_cast< BerthelotRate<CoeffType>*>(&rate)->set_parameter(parameter,new_coef);
         }
         break;
 
       case(KineticsModel::ARRHENIUS):
         {
-          static_cast< ArrheniusRate<CoeffType>*>(&rate)->set_parameter(parameter,new_value);
+          static_cast< ArrheniusRate<CoeffType>*>(&rate)->set_parameter(parameter,new_coef);
         }
         break;
 
       case(KineticsModel::BHE):
         {
-          static_cast< BerthelotHercourtEssenRate<CoeffType>*>(&rate)->set_parameter(parameter,new_value);
+          static_cast< BerthelotHercourtEssenRate<CoeffType>*>(&rate)->set_parameter(parameter,new_coef);
         }
         break;
 
       case(KineticsModel::KOOIJ):
         {
-          static_cast< KooijRate<CoeffType>*>(&rate)->set_parameter(parameter,new_value);
+          static_cast< KooijRate<CoeffType>*>(&rate)->set_parameter(parameter,new_coef);
         }
         break;
 
       case(KineticsModel::VANTHOFF):
         {
-          static_cast< VantHoffRate<CoeffType>*>(&rate)->set_parameter(parameter,new_value);
+          static_cast< VantHoffRate<CoeffType>*>(&rate)->set_parameter(parameter,new_coef);
         }
         break;
 
       case(KineticsModel::PHOTOCHEM):
         {
-          static_cast<PhotochemicalRate<CoeffType,VectorCoeffType>*>(&rate)->set_parameter(parameter,new_value);
+          static_cast<PhotochemicalRate<CoeffType,VectorCoeffType>*>(&rate)->set_parameter(parameter,new_coef);
         }
         break;
 

--- a/src/kinetics/include/antioch/kinetics_parsing.h
+++ b/src/kinetics/include/antioch/kinetics_parsing.h
@@ -53,6 +53,16 @@ namespace Antioch
   template<typename CoeffType, typename VectorCoeffType, typename VectorType>
   void reset_rate( KineticsType<CoeffType,VectorCoeffType> & kin, const VectorType & coefs);
 
+  /*!
+   * The rate constant models derived from the Arrhenius model have
+   * an activation energy which is stored and used, for efficiency reasons,
+   * in the reduced \f$\frac{E_a}{\mathrm{R}}\f$ form in K.
+   * This calls for a subtle management of the get/set function.
+   * This is done by a unit management, by default an activation energy is
+   * an energy by quantity, so the default is to consider the SI unit
+   * for an energy, (J/mol). Therefore if the provided value is in Kelvin,
+   * it should be explicitely provided.
+   */
   template <typename CoeffType, typename VectorCoeffType>
   void reset_parameter_of_rate(KineticsType<CoeffType,VectorCoeffType> & rate,
                                KineticsModel::Parameters parameter,

--- a/src/kinetics/include/antioch/kinetics_parsing.h
+++ b/src/kinetics/include/antioch/kinetics_parsing.h
@@ -51,6 +51,15 @@ namespace Antioch
   template<typename CoeffType, typename VectorCoeffType, typename VectorType>
   void reset_rate( KineticsType<CoeffType,VectorCoeffType> & kin, const VectorType & coefs);
 
+  // ParamType is either VectorCoeffType or CoeffType
+  template <typename CoeffType, typename VectorCoeffType, typename ParamType>
+  void reset_parameter_of_rate(KineticsType<CoeffType,VectorCoeffType> & rate,
+                               KineticsModel::Parameters parameter,
+                               const ParamType & new_value);
+
+
+//----------------------------------------
+
   //! We take here the parameters as:
   //  - \f$A\f$, \f$\beta\f$, \f$E_a\f$, \f$D\f$, \f$\mathrm{T_{ref}}\f$, \f$\mathrm{scale}\f$.
   //  The \f$\mathrm{scale}\f$ parameter is the factor of \f$E_a\f$ from its unit
@@ -202,6 +211,71 @@ namespace Antioch
 
       } // switch(kin.type())
   }
+
+
+  template <typename CoeffType, typename VectorCoeffType, typename ParamType>
+  void reset_parameter_of_rate(KineticsType<CoeffType,VectorCoeffType> & rate,
+                               KineticsModel::Parameters parameter,
+                               const ParamType & new_value)
+  {
+    switch(rate.type())
+      {
+      case(KineticsModel::CONSTANT):
+        {
+          static_cast<ConstantRate<CoeffType>*>(&rate)->set_parameter(parameter,new_value);
+        }
+        break;
+
+      case(KineticsModel::HERCOURT_ESSEN):
+        {
+          static_cast< HercourtEssenRate<CoeffType>*>(&rate)->set_parameter(parameter,new_value);
+        }
+        break;
+
+      case(KineticsModel::BERTHELOT):
+        {
+          static_cast< BerthelotRate<CoeffType>*>(&rate)->set_parameter(parameter,new_value);
+        }
+        break;
+
+      case(KineticsModel::ARRHENIUS):
+        {
+          static_cast< ArrheniusRate<CoeffType>*>(&rate)->set_parameter(parameter,new_value);
+        }
+        break;
+
+      case(KineticsModel::BHE):
+        {
+          static_cast< BerthelotHercourtEssenRate<CoeffType>*>(&rate)->set_parameter(parameter,new_value);
+        }
+        break;
+
+      case(KineticsModel::KOOIJ):
+        {
+          static_cast< KooijRate<CoeffType>*>(&rate)->set_parameter(parameter,new_value);
+        }
+        break;
+
+      case(KineticsModel::VANTHOFF):
+        {
+          static_cast< VantHoffRate<CoeffType>*>(&rate)->set_parameter(parameter,new_value);
+        }
+        break;
+
+      case(KineticsModel::PHOTOCHEM):
+        {
+          static_cast<PhotochemicalRate<CoeffType,VectorCoeffType>*>(&rate)->set_parameter(parameter,new_value);
+        }
+        break;
+
+      default:
+        {
+          antioch_error();
+        }
+
+      } // switch(kin.type())
+  }
+
 
 
 } // end namespace Antioch

--- a/src/kinetics/include/antioch/kinetics_parsing.h
+++ b/src/kinetics/include/antioch/kinetics_parsing.h
@@ -53,11 +53,16 @@ namespace Antioch
   template<typename CoeffType, typename VectorCoeffType, typename VectorType>
   void reset_rate( KineticsType<CoeffType,VectorCoeffType> & kin, const VectorType & coefs);
 
-  // ParamType is either VectorCoeffType or CoeffType
-  template <typename CoeffType, typename VectorCoeffType, typename ParamType>
+  template <typename CoeffType, typename VectorCoeffType>
   void reset_parameter_of_rate(KineticsType<CoeffType,VectorCoeffType> & rate,
                                KineticsModel::Parameters parameter,
-                               const ParamType new_value, const std::string & unit = "SI");
+                               const CoeffType new_value, const std::string & unit = "SI");
+
+  // vectorized parameter
+  template <typename CoeffType, typename VectorCoeffType>
+  void reset_parameter_of_rate(KineticsType<CoeffType,VectorCoeffType> & rate,
+                               KineticsModel::Parameters parameter,
+                               const CoeffType new_value, int l, const std::string & unit = "SI");
 
 
 //----------------------------------------
@@ -215,18 +220,18 @@ namespace Antioch
   }
 
 
-  template <typename CoeffType, typename VectorCoeffType, typename ParamType>
+  template <typename CoeffType, typename VectorCoeffType>
   void reset_parameter_of_rate(KineticsType<CoeffType,VectorCoeffType> & rate,
                                KineticsModel::Parameters parameter,
-                               const ParamType new_value, const std::string & unit)
+                               const CoeffType new_value, const std::string & unit)
   {
 
 // this is crude at the moment, no test
 // this will be replaced by a unit manager
 // at some point, to be able to have an explicit
 // custom internal unit system with appropriate testing
-    ParamType new_coef = (unit == "SI")?new_value:
-                                        new_value * Units<typename value_type<ParamType>::type>(unit).get_SI_factor();
+    CoeffType new_coef = (unit == "SI")?new_value:
+                                        new_value * Units<typename value_type<CoeffType>::type>(unit).get_SI_factor();
 
 // Ea management, we want K, two possibilities now
 // 1 - Ea is already in K
@@ -235,7 +240,7 @@ namespace Antioch
    {
       if(unit != "K")
       {
-         new_coef = new_coef / Constants::R_universal<typename value_type<ParamType>::type>();
+         new_coef = new_coef / Constants::R_universal<typename value_type<CoeffType>::type>();
       }
    }
    
@@ -284,9 +289,32 @@ namespace Antioch
         }
         break;
 
+      default:
+        {
+          antioch_error();
+        }
+
+      } // switch(kin.type())
+  }
+
+  template <typename CoeffType, typename VectorCoeffType>
+  void reset_parameter_of_rate(KineticsType<CoeffType,VectorCoeffType> & rate,
+                               KineticsModel::Parameters parameter,
+                               const CoeffType new_value, int l, const std::string & unit)
+  {
+
+// this is crude at the moment, no test
+// this will be replaced by a unit manager
+// at some point, to be able to have an explicit
+// custom internal unit system with appropriate testing
+    CoeffType new_coef = (unit == "SI")?new_value:
+                                        new_value * Units<typename value_type<CoeffType>::type>(unit).get_SI_factor();
+
+    switch(rate.type())
+    {
       case(KineticsModel::PHOTOCHEM):
         {
-          static_cast<PhotochemicalRate<CoeffType,VectorCoeffType>*>(&rate)->set_parameter(parameter,new_coef);
+          static_cast<PhotochemicalRate<CoeffType,VectorCoeffType>*>(&rate)->set_parameter(parameter,l,new_coef);
         }
         break;
 

--- a/src/kinetics/include/antioch/kinetics_parsing.h
+++ b/src/kinetics/include/antioch/kinetics_parsing.h
@@ -29,6 +29,7 @@
 //Antioch
 #include "antioch/antioch_asserts.h"
 #include "antioch/metaprogramming_decl.h"
+#include "antioch/physical_constants.h"
 #include "antioch/kinetics_type.h"
 #include "antioch/constant_rate.h"
 #include "antioch/hercourtessen_rate.h"
@@ -226,6 +227,18 @@ namespace Antioch
 // custom internal unit system with appropriate testing
     ParamType new_coef = (unit == "SI")?new_value:
                                         new_value * Units<typename value_type<ParamType>::type>(unit).get_SI_factor();
+
+// Ea management, we want K, two possibilities now
+// 1 - Ea is already in K
+// 2 - Ea is in J.mol-1
+   if(parameter == KineticsModel::Parameters::E)
+   {
+      if(unit != "K")
+      {
+         new_coef = new_coef / Constants::R_universal<typename value_type<ParamType>::type>();
+      }
+   }
+   
 
     switch(rate.type())
       {

--- a/src/kinetics/include/antioch/kinetics_type.h
+++ b/src/kinetics/include/antioch/kinetics_type.h
@@ -97,6 +97,12 @@ namespace Antioch{
     template <typename StateType, typename VectorStateType>
     StateType derivative( const KineticsConditions<StateType,VectorStateType> & conditions ) const;
 
+    //! get one parameter, characterized by enum 
+    CoeffType get_parameter(KineticsModel::Parameters parameter) const;
+
+    //! get one parameter, characterized by enum, for vectorized parameter 
+    CoeffType get_parameter(KineticsModel::Parameters parameter, int l) const;
+
     // Deprecated API for backwards compatibility
     template <typename StateType>
     StateType derivative( const StateType & conditions ) const;
@@ -387,6 +393,85 @@ namespace Antioch{
       } // switch(my_type)
     
     return;
+  }
+
+  template <typename CoeffType, typename VectorCoeffType>
+  CoeffType KineticsType<CoeffType,VectorCoeffType>::get_parameter(KineticsModel::Parameters parameter) const
+  {
+    switch (my_type) 
+      {
+      case(KineticsModel::CONSTANT):
+        {
+          return (static_cast<const ConstantRate<CoeffType>*>(this))->get_parameter(parameter);
+        }
+        break;
+
+      case(KineticsModel::HERCOURT_ESSEN):
+        {
+          return (static_cast<const HercourtEssenRate<CoeffType>*>(this))->get_parameter(parameter);
+        }
+        break;
+
+      case(KineticsModel::BERTHELOT):
+        {
+          return (static_cast<const BerthelotRate<CoeffType>*>(this))->get_parameter(parameter);
+        }
+        break;
+
+      case(KineticsModel::ARRHENIUS):
+        {
+          return (static_cast<const ArrheniusRate<CoeffType>*>(this))->get_parameter(parameter);
+        }
+        break;
+
+      case(KineticsModel::BHE):
+        {
+          return (static_cast<const BerthelotHercourtEssenRate<CoeffType>*>(this))->get_parameter(parameter);
+        }
+        break;
+
+      case(KineticsModel::KOOIJ):
+        {
+          return (static_cast<const KooijRate<CoeffType>*>(this))->get_parameter(parameter);
+        }
+        break;
+
+      case(KineticsModel::VANTHOFF):
+        {
+          return (static_cast<const VantHoffRate<CoeffType>*>(this))->get_parameter(parameter);
+        }
+        break;
+
+      default:
+        {
+          antioch_error();
+        }
+
+      } // switch(my_type)
+
+      return 0;
+  }
+
+
+  template <typename CoeffType, typename VectorCoeffType>
+  CoeffType KineticsType<CoeffType,VectorCoeffType>::get_parameter(KineticsModel::Parameters parameter, int l) const
+  {
+    switch(my_type)
+      {
+      case(KineticsModel::PHOTOCHEM):
+        {
+          return (static_cast<const PhotochemicalRate<CoeffType,VectorCoeffType>*>(this))->get_parameter(parameter,l);
+        }
+        break;
+
+      default:
+        {
+          antioch_error();
+        }
+
+      } // switch(my_type)
+
+      return 0;
   }
 
   template <typename CoeffType, typename VectorCoeffType>

--- a/src/kinetics/include/antioch/kooij_rate.h
+++ b/src/kinetics/include/antioch/kooij_rate.h
@@ -83,6 +83,12 @@ namespace Antioch
     //! set one parameter, characterized by enum
     void set_parameter(KineticsModel::Parameters parameter, CoeffType new_value);
 
+    //! for compatibility purpose with photochemistry (particle flux reactions)
+    //
+    // \todo, solve this
+    template <typename VectorCoeffType>
+    void set_parameter(KineticsModel::Parameters parameter, VectorCoeffType new_value){antioch_error();}
+
     /*! reset the coeffs
      *
      * Two ways of modifying your rate:

--- a/src/kinetics/include/antioch/kooij_rate.h
+++ b/src/kinetics/include/antioch/kooij_rate.h
@@ -86,6 +86,9 @@ namespace Antioch
     //! set one parameter, characterized by enum
     void set_parameter(KineticsModel::Parameters parameter, CoeffType new_value);
 
+    //! get one parameter, characterized by enum
+    CoeffType get_parameter(KineticsModel::Parameters parameter) const;
+
     //! for compatibility purpose with photochemistry (particle flux reactions)
     //
     // \todo, solve this
@@ -108,6 +111,7 @@ namespace Antioch
     CoeffType Cf()     const;
     CoeffType eta()    const;
     CoeffType Ea()     const;
+    CoeffType Ea_K()   const;
     CoeffType Tref()   const;
     CoeffType rscale() const;
 
@@ -317,6 +321,47 @@ namespace Antioch
 
   template<typename CoeffType>
   inline
+  CoeffType KooijRate<CoeffType>::get_parameter(KineticsModel::Parameters parameter) const
+  {
+    switch(parameter)
+    {
+       case KineticsModel::Parameters::R_SCALE:
+       {
+          return this->rscale();
+       }
+        break;
+       case KineticsModel::Parameters::T_REF:
+       {
+         return this->Tref();
+       }
+        break;
+       case KineticsModel::Parameters::A:
+       {
+         return this->Cf();
+       }
+        break;
+       case KineticsModel::Parameters::B:
+       {
+         return this->eta();
+       }
+        break;
+       case KineticsModel::Parameters::E:
+       {
+         return this->Ea();
+       }
+        break;
+       default:
+       {
+         antioch_error();
+       }
+        break;
+    }
+
+    return 0;
+  }
+
+  template<typename CoeffType>
+  inline
   CoeffType KooijRate<CoeffType>::Cf() const
   { return _Cf; }
 
@@ -328,6 +373,11 @@ namespace Antioch
   template<typename CoeffType>
   inline
   CoeffType KooijRate<CoeffType>::Ea() const
+  { return _raw_Ea; }
+
+  template<typename CoeffType>
+  inline
+  CoeffType KooijRate<CoeffType>::Ea_K() const
   { return _Ea; }
 
   template<typename CoeffType>

--- a/src/kinetics/include/antioch/kooij_rate.h
+++ b/src/kinetics/include/antioch/kooij_rate.h
@@ -81,7 +81,7 @@ namespace Antioch
     void set_rscale(const CoeffType scale );
 
     //! set one parameter, characterized by enum
-    void set_parameter(KineticsModel::Parameters parameter, const CoeffType & new_value);
+    void set_parameter(KineticsModel::Parameters parameter, CoeffType new_value);
 
     /*! reset the coeffs
      *
@@ -260,7 +260,7 @@ namespace Antioch
 
   template<typename CoeffType>
   inline
-  void KooijRate<CoeffType>::set_parameter(KineticsModel::Parameters parameter, const CoeffType & new_value)
+  void KooijRate<CoeffType>::set_parameter(KineticsModel::Parameters parameter, CoeffType new_value)
   {
     switch(parameter)
     {

--- a/src/kinetics/include/antioch/kooij_rate.h
+++ b/src/kinetics/include/antioch/kooij_rate.h
@@ -76,7 +76,10 @@ namespace Antioch
     
     void set_Cf(    const CoeffType Cf );
     void set_eta(   const CoeffType eta );
+    //! set _raw_Ea, unit is known (cal.mol-1, J.mol-1, whatever), _Ea is computed
     void set_Ea(    const CoeffType Ea );
+    //! set _Ea, unit is K, _raw_Ea is computed
+    void reset_Ea(    const CoeffType Ea );
     void set_Tref(  const CoeffType Tref );
     void set_rscale(const CoeffType scale );
 
@@ -237,6 +240,15 @@ namespace Antioch
 
   template<typename CoeffType>
   inline
+  void KooijRate<CoeffType>::reset_Ea( const CoeffType Ea )
+  {
+    _Ea = Ea;
+    _raw_Ea = _Ea * _rscale;
+    return;
+  }
+
+  template<typename CoeffType>
+  inline
   void KooijRate<CoeffType>::set_rscale( const CoeffType rscale )
   {
     _rscale = rscale;
@@ -292,7 +304,7 @@ namespace Antioch
         break;
        case KineticsModel::Parameters::E:
        {
-        this->set_Ea(new_value);
+        this->reset_Ea(new_value);
        }
         break;
        default:

--- a/src/kinetics/include/antioch/kooij_rate.h
+++ b/src/kinetics/include/antioch/kooij_rate.h
@@ -80,6 +80,9 @@ namespace Antioch
     void set_Tref(  const CoeffType Tref );
     void set_rscale(const CoeffType scale );
 
+    //! set one parameter, characterized by enum
+    void set_parameter(KineticsModel::Parameters parameter, const CoeffType & new_value);
+
     /*! reset the coeffs
      *
      * Two ways of modifying your rate:
@@ -253,6 +256,45 @@ namespace Antioch
      this->set_Cf(coefficients[0]);
      this->set_eta(coefficients[1]);
      this->set_Ea(coefficients[2]);
+  }
+
+  template<typename CoeffType>
+  inline
+  void KooijRate<CoeffType>::set_parameter(KineticsModel::Parameters parameter, const CoeffType & new_value)
+  {
+    switch(parameter)
+    {
+       case KineticsModel::Parameters::R_SCALE:
+       {
+          this->set_rscale(new_value);
+       }
+        break;
+       case KineticsModel::Parameters::T_REF:
+       {
+         this->set_Tref(new_value);
+       }
+        break;
+       case KineticsModel::Parameters::A:
+       {
+        this->set_Cf(new_value);
+       }
+        break;
+       case KineticsModel::Parameters::B:
+       {
+        this->set_eta(new_value);
+       }
+        break;
+       case KineticsModel::Parameters::E:
+       {
+        this->set_Ea(new_value);
+       }
+        break;
+       default:
+       {
+         antioch_error();
+       }
+        break;
+    }
   }
 
   template<typename CoeffType>

--- a/src/kinetics/include/antioch/photochemical_rate.h
+++ b/src/kinetics/include/antioch/photochemical_rate.h
@@ -68,6 +68,16 @@ namespace Antioch{
        //!
        void set_lambda_grid(const VectorCoeffType &l);
 
+       //! set one parameter, characterized by enum
+       void set_parameter(KineticsModel::Parameters parameter, const VectorCoeffType & new_value);
+       //! compatibility, this is wrong
+       //
+       // \todo, we need a way to give the VectorCoeffType by
+       // the user at high level. At the moment it is necessarily
+       // std::vector<CoeffType>, as defined (and imposed) in
+       // read_reaction_set_data.h (l. 430) by the data vector.
+       void set_parameter(KineticsModel::Parameters parameter, const CoeffType & new_value) {antioch_error();}
+
        /*! reset the coefficients
         *
         *  Contrary to the other rate models, no choice here in the VectorCoeffType type.
@@ -162,6 +172,32 @@ namespace Antioch{
       }
       this->set_lambda_grid(l);
       this->set_cross_section(cs);
+  }
+
+  template<typename CoeffType, typename VectorCoeffType>
+  inline
+  void PhotochemicalRate<CoeffType,VectorCoeffType>::set_parameter(KineticsModel::Parameters parameter, const VectorCoeffType & new_value)
+  {
+    antioch_assert_equal_to(new_value.size(),_lambda_grid.size());
+
+    switch(parameter)
+    {
+      case KineticsModel::Parameters::LAMBDA:
+      {
+         this->set_lambda_grid(new_value);
+      }
+       break;
+      case KineticsModel::Parameters::SIGMA:
+      {
+         this->set_cross_section(new_value);
+      }
+        break;
+      default:
+      {
+        antioch_error();
+      }
+       break;
+    }
   }
 
   template<typename CoeffType, typename VectorCoeffType>

--- a/src/kinetics/include/antioch/photochemical_rate.h
+++ b/src/kinetics/include/antioch/photochemical_rate.h
@@ -62,21 +62,28 @@ namespace Antioch{
        PhotochemicalRate();
        ~PhotochemicalRate();
 
+
+       VectorCoeffType cross_section() const;
+       VectorCoeffType lambda_grid()   const;
+
+
        //!
        void set_cross_section(const VectorCoeffType &cs);
 
        //!
        void set_lambda_grid(const VectorCoeffType &l);
 
+       //!
+       void set_cross_section(CoeffType cs, int il);
+
+       //!
+       void set_lambda_grid(CoeffType l, int il);
+
+       //! set one value of one parameter, characterized by enum and its index
+       void set_parameter(KineticsModel::Parameters parameter, int l, CoeffType new_value);
+
        //! set one parameter, characterized by enum
-       void set_parameter(KineticsModel::Parameters parameter, VectorCoeffType new_value);
-       //! compatibility, this is wrong
-       //
-       // \todo, we need a way to give the VectorCoeffType by
-       // the user at high level. At the moment it is necessarily
-       // std::vector<CoeffType>, as defined (and imposed) in
-       // read_reaction_set_data.h (l. 430) by the data vector.
-       void set_parameter(KineticsModel::Parameters parameter, CoeffType new_value) {antioch_error();}
+       CoeffType get_parameter(KineticsModel::Parameters parameter, int l) const;
 
        /*! reset the coefficients
         *
@@ -154,6 +161,23 @@ namespace Antioch{
   {
      _lambda_grid = l;
   }
+  template<typename CoeffType, typename VectorCoeffType>
+  inline
+  void PhotochemicalRate<CoeffType,VectorCoeffType>::set_cross_section(CoeffType cs, int il)
+  {
+     antioch_assert_less(il,_cross_section.size());
+
+    _cross_section[il] = cs;
+  }
+
+  template<typename CoeffType, typename VectorCoeffType>
+  inline
+  void PhotochemicalRate<CoeffType,VectorCoeffType>::set_lambda_grid(CoeffType l, int il)
+  {
+     antioch_assert_less(il,_lambda_grid.size());
+
+     _lambda_grid[il] = l;
+  }
 
   template<typename CoeffType, typename VectorCoeffType>
   inline
@@ -176,20 +200,19 @@ namespace Antioch{
 
   template<typename CoeffType, typename VectorCoeffType>
   inline
-  void PhotochemicalRate<CoeffType,VectorCoeffType>::set_parameter(KineticsModel::Parameters parameter, VectorCoeffType new_value)
+  void PhotochemicalRate<CoeffType,VectorCoeffType>::set_parameter(KineticsModel::Parameters parameter, int l, CoeffType new_value)
   {
-    antioch_assert_equal_to(new_value.size(),_lambda_grid.size());
 
     switch(parameter)
     {
       case KineticsModel::Parameters::LAMBDA:
       {
-         this->set_lambda_grid(new_value);
+         this->set_lambda_grid(new_value,l);
       }
        break;
       case KineticsModel::Parameters::SIGMA:
       {
-         this->set_cross_section(new_value);
+         this->set_cross_section(new_value,l);
       }
         break;
       default:
@@ -198,6 +221,35 @@ namespace Antioch{
       }
        break;
     }
+  }
+
+  template<typename CoeffType, typename VectorCoeffType>
+  inline
+  CoeffType PhotochemicalRate<CoeffType,VectorCoeffType>::get_parameter(KineticsModel::Parameters parameter,int l) const
+  {
+
+   antioch_assert_less(l,_cross_section.size());
+
+    switch(parameter)
+    {
+      case KineticsModel::Parameters::LAMBDA:
+      {
+         return this->lambda_grid()[l];
+      }
+       break;
+      case KineticsModel::Parameters::SIGMA:
+      {
+         return this->cross_section()[l];
+      }
+        break;
+      default:
+      {
+        antioch_error();
+      }
+       break;
+    }
+
+     return 0;
   }
 
   template<typename CoeffType, typename VectorCoeffType>
@@ -248,6 +300,20 @@ namespace Antioch{
     Antioch::init_clone(rate,this->rate(pf));
     Antioch::set_zero(drate_dT);
     return;
+  }
+
+  template<typename CoeffType, typename VectorCoeffType>
+  inline
+  VectorCoeffType PhotochemicalRate<CoeffType,VectorCoeffType>::cross_section() const
+  {
+     return _cross_section;
+  }
+
+  template<typename CoeffType, typename VectorCoeffType>
+  inline
+  VectorCoeffType PhotochemicalRate<CoeffType,VectorCoeffType>::lambda_grid() const
+  {
+     return _lambda_grid;
   }
 
 } //end namespace Antioch

--- a/src/kinetics/include/antioch/photochemical_rate.h
+++ b/src/kinetics/include/antioch/photochemical_rate.h
@@ -69,14 +69,14 @@ namespace Antioch{
        void set_lambda_grid(const VectorCoeffType &l);
 
        //! set one parameter, characterized by enum
-       void set_parameter(KineticsModel::Parameters parameter, const VectorCoeffType & new_value);
+       void set_parameter(KineticsModel::Parameters parameter, VectorCoeffType new_value);
        //! compatibility, this is wrong
        //
        // \todo, we need a way to give the VectorCoeffType by
        // the user at high level. At the moment it is necessarily
        // std::vector<CoeffType>, as defined (and imposed) in
        // read_reaction_set_data.h (l. 430) by the data vector.
-       void set_parameter(KineticsModel::Parameters parameter, const CoeffType & new_value) {antioch_error();}
+       void set_parameter(KineticsModel::Parameters parameter, CoeffType new_value) {antioch_error();}
 
        /*! reset the coefficients
         *
@@ -176,7 +176,7 @@ namespace Antioch{
 
   template<typename CoeffType, typename VectorCoeffType>
   inline
-  void PhotochemicalRate<CoeffType,VectorCoeffType>::set_parameter(KineticsModel::Parameters parameter, const VectorCoeffType & new_value)
+  void PhotochemicalRate<CoeffType,VectorCoeffType>::set_parameter(KineticsModel::Parameters parameter, VectorCoeffType new_value)
   {
     antioch_assert_equal_to(new_value.size(),_lambda_grid.size());
 

--- a/src/kinetics/include/antioch/reaction.h
+++ b/src/kinetics/include/antioch/reaction.h
@@ -154,7 +154,7 @@ namespace Antioch
 
     //! reset a parameter from the rate constant
     template <typename ParamType>
-    void set_parameter_of_rate(KineticsModel::Parameters parameter, ParamType new_value, unsigned int n_reaction = 0);
+    void set_parameter_of_rate(KineticsModel::Parameters parameter, ParamType new_value, unsigned int n_reaction = 0, const std::string & unit = "SI");
 
     //! reset a parameter from the chemical process
     void set_parameter_of_chemical_process(ReactionType::Parameters parameter, CoeffType new_value, unsigned int species = std::numeric_limits<unsigned int>::max() );
@@ -1244,10 +1244,10 @@ namespace Antioch
   template<typename CoeffType, typename VectorCoeffType>
   template <typename ParamType>
   inline
-  void Reaction<CoeffType,VectorCoeffType>::set_parameter_of_rate(KineticsModel::Parameters parameter, ParamType new_value, unsigned int n_kin)
+  void Reaction<CoeffType,VectorCoeffType>::set_parameter_of_rate(KineticsModel::Parameters parameter, ParamType new_value, unsigned int n_kin, const std::string & unit)
   {
       antioch_assert_less(n_kin,_forward_rate.size());
-      reset_parameter_of_rate(*_forward_rate[n_kin], parameter, new_value);
+      reset_parameter_of_rate(*_forward_rate[n_kin], parameter, new_value, unit);
   }
 
   template<typename CoeffType, typename VectorCoeffType>

--- a/src/kinetics/include/antioch/reaction.h
+++ b/src/kinetics/include/antioch/reaction.h
@@ -1211,6 +1211,18 @@ namespace Antioch
         }
         break;
 
+        case(ReactionType::LINDEMANN_FALLOFF_THREE_BODY):
+        {
+          (static_cast<const FalloffThreeBodyReaction<CoeffType,LindemannFalloff<CoeffType> >*>(this))->F();
+        }
+        break;
+
+        case(ReactionType::TROE_FALLOFF_THREE_BODY):
+        {
+          (static_cast<const FalloffThreeBodyReaction<CoeffType,LindemannFalloff<CoeffType> >*>(this))->F();
+        }
+        break;
+
         default:
         {
           std::cerr << "You are trying to retrieve a Falloff object in a reaction that is not a falloff.\n"

--- a/src/kinetics/include/antioch/reaction.h
+++ b/src/kinetics/include/antioch/reaction.h
@@ -121,10 +121,10 @@ namespace Antioch
     unsigned int n_species() const;
     
     //! \returns the equation for this reaction.
-    std::string equation() const;
+    const std::string & equation() const;
 
     //! \returns the reaction id.
-    std::string id() const;
+    const std::string & id() const;
 
     //! set the reaction id.
     void set_id(const std::string & id);
@@ -363,7 +363,7 @@ namespace Antioch
 
   template<typename CoeffType, typename VectorCoeffType>
   inline
-  std::string Reaction<CoeffType,VectorCoeffType>::id() const
+  const std::string & Reaction<CoeffType,VectorCoeffType>::id() const
   {
     return _id;
   }
@@ -377,7 +377,7 @@ namespace Antioch
 
   template<typename CoeffType, typename VectorCoeffType>
   inline
-  std::string Reaction<CoeffType,VectorCoeffType>::equation() const
+  const std::string & Reaction<CoeffType,VectorCoeffType>::equation() const
   {
     return _equation;
   }

--- a/src/kinetics/include/antioch/reaction.h
+++ b/src/kinetics/include/antioch/reaction.h
@@ -123,6 +123,12 @@ namespace Antioch
     //! \returns the equation for this reaction.
     std::string equation() const;
 
+    //! \returns the reaction id.
+    std::string id() const;
+
+    //! set the reaction id.
+    void set_id(const std::string & id);
+
     /*! Type of reaction.
      *  reversible reactions are considered.
      */
@@ -319,6 +325,7 @@ namespace Antioch
   protected:
 
     unsigned int _n_species;
+    std::string _id;
     std::string _equation;
     std::vector<std::string> _reactant_names;
     std::vector<std::string> _product_names;
@@ -352,6 +359,20 @@ namespace Antioch
   unsigned int Reaction<CoeffType,VectorCoeffType>::n_species() const
   {
     return _n_species;
+  }
+
+  template<typename CoeffType, typename VectorCoeffType>
+  inline
+  std::string Reaction<CoeffType,VectorCoeffType>::id() const
+  {
+    return _id;
+  }
+
+  template<typename CoeffType, typename VectorCoeffType>
+  inline
+  void Reaction<CoeffType,VectorCoeffType>::set_id(const std::string & id)
+  {
+    _id = id;
   }
 
   template<typename CoeffType, typename VectorCoeffType>

--- a/src/kinetics/include/antioch/reaction_enum.h
+++ b/src/kinetics/include/antioch/reaction_enum.h
@@ -44,7 +44,15 @@ namespace Antioch
                         LINDEMANN_FALLOFF_THREE_BODY,
                         TROE_FALLOFF_THREE_BODY};
 
+  enum Parameters{ EFFICIENCIES = 0,
+                   TROE_ALPHA,
+                   TROE_T1,
+                   TROE_T2,
+                   TROE_T3
+                  };
+
   } // end namespace ReactionType
+
 
 } // end namespace Antioch
 

--- a/src/kinetics/include/antioch/reaction_enum.h
+++ b/src/kinetics/include/antioch/reaction_enum.h
@@ -44,7 +44,8 @@ namespace Antioch
                         LINDEMANN_FALLOFF_THREE_BODY,
                         TROE_FALLOFF_THREE_BODY};
 
-  enum Parameters{ EFFICIENCIES = 0,
+  enum Parameters{ NOT_FOUND = 0,
+                   EFFICIENCIES,
                    TROE_ALPHA,
                    TROE_T1,
                    TROE_T2,

--- a/src/kinetics/include/antioch/reaction_parsing.h
+++ b/src/kinetics/include/antioch/reaction_parsing.h
@@ -50,6 +50,15 @@ namespace Antioch
                                        const ReactionType::ReactionType& type , 
                                        const KineticsModel::KineticsModel& kin );
 
+
+  template <typename CoeffType>
+  void reset_parameter_of_chemical_process(Reaction<CoeffType> * reac,
+                                           ReactionType::Parameters parameter,
+                                           const CoeffType & new_value,
+                                           unsigned int species = 0); // if resetting epsilon
+
+// ----------------------
+
   template<typename CoeffType>
   inline
   Reaction<CoeffType>* build_reaction( const unsigned int n_species, 
@@ -110,6 +119,58 @@ namespace Antioch
     // Dummy
     return reaction;
   }
+
+
+  template <typename CoeffType>
+  inline
+  void reset_parameter_of_chemical_process(Reaction<CoeffType> * reac,
+                                           ReactionType::Parameters parameter,
+                                           const CoeffType & new_value,
+                                           unsigned int species)
+  {
+      switch(parameter)
+      {
+        case ReactionType::EFFICIENCIES:
+        {
+          reac->set_efficiency(std::string(),species,new_value); // tests inside, if not three-body or species wrong
+        }
+          break;
+        case ReactionType::TROE_ALPHA:
+        {
+          antioch_assert( (reac->type() == ReactionType::TROE_FALLOFF) || 
+                          (reac->type() == ReactionType::TROE_FALLOFF_THREE_BODY) );
+          reac->falloff().set_alpha(new_value);
+        }
+          break;
+        case ReactionType::TROE_T1:
+        {
+          antioch_assert( (reac->type() == ReactionType::TROE_FALLOFF) || 
+                          (reac->type() == ReactionType::TROE_FALLOFF_THREE_BODY) );
+          reac->falloff().set_T1(new_value);
+        }
+          break;
+        case ReactionType::TROE_T2:
+        {
+          antioch_assert( (reac->type() == ReactionType::TROE_FALLOFF) || 
+                          (reac->type() == ReactionType::TROE_FALLOFF_THREE_BODY) );
+          reac->falloff().set_T2(new_value);
+        }
+          break;
+        case ReactionType::TROE_T3:
+        {
+          antioch_assert( (reac->type() == ReactionType::TROE_FALLOFF) || 
+                          (reac->type() == ReactionType::TROE_FALLOFF_THREE_BODY) );
+          reac->falloff().set_T3(new_value);
+        }
+          break;
+        default:
+        {
+          antioch_error();
+        }
+          break;
+      }
+  }
+
 
 } // end namespace Antioch
 

--- a/src/kinetics/include/antioch/reaction_parsing.h
+++ b/src/kinetics/include/antioch/reaction_parsing.h
@@ -50,13 +50,6 @@ namespace Antioch
                                        const ReactionType::ReactionType& type , 
                                        const KineticsModel::KineticsModel& kin );
 
-
-  template <typename CoeffType>
-  void reset_parameter_of_chemical_process(Reaction<CoeffType> * reac,
-                                           ReactionType::Parameters parameter,
-                                           const CoeffType & new_value,
-                                           unsigned int species = 0); // if resetting epsilon
-
 // ----------------------
 
   template<typename CoeffType>
@@ -119,58 +112,6 @@ namespace Antioch
     // Dummy
     return reaction;
   }
-
-
-  template <typename CoeffType>
-  inline
-  void reset_parameter_of_chemical_process(Reaction<CoeffType> * reac,
-                                           ReactionType::Parameters parameter,
-                                           const CoeffType & new_value,
-                                           unsigned int species)
-  {
-      switch(parameter)
-      {
-        case ReactionType::EFFICIENCIES:
-        {
-          reac->set_efficiency(std::string(),species,new_value); // tests inside, if not three-body or species wrong
-        }
-          break;
-        case ReactionType::TROE_ALPHA:
-        {
-          antioch_assert( (reac->type() == ReactionType::TROE_FALLOFF) || 
-                          (reac->type() == ReactionType::TROE_FALLOFF_THREE_BODY) );
-          reac->falloff().set_alpha(new_value);
-        }
-          break;
-        case ReactionType::TROE_T1:
-        {
-          antioch_assert( (reac->type() == ReactionType::TROE_FALLOFF) || 
-                          (reac->type() == ReactionType::TROE_FALLOFF_THREE_BODY) );
-          reac->falloff().set_T1(new_value);
-        }
-          break;
-        case ReactionType::TROE_T2:
-        {
-          antioch_assert( (reac->type() == ReactionType::TROE_FALLOFF) || 
-                          (reac->type() == ReactionType::TROE_FALLOFF_THREE_BODY) );
-          reac->falloff().set_T2(new_value);
-        }
-          break;
-        case ReactionType::TROE_T3:
-        {
-          antioch_assert( (reac->type() == ReactionType::TROE_FALLOFF) || 
-                          (reac->type() == ReactionType::TROE_FALLOFF_THREE_BODY) );
-          reac->falloff().set_T3(new_value);
-        }
-          break;
-        default:
-        {
-          antioch_error();
-        }
-          break;
-      }
-  }
-
 
 } // end namespace Antioch
 

--- a/src/kinetics/include/antioch/reaction_set.h
+++ b/src/kinetics/include/antioch/reaction_set.h
@@ -351,10 +351,19 @@ namespace Antioch
       {
           // which rate?
            unsigned int nr(0);
+           std::string unit("SI");
            if(keywords.size() > 1)nr = std::stoi(keywords[1]); //C++11, throws an exception on error
-           this->reaction(r).set_parameter_of_rate(paramKin, value, nr);
+           if(keywords.size() > 2)unit = keywords[2];
+           this->reaction(r).set_parameter_of_rate(paramKin, value, nr, unit);
       }else if(paramChem != ReactionType::Parameters::NOT_FOUND)
       {
+// there's not really a unit issue here:
+//   * efficiencies: unitless
+//   * Troe alpha: unitless
+//   * Troe T*:   temperature, if it's other than K, you're a bad (like really really bad) scientist, get off my library
+//   * Troe T**:  temperature, if it's other than K, you're a bad (like really really bad) scientist, get off my library
+//   * Troe T***: temperature, if it's other than K, you're a bad (like really really bad) scientist, get off my library
+
            unsigned int species = std::numeric_limits<unsigned int>::max(); // sensible default
            if(paramChem == ReactionType::Parameters::EFFICIENCIES) // who?
            {

--- a/src/kinetics/include/antioch/troe_falloff.h
+++ b/src/kinetics/include/antioch/troe_falloff.h
@@ -120,6 +120,11 @@ namespace Antioch
     void set_T2(const CoeffType &T);
     void set_T3(const CoeffType &T);
 
+    CoeffType get_alpha() const;
+    CoeffType get_T1()    const;
+    CoeffType get_T2()    const;
+    CoeffType get_T3()    const;
+
     template <typename StateType>
     StateType operator()(const StateType &T,
                          const StateType &M,
@@ -194,6 +199,35 @@ namespace Antioch
     _T3 = T;
     return;
   }
+
+  template<typename CoeffType>
+  inline
+  CoeffType TroeFalloff<CoeffType>::get_alpha() const
+  {
+     return _alpha;
+  }
+
+  template<typename CoeffType>
+  inline
+  CoeffType TroeFalloff<CoeffType>::get_T1()    const
+  {
+     return _T1;
+  }
+
+  template<typename CoeffType>
+  inline
+  CoeffType TroeFalloff<CoeffType>::get_T2()    const
+  {
+     return _T2;
+  }
+
+  template<typename CoeffType>
+  inline
+  CoeffType TroeFalloff<CoeffType>::get_T3()    const
+  {
+     return _T3;
+  }
+
 
   template<typename CoeffType>
   template<typename StateType>

--- a/src/kinetics/include/antioch/vanthoff_rate.h
+++ b/src/kinetics/include/antioch/vanthoff_rate.h
@@ -85,7 +85,7 @@ namespace Antioch
     void set_rscale(const CoeffType rscale );
 
     //! set one parameter, characterized by enum
-    void set_parameter(KineticsModel::Parameters parameter, const CoeffType & new_value);
+    void set_parameter(KineticsModel::Parameters parameter, CoeffType new_value);
 
     /*! reset the coeffs
      *
@@ -274,7 +274,7 @@ namespace Antioch
 
   template<typename CoeffType>
   inline
-  void VantHoffRate<CoeffType>::set_parameter(KineticsModel::Parameters parameter, const CoeffType & new_value)
+  void VantHoffRate<CoeffType>::set_parameter(KineticsModel::Parameters parameter, CoeffType new_value)
   {
     switch(parameter)
     {

--- a/src/kinetics/include/antioch/vanthoff_rate.h
+++ b/src/kinetics/include/antioch/vanthoff_rate.h
@@ -79,7 +79,10 @@ namespace Antioch
     
     void set_Cf(    const CoeffType Cf );
     void set_eta(   const CoeffType eta );
+    //! set _raw_Ea, unit is known (cal.mol-1, J.mol-1, whatever), _Ea is computed
     void set_Ea(    const CoeffType Ea );
+    //! set _Ea, unit is K, _raw_Ea is computed
+    void reset_Ea(    const CoeffType Ea );
     void set_D(     const CoeffType D );
     void set_Tref(  const CoeffType Tref );
     void set_rscale(const CoeffType rscale );
@@ -242,6 +245,15 @@ namespace Antioch
 
   template<typename CoeffType>
   inline
+  void VantHoffRate<CoeffType>::reset_Ea( const CoeffType Ea )
+  {
+    _Ea = Ea;
+    _raw_Ea = _Ea * _rscale;
+    return;
+  }
+
+  template<typename CoeffType>
+  inline
   void VantHoffRate<CoeffType>::set_rscale( const CoeffType rscale )
   {
     _rscale = rscale;
@@ -306,7 +318,7 @@ namespace Antioch
         break;
       case KineticsModel::Parameters::E:
       {
-        this->set_Ea(new_value);
+        this->reset_Ea(new_value);
       }
         break;
       case KineticsModel::Parameters::D:

--- a/src/kinetics/include/antioch/vanthoff_rate.h
+++ b/src/kinetics/include/antioch/vanthoff_rate.h
@@ -90,6 +90,9 @@ namespace Antioch
     //! set one parameter, characterized by enum
     void set_parameter(KineticsModel::Parameters parameter, CoeffType new_value);
 
+    //! get one parameter, characterized by enum
+    CoeffType get_parameter(KineticsModel::Parameters parameter) const;
+
     //! for compatibility purpose with photochemistry (particle flux reactions)
     //
     // \todo, solve this
@@ -112,6 +115,7 @@ namespace Antioch
     CoeffType Cf()     const;
     CoeffType eta()    const;
     CoeffType Ea()     const;
+    CoeffType Ea_K()   const;
     CoeffType D()      const;
     CoeffType Tref()   const;
     CoeffType rscale() const;
@@ -334,6 +338,51 @@ namespace Antioch
     }
   }
 
+  template<typename CoeffType>
+  inline
+  CoeffType VantHoffRate<CoeffType>::get_parameter(KineticsModel::Parameters parameter) const
+  {
+    switch(parameter)
+    {
+      case KineticsModel::Parameters::R_SCALE:
+      {
+         return this->rscale();
+      }
+       break;
+      case KineticsModel::Parameters::T_REF:
+      {
+         return this->Tref();
+      }
+       break;
+      case KineticsModel::Parameters::A:
+      {
+         return this->Cf();
+      }
+        break;
+      case KineticsModel::Parameters::B:
+      {
+         return this->eta();
+      }
+        break;
+      case KineticsModel::Parameters::E:
+      {
+         return this->Ea();
+      }
+        break;
+      case KineticsModel::Parameters::D:
+      {
+        return this->D();
+      }
+        break;
+      default:
+      {
+        antioch_error();
+      }
+       break;
+    }
+
+    return 0;
+  }
 
   template<typename CoeffType>
   inline
@@ -348,6 +397,11 @@ namespace Antioch
   template<typename CoeffType>
   inline
   CoeffType VantHoffRate<CoeffType>::Ea() const
+  { return _raw_Ea; }
+
+  template<typename CoeffType>
+  inline
+  CoeffType VantHoffRate<CoeffType>::Ea_K() const
   { return _Ea; }
 
   template<typename CoeffType>

--- a/src/kinetics/include/antioch/vanthoff_rate.h
+++ b/src/kinetics/include/antioch/vanthoff_rate.h
@@ -84,6 +84,9 @@ namespace Antioch
     void set_Tref(  const CoeffType Tref );
     void set_rscale(const CoeffType rscale );
 
+    //! set one parameter, characterized by enum
+    void set_parameter(KineticsModel::Parameters parameter, const CoeffType & new_value);
+
     /*! reset the coeffs
      *
      * Two ways of modifying your rate:
@@ -267,6 +270,50 @@ namespace Antioch
      this->set_eta(coefficients[1]);
      this->set_Ea(coefficients[2]);
      this->set_D(coefficients[3]);
+  }
+
+  template<typename CoeffType>
+  inline
+  void VantHoffRate<CoeffType>::set_parameter(KineticsModel::Parameters parameter, const CoeffType & new_value)
+  {
+    switch(parameter)
+    {
+      case KineticsModel::Parameters::R_SCALE:
+      {
+        this->set_rscale(new_value);
+      }
+       break;
+      case KineticsModel::Parameters::T_REF:
+      {
+        this->set_Tref(new_value);
+      }
+       break;
+      case KineticsModel::Parameters::A:
+      {
+        this->set_Cf(new_value);
+      }
+        break;
+      case KineticsModel::Parameters::B:
+      {
+        this->set_eta(new_value);
+      }
+        break;
+      case KineticsModel::Parameters::E:
+      {
+        this->set_Ea(new_value);
+      }
+        break;
+      case KineticsModel::Parameters::D:
+      {
+        this->set_D(new_value);
+      }
+        break;
+      default:
+      {
+        antioch_error();
+      }
+       break;
+    }
   }
 
 

--- a/src/kinetics/include/antioch/vanthoff_rate.h
+++ b/src/kinetics/include/antioch/vanthoff_rate.h
@@ -87,6 +87,12 @@ namespace Antioch
     //! set one parameter, characterized by enum
     void set_parameter(KineticsModel::Parameters parameter, CoeffType new_value);
 
+    //! for compatibility purpose with photochemistry (particle flux reactions)
+    //
+    // \todo, solve this
+    template <typename VectorCoeffType>
+    void set_parameter(KineticsModel::Parameters parameter, VectorCoeffType new_value){antioch_error();}
+
     /*! reset the coeffs
      *
      * Two ways of modifying your rate:

--- a/src/parsing/include/antioch/read_reaction_set_data.h
+++ b/src/parsing/include/antioch/read_reaction_set_data.h
@@ -287,7 +287,7 @@ namespace Antioch
 
     while (parser->reaction())
       {
-        if (verbose) std::cout << "Reaction #" << parser->reaction_id() << ":\n"
+        if (verbose) std::cout << "Reaction \"" << parser->reaction_id() << "\":\n"
                                << " eqn: " << parser->reaction_equation()
                                << std::endl;
 

--- a/src/parsing/include/antioch/read_reaction_set_data.h
+++ b/src/parsing/include/antioch/read_reaction_set_data.h
@@ -339,6 +339,7 @@ namespace Antioch
         // construct a Reaction object    
         Reaction<NumericType>* my_rxn = build_reaction<NumericType>(n_species, parser->reaction_equation(),
                                                                                reversible,typeReaction,kineticsModel);
+        my_rxn->set_id(parser->reaction_id());
 
         // We will add the reaction, unless we do not have a 
         // reactant or product

--- a/src/parsing/include/antioch/xml_parser.h
+++ b/src/parsing/include/antioch/xml_parser.h
@@ -449,7 +449,7 @@ namespace Antioch{
   const std::string XMLParser<NumericType>::reaction_id() const
   {
     std::stringstream id;
-    id << _reaction->IntAttribute(_map.at(ParsingKey::ID).c_str());
+    id << _reaction->Attribute(_map.at(ParsingKey::ID).c_str());
     return id.str();
   }
 

--- a/src/utilities/include/antioch/antioch_asserts.h
+++ b/src/utilities/include/antioch/antioch_asserts.h
@@ -123,7 +123,6 @@
 
 
 // Just outputing to std::cerr
-#define antioch_msg_error(errmsg)           do { std::cerr << errmsg << std::endl; }                   while(0)
-#define antioch_not_implemented_msg(errmsg) do {antioch_msg_error(errmsg); antioch_not_implemented();} while(0) 
+#define antioch_not_implemented_msg(errmsg) do {antioch_warning(errmsg); antioch_not_implemented();} while(0) 
 
 #endif // ANTIOCH_ASSERTS_H

--- a/src/utilities/include/antioch/string_utils.h
+++ b/src/utilities/include/antioch/string_utils.h
@@ -33,6 +33,9 @@
 
 // Antioch
 #include "antioch/antioch_asserts.h"
+// some enum
+#include "antioch/kinetics_enum.h"
+#include "antioch/reaction_enum.h"
 
 // C++
 #include <iostream>
@@ -186,6 +189,64 @@ namespace Antioch
      return buf.good();
   }
 
+  inline
+  KineticsModel::Parameters string_to_kin_enum(const std::string & str)
+  {
+// kinetics 
+      if(str == "A")
+      {
+        return KineticsModel::Parameters::A;
+      }else if(str == "E")
+      {
+        return KineticsModel::Parameters::E;
+      }else if(str == "B")
+      {
+        return KineticsModel::Parameters::B;
+      }else if(str == "D")
+      {
+        return KineticsModel::Parameters::D;
+      }else if(str == "Tref")
+      {
+        return KineticsModel::Parameters::T_REF;
+      }else if(str == "Rscale")
+      {
+        return KineticsModel::Parameters::R_SCALE;
+      }else if(str == "sigma")
+      {
+        return KineticsModel::Parameters::SIGMA;
+      }else if(str == "lambda")
+      {
+        return KineticsModel::Parameters::LAMBDA;
+      }else
+      {
+        return KineticsModel::Parameters::NOT_FOUND;
+      }
+   }
+
+  inline
+  ReactionType::Parameters string_to_chem_enum(const std::string & str)
+  {
+// chemical
+      if(str == "efficiencies")
+      {
+        return ReactionType::Parameters::EFFICIENCIES;
+      }else if(str == "alpha")
+      {
+        return ReactionType::Parameters::TROE_ALPHA;
+      }else if(str == "T1")
+      {
+        return ReactionType::Parameters::TROE_T1;
+      }else if(str == "T2")
+      {
+        return ReactionType::Parameters::TROE_T2;
+      }else if(str == "T3")
+      {
+        return ReactionType::Parameters::TROE_T3;
+      }else
+      {
+        return ReactionType::Parameters::NOT_FOUND;
+      }
+  } 
 
 } // end namespace Antioch
 

--- a/src/utilities/include/antioch/string_utils.h
+++ b/src/utilities/include/antioch/string_utils.h
@@ -217,6 +217,12 @@ namespace Antioch
       }else if(str == "lambda")
       {
         return KineticsModel::Parameters::LAMBDA;
+      }else if(str == "0")
+      {
+        return KineticsModel::Parameters::LOW_PRESSURE;
+      }else if(str == "inf")
+      {
+        return KineticsModel::Parameters::HIGH_PRESSURE;
       }else
       {
         return KineticsModel::Parameters::NOT_FOUND;

--- a/src/utilities/include/antioch/vector_utils.h
+++ b/src/utilities/include/antioch/vector_utils.h
@@ -65,6 +65,32 @@ operator<< (std::ostream& output, const std::vector<T>& a)
   return output;
 }
 
+template <typename T>
+inline
+std::vector<T>
+operator* (const std::vector<T>& src, const T & mul)
+{
+  std::vector<T> output(src);
+  const std::size_t size = src.size();
+  for (std::size_t i=1; i<size; ++i)
+    output[i] = src[i] * mul;
+  
+  return output;
+}
+
+template <typename T>
+inline
+std::vector<T>
+operator/ (const std::vector<T>& src, const T & mul)
+{
+  std::vector<T> output(src);
+  const std::size_t size = src.size();
+  for (std::size_t i=1; i<size; ++i)
+    output[i] = src[i] / mul;
+  
+  return output;
+}
+
 } // end namespace std
 
 namespace Antioch

--- a/src/utilities/include/antioch/vector_utils_decl.h
+++ b/src/utilities/include/antioch/vector_utils_decl.h
@@ -52,6 +52,16 @@ inline
 std::ostream&
 operator<< (std::ostream& output, const std::vector<T>& a);
 
+template <typename T>
+inline
+std::vector<T>
+operator* (const std::vector<T>& src, const T & mul);
+
+template <typename T>
+inline
+std::vector<T>
+operator/ (const std::vector<T>& src, const T & mul);
+
 } // end namespace std
 
 namespace Antioch

--- a/test/kinetics_regression.C
+++ b/test/kinetics_regression.C
@@ -270,6 +270,31 @@ int tester(const std::string& input_name)
     {
       return_flag = checker(omega_dot_reg[s],omega_dot[s] ,"resetted omega dot of species "  + chem_mixture.chemical_species()[s]->species()) || return_flag;
     }
+
+// and now a get/set loop
+  reaction_id = "0004";
+  const Scalar val(1.1L);
+  keywords.clear();
+  keywords.push_back("E");
+//  keywords.push_back("cal/mol"); // no, you only get SI
+  reaction_set.set_parameter_of_reaction(reaction_id,keywords,
+                                               val * reaction_set.get_parameter_of_reaction(reaction_id,keywords) );
+
+//recomputing
+  Antioch::set_zero(omega_dot);
+  kinetics.compute_mass_sources( conditions , molar_densities, h_RT_minus_s_R, omega_dot);
+
+// new values, SI
+  omega_dot_reg[0] =  1.541307374714467399842142e4;
+  omega_dot_reg[1] = -3.345669367278851525665733e5;
+  omega_dot_reg[2] = -1.723780168437354542966397e5;
+  omega_dot_reg[3] =  1.552808795073360031682657e5;
+  omega_dot_reg[4] =  3.362510003171399296965259e5;
+
+  for( unsigned int s = 0; s < n_species; s++)
+    {
+      return_flag = checker(omega_dot_reg[s],omega_dot[s] ,"loop-resetted omega dot of species "  + chem_mixture.chemical_species()[s]->species()) || return_flag;
+    }
  
   return return_flag;
 }

--- a/test/kinetics_regression.C
+++ b/test/kinetics_regression.C
@@ -44,6 +44,30 @@
 #include "antioch/cea_thermo.h"
 #include "antioch/kinetics_evaluator.h"
 
+
+template <typename Scalar>
+int checker(const Scalar & theory, const Scalar & computed, const std::string& words)
+{
+
+  int return_flag(0);
+  const Scalar tol = std::numeric_limits<Scalar>::epsilon() * 500;
+
+  const Scalar rel_error = std::abs( (computed - theory)/theory);
+  if( rel_error > tol )
+  {
+     std::cerr << "Error: Mismatch between theory and regression values in test " << words << std::endl;
+     std::cout << std::scientific << std::setprecision(16)
+               << "theory value        = " << theory    << std::endl
+               << "computed value      = " << computed  << std::endl
+               << "relative difference = " << rel_error << std::endl
+               << "tolerance           = " << tol       << std::endl << std::endl;
+     return_flag = 1;
+  }
+
+  return return_flag;
+}
+
+
 template <typename Scalar>
 int tester(const std::string& input_name)
 {
@@ -136,8 +160,6 @@ int tester(const std::string& input_name)
 
   int return_flag = 0;
 
-  const Scalar tol = std::numeric_limits<Scalar>::epsilon() * 500;
-  
   // Regression values for omega_dot
   std::vector<Scalar> omega_dot_reg(n_species);
   omega_dot_reg[0] =  9.1623705357123753e+04;
@@ -146,40 +168,13 @@ int tester(const std::string& input_name)
   omega_dot_reg[3] =  1.9782018625609628e+05;
   omega_dot_reg[4] =  2.5656853231019735e+05;
     
-  for( unsigned int s = 0; s < n_species; s++)
-    {
-      const Scalar rel_error = abs( (omega_dot[s] - omega_dot_reg[s])/omega_dot_reg[s]);
-      if( rel_error > tol )
-        {
-          return_flag = 1;
-        }
-    }
- 
-  for( unsigned int s = 0; s < n_species; s++)
-    {
-      const Scalar rel_error = abs( (omega_dot_2[s] - omega_dot_reg[s])/omega_dot_reg[s]);
-      if( rel_error > tol )
-        {
-          return_flag = 1;
-        }
-    }
 
+// omega_dots tests
   for( unsigned int s = 0; s < n_species; s++)
     {
-      const Scalar rel_error = abs( (omega_dot_3[s] - omega_dot_reg[s])/omega_dot_reg[s]);
-      if( rel_error > tol )
-        {
-          return_flag = 1;
-        }
-    }
- 
-  for( unsigned int s = 0; s < n_species; s++)
-    {
-      const Scalar rel_error = abs( (omega_dot_4[s] - omega_dot_reg[s])/omega_dot_reg[s]);
-      if( rel_error > tol )
-        {
-          return_flag = 1;
-        }
+      return_flag = checker(omega_dot_reg[s],omega_dot_2[s],"omega dot2 of species " + chem_mixture.chemical_species()[s]->species()) || return_flag;
+      return_flag = checker(omega_dot_reg[s],omega_dot_3[s],"omega dot3 of species " + chem_mixture.chemical_species()[s]->species()) || return_flag;
+      return_flag = checker(omega_dot_reg[s],omega_dot_4[s],"omega dot4 of species " + chem_mixture.chemical_species()[s]->species()) || return_flag;
     }
 
   // Regression values for domega_dot_dT
@@ -192,20 +187,8 @@ int tester(const std::string& input_name)
 
   for( unsigned int s = 0; s < n_species; s++)
     {
-      const Scalar rel_error = abs( (domega_dot_dT[s] - domega_dot_reg_dT[s])/domega_dot_reg_dT[s]);
-      if( rel_error > tol )
-        {
-          return_flag = 1;
-        }
-    }
-
-  for( unsigned int s = 0; s < n_species; s++)
-    {
-      const Scalar rel_error = abs( (domega_dot_dT_2[s] - domega_dot_reg_dT[s])/domega_dot_reg_dT[s]);
-      if( rel_error > tol )
-        {
-          return_flag = 1;
-        }
+      return_flag = checker(domega_dot_reg_dT[s],domega_dot_dT[s],"domega_dot_dT of species "   + chem_mixture.chemical_species()[s]->species()) || return_flag;
+      return_flag = checker(domega_dot_reg_dT[s],domega_dot_dT_2[s],"domega_dot_dT2 of species "  + chem_mixture.chemical_species()[s]->species()) || return_flag;
     }
 
   // Regression values for domega_dot_drho_s
@@ -249,62 +232,43 @@ int tester(const std::string& input_name)
     {
       for( unsigned int t = 0; t < n_species; t++)
         {
-          const Scalar rel_error = abs( (domega_dot_drho_s[s][t] - domega_dot_reg_drhos[s][t])/domega_dot_reg_drhos[s][t]);
-          if( rel_error > tol )
-            {
-              return_flag = 1;
-            }
+          return_flag = checker(domega_dot_reg_drhos[s][t],domega_dot_drho_s[s][t]  , "domega_dot_drhos of species "
+                                                                                      + chem_mixture.chemical_species()[s]->species()
+                                                                                      + " with respect to species "
+                                                                                      + chem_mixture.chemical_species()[t]->species()) || return_flag;
+          return_flag = checker(domega_dot_reg_drhos[s][t],domega_dot_drho_s_2[s][t], "domega_dot_drhos of species "
+                                                                                      + chem_mixture.chemical_species()[s]->species()
+                                                                                      + " with respect to species "
+                                                                                      + chem_mixture.chemical_species()[t]->species()) || return_flag;
         }
     }
+
+// now some resetting and verifying omega_dot
+  std::string reaction_id("0001");
+  std::vector<std::string> keywords;
+  keywords.push_back("A");
+  Scalar new_value(6e15L); //SI, original is 7e15
+  reaction_set.set_parameter_of_reaction(reaction_id,keywords,new_value);
+  reaction_id = "0002";
+  keywords[0] = "efficiencies";
+  keywords.push_back("O2");
+  new_value = 1.2L;
+  reaction_set.set_parameter_of_reaction(reaction_id,keywords,new_value);
+ 
+//recomputing
+  Antioch::set_zero(omega_dot);
+  kinetics.compute_mass_sources( conditions , molar_densities, h_RT_minus_s_R, omega_dot);
+
+// new values, SI
+  omega_dot_reg[0] =  8.9806036413183845e4;
+  omega_dot_reg[1] = -3.3456693672788515e5;
+  omega_dot_reg[2] = -2.0957449817675504e5;
+  omega_dot_reg[3] =  1.9776686618125900e5;
+  omega_dot_reg[4] =  2.5656853231019735e5;
 
   for( unsigned int s = 0; s < n_species; s++)
     {
-      for( unsigned int t = 0; t < n_species; t++)
-        {
-          const Scalar rel_error = abs( (domega_dot_drho_s_2[s][t] - domega_dot_reg_drhos[s][t])/domega_dot_reg_drhos[s][t]);
-          if( rel_error > tol )
-            {
-              return_flag = 1;
-            }
-        }
-    }
-
-  // Print out pretty message if there was a problem.
-  if( return_flag == 1 )
-    {
-      std::cerr << "Error: Mismatch between compute mass source terms and regression values." << std::endl;
-      for( unsigned int s = 0; s < n_species; s++)
-	{
-	  std::cout << std::scientific << std::setprecision(16)
-		    << "omega_dot(" << chem_mixture.chemical_species()[s]->species() << ") = " << omega_dot[s]
-		    << ", omega_dot_reg(" << chem_mixture.chemical_species()[s]->species() << ") = "
-                    << omega_dot_reg[s] << std::endl << std::endl;
-	}
-      
-      for( unsigned int s = 0; s < n_species; s++)
-	{
-	  std::cout << std::scientific << std::setprecision(16)
-		    << "domega_dot_dT(" << chem_mixture.chemical_species()[s]->species() << ") = " << domega_dot_dT[s]
-		    << ", domega_dot_reg_dT(" << chem_mixture.chemical_species()[s]->species() << ") = "
-                    << domega_dot_reg_dT[s] << std::endl << std::endl;
-	}
-
-      for( unsigned int s = 0; s < n_species; s++)
-	{
-          for( unsigned int t = 0; t < n_species; t++)
-            {
-              std::cout << std::scientific << std::setprecision(16)
-                        << "domega_dot_drho_s(" 
-                        << chem_mixture.chemical_species()[s]->species() 
-                        << ", " << chem_mixture.chemical_species()[t]->species()
-                        << ") = " << domega_dot_drho_s[s][t]
-                        << ", domega_dot_reg_drho_s("
-                        << chem_mixture.chemical_species()[s]->species()
-                        << ", " << chem_mixture.chemical_species()[t]->species()
-                        << ") = " << domega_dot_reg_drhos[s][t] << std::endl << std::endl;
-            }
-	}
-
+      return_flag = checker(omega_dot_reg[s],omega_dot[s] ,"resetted omega dot of species "  + chem_mixture.chemical_species()[s]->species()) || return_flag;
     }
  
   return return_flag;
@@ -321,7 +285,7 @@ int main(int argc, char* argv[])
     }
 
   return (tester<float>(std::string(argv[1])) ||
-          tester<double>(std::string(argv[1])) /*||
-          tester<long double>(std::string(argv[1])) || */
+          tester<double>(std::string(argv[1])) /* ||
+          tester<long double>(std::string(argv[1]))*/
           );
 }

--- a/test/kinetics_settings_unit.C
+++ b/test/kinetics_settings_unit.C
@@ -141,10 +141,10 @@ int tester()
 
   Scalar Cf_reset = 1e-7L;
   Scalar eta_reset = 1.5L;
-  Scalar Ea_reset = 36000.L;
-  Scalar D_reset = -5.e-2L;
+  Scalar Ea_reset = 36000;
+  Scalar D_reset = -5e-2L;
   Scalar Tref_reset = 298;
-  Scalar R_reset = Antioch::Constants::R_universal<Scalar>() * Antioch::Units<Scalar>("cal").get_SI_factor();
+  Scalar R_reset = Antioch::Constants::R_universal<Scalar>() / Antioch::Units<Scalar>("cal").get_SI_factor();
 
 /// building only here
 
@@ -187,7 +187,7 @@ int tester()
   
   return_flag = test_values(Cf,zero,Ea,zero,Tref,R,*kin_base) || return_flag;
 
-  Antioch::reset_parameter_of_rate(*kin_base,Antioch::KineticsModel::E,Ea_reset);
+  Antioch::reset_parameter_of_rate(*kin_base,Antioch::KineticsModel::E,Ea_reset,"K");
 
   return_flag = test_values(Cf,zero,Ea_reset,zero,Tref,R,*kin_base) || return_flag;
 
@@ -241,7 +241,7 @@ int tester()
 
   Antioch::reset_parameter_of_rate(*kin_base,Antioch::KineticsModel::R_SCALE,R_reset);
 
-  Antioch::reset_parameter_of_rate(*kin_base,Antioch::KineticsModel::E,Ea_reset);
+  Antioch::reset_parameter_of_rate(*kin_base,Antioch::KineticsModel::E,Ea_reset,"cal/mol");
 
   return_flag = test_values(Cf,eta,Ea_reset,zero,Tref,R_reset,*kin_base) || return_flag;
 
@@ -269,7 +269,7 @@ int tester()
   return_flag = test_values(Cf_reset,eta,Ea,D_reset,Tref_reset,R,*kin_base) || return_flag;
 
 //// reset the whole kinetics
-
+  Ea_reset = -50000; // sensitive here...
   coeffs[0] = Cf_reset;
   coeffs[1] = eta_reset;
   coeffs[2] = Ea_reset;

--- a/test/photochemical_rate_unit.C
+++ b/test/photochemical_rate_unit.C
@@ -124,10 +124,8 @@ int tester(std::string path_to_files)
   int return_flag = check_rate(rate_exact,rate);
 
  // multiplying by 2 the cross-section
-  for(unsigned int l = 0; l < CH4_cs.size(); l++)
-  {
-     CH4_cs[l] *= 2;
-  }
+  int il = CH4_cs.size() * 2 / 3; 
+  CH4_cs[il] *= 2;
 
   bin.y_on_custom_grid(CH4_lambda,CH4_cs,hv_lambda,sigma_rescaled);
 
@@ -136,16 +134,14 @@ int tester(std::string path_to_files)
   {
       rate_exact += sigma_rescaled[il] * hv_irr[il] * (hv_lambda[il+1] - hv_lambda[il]);
   }
-  rate_hv.set_parameter(Antioch::KineticsModel::Parameters::SIGMA,CH4_cs);
+  rate_hv.set_parameter(Antioch::KineticsModel::Parameters::SIGMA, il, CH4_cs[il]);
   rate = rate_hv.rate(part_flux);
 
   return_flag = check_rate(rate_exact,rate) || return_flag;
 
- // multiplying by 2 the cross-section again
-  for(unsigned int l = 0; l < CH4_cs.size(); l++)
-  {
-     CH4_cs[l] *= 2;
-  }
+ // multiplying by 2 one value of the cross-section
+  il = CH4_cs.size()/2;
+  CH4_cs[il] *= 2;
 
   bin.y_on_custom_grid(CH4_lambda,CH4_cs,hv_lambda,sigma_rescaled);
 
@@ -156,7 +152,7 @@ int tester(std::string path_to_files)
   }
 
 // the other way to reset
-  Antioch::reset_parameter_of_rate(rate_hv,Antioch::KineticsModel::Parameters::SIGMA,CH4_cs);
+  Antioch::reset_parameter_of_rate(rate_hv,Antioch::KineticsModel::Parameters::SIGMA, CH4_cs[il] , il, "SI");
   rate = rate_hv.rate(part_flux);
 
   return_flag = check_rate(rate_exact,rate) || return_flag;


### PR DESCRIPTION
It'a work still in progress, but as feedback is really wanted, the whole thing will come to life before your eyes.  There's no [DO NOT MERGE] tag so here's a nice question one just to show there's more to it than meets the eye.

So the idea here is to be able to specify in an input file parameters we want to be perturbed, therefore reset.  Human-friendliness requires to have a string-to-parameter map, here's how it goes.

Below the kinetics part, the transport part should be easy to do already, but it's worth to go through it after the kinetics done, so we are comprehensive (same comment for thermo).

### context

A reaction has two levels, the chemical process and the kinetics model.  The XML parser already has string keywords for the parameters, ChemKin format is hard-coded so there's very little need of keywords (and no keyword for the parameters we're interested in), and ASCII can't parse the kinetics.  So XML keywords we go! They will be in italics for easy of read.
An example of every type of reaction can be found in the ```test/input_files/test_parsing.xml``` file.

A kinetics model contains a subset of the parameters *A, b, E, D, lambda, cross_section*. Now depending on the chemical process, we have different requirements as of how do we recognize them:
  - Elementary process: nothing special.
  - Duplicate process: in this we have k = sum_i ki(Ai, bi, Ei,...), so we need to know which one we're talking about.
  - Three-body: we need the *efficiencies* per species.
  - Falloff (whatever): it requires to know if we are in the low-pressure rate (*k0*) or the high-pressure rate (kinf - it's not a typo, there's no keyword).  I propose **0** and **inf**.
  - TroeFalloff: we need the parameters *alpha, T1, T2, T3*.
  - Three-body falloff: I don't want to talk about this...

### input file
So here's how the input file would show up, the reactions are taken from the ```test/input_files/test_parsing.xml``` file (we talked about this with Roy, but I still want to be sure you saw, read, agreed to it, please comment):
```
Antioch/0008/A/0
Antioch/0008/b/2

Antioch/0014/efficiencies/CH4

Antioch/0022/D/inf

Antioch/0032/E/0
Antioch/0032/alpha
```

So the reaction ```0008``` is a duplicate, the indexes range from 0 to 2.  We're asking here to modify the pre-exponential parameter of the first and the power parameter of the last, they're indexed in the order they come.  We should probably add the capability to explicitely give the order in the input.

Reaction ```0014``` is a three body, we're changing the efficiency of CH4 from the default of 1 to whatever.

Reaction ```0022``` is a Lindemann falloff, we're changing the Berthelot parameter of the high-pressure rate.

Reaction ```0032``` is a Troe falloff, we're changing the activation energy of the low pressure rate and the alpha parameter of the Troe model.

### the code

So the first step is to add an id to the reaction.  We already have those ids, the parsers provide them for warning messages purpose, so the first commit just change the ```Reaction``` object to store it and adds the setting line while parsing.

Next step will be to implement at the ```ReactionSet``` level the capacility to pinpoint a specific parameter and change its value.  A method of the taste:
```
void set_parameter_of_reaction(const std::string & reaction_id, const std::vector<std::string> & parameter_keywords, CoeffType new_value);
```
Fondamentally, this method would use a capability similar to the one described in PR #84, with the difference that you reset only one parameter and not the whole thing:
```
// find reaction_id, index r
... loop on reactions, test reaction_id == reaction(r).id() ...

... find the wanted parameter defined by the different keywords...

// either 
//   kinetics parameter this of rate number that
// or 
//   parameter this of chemical process
if(change_kinetics_model) // kinetics parameter
{
  reset_parameter_of_rate(reaction(r).forward_rate(that),this,new_values);
}else // chemical process parameter
{
  reset_parameter_of_chemical_process(this, new_value);
}
```

So we need to write the ```reset_parameter_of...``` methods and the details of the finding with appropriate checks.
The ```reset_parameter_of...``` methods are to be in the ```src/kinetics/.../kinetics_parsing.h``` and ```src/kinetics/.../reaction_parsing.h``` files.

Comments welcome.