### PR TITLE
Clear unused variable warnings from chemkin parser

### DIFF
--- a/src/parsing/include/antioch/chemkin_parser.h
+++ b/src/parsing/include/antioch/chemkin_parser.h
@@ -115,15 +115,15 @@ namespace Antioch{
                 {this->read_thermodynamic_data_root(thermo);}
 
         //! reads the thermo, NASA generalist, no templates for virtual
-        void read_thermodynamic_data(NASAThermoMixture<NumericType, NASA9CurveFit<NumericType> >& thermo)
+        void read_thermodynamic_data(NASAThermoMixture<NumericType, NASA9CurveFit<NumericType> >& /*thermo*/)
                 {antioch_not_implemented_msg(ParserBase<NumericType>::_not_implemented);}
 
         //! reads the thermo, NASA generalist, no templates for virtual
-        void read_thermodynamic_data(NASAThermoMixture<NumericType, CEACurveFit<NumericType> >& thermo)  
+        void read_thermodynamic_data(NASAThermoMixture<NumericType, CEACurveFit<NumericType> >& /*thermo*/)
                 {antioch_not_implemented_msg(ParserBase<NumericType>::_not_implemented);}
 
-        //! reads the thermo, CEA deprecated 
-        void read_thermodynamic_data(CEAThermodynamics<NumericType >& thermo)  
+        //! reads the thermo, CEA deprecated
+        void read_thermodynamic_data(CEAThermodynamics<NumericType >& /*thermo*/)
                 {antioch_not_implemented_msg(ParserBase<NumericType>::_not_implemented);}
 
 ///////////////// kinetics


### PR DESCRIPTION
This clears the last compiler warnings when compiling GRINS with Antioch.