### PR TITLE
bugfix + printing more verbose

### DIFF
--- a/src/diffusion/include/antioch/molecular_binary_diffusion.h
+++ b/src/diffusion/include/antioch/molecular_binary_diffusion.h
@@ -320,7 +320,8 @@ namespace Antioch{
          << "  reduced dipole moment = " << _reduced_dipole_moment << "\n"
          << "  xi = "                    << _xi                    << "\n"
          << "  reduced LJ diameter = "   << _reduced_LJ_diameter   << "\n"
-         << "  reduced LJ depth = "      << _reduced_LJ_depth 
+         << "  reduced LJ depth = "      << _reduced_LJ_depth      << "\n"
+         << "  [coefficient = "          << _coefficient           << "]"
          << std::endl;
   }
 

--- a/src/diffusion/include/antioch/molecular_binary_diffusion.h
+++ b/src/diffusion/include/antioch/molecular_binary_diffusion.h
@@ -46,6 +46,26 @@
 
 namespace Antioch{
 
+  /*! \class MolecularBinaryDiffusion
+   *
+   * An important remark about precision:
+   * the diffusion is computed as \f$c * s(T)\f$ with \f$c\f$ a coefficient
+   * and \f$s(T)\f$ the Stockmayer potential spline. The expression of \f$c\f$
+   * is
+   * \f[
+   *     c = \frac{3}{16} \sqrt{\frac{2 \mathrm{k_B}}{m \mathcal{N}_\mathrm{A}\pi}} \frac{1}{\sigma^2}
+   * \f]
+   *  which roughly scales as
+   * \f[
+   *    10^{-4}  = 10^{-1} \sqrt{\frac{10^{-23}}{10^{23}}} \frac{1}{10^{-20}}
+   * \f]
+   * The main issue lies in the square root, the float precision evaluate
+   * \f$\sqrt{10^{-46}}\f$ to be zero. Therefore some adaptation has been
+   * made by multiplying the factor in the square root by \f$10^{50}\f$,
+   * \f$\mathrm{k_B}\f$ by \f$10^{25}\f$ and \f$\mathcal{N}_\mathrm{A}\f$ by
+   * \f$10^{-25}\f$, and
+   * multiplying afterwards by \f$10^{-25}\f$.
+   */
   template <typename CoeffType, typename Interpolator = GSLSpliner>
   class MolecularBinaryDiffusion
   {

--- a/src/thermal_conduction/include/antioch/kinetics_theory_thermal_conductivity_utils.h
+++ b/src/thermal_conduction/include/antioch/kinetics_theory_thermal_conductivity_utils.h
@@ -60,8 +60,8 @@ namespace Antioch
                         t(th),Z_298K(Z_298K_),LJ_depth(LJ_depth_){}
 
      const ThermoEvaluator & t;
-     const CoeffType       & Z_298K;
-     const CoeffType       & LJ_depth;
+     const CoeffType        Z_298K;
+     const CoeffType        LJ_depth;
   };
 
    // custom add

--- a/src/viscosity/include/antioch/kinetics_theory_viscosity.h
+++ b/src/viscosity/include/antioch/kinetics_theory_viscosity.h
@@ -255,7 +255,9 @@ namespace Antioch
      _delta_star = CoeffType(1e-7L) * ant_pow(Constants::light_celerity<CoeffType>(),2) * // * 1/(4*pi * eps_0) = 10^-7 * c^2
                     ant_pow(_dipole_moment * Units<CoeffType>("D").get_SI_factor(),2) /             
                      ( _LJ.depth() * Constants::Boltzmann_constant<CoeffType>() * 2 * ant_pow(_LJ.diameter() * Units<CoeffType>("ang").get_SI_factor(),3) );
-     _a = CoeffType(0.3125L) * ant_sqrt(Constants::Boltzmann_constant<CoeffType>() * _mass / Constants::pi<CoeffType>())
+           /* 5 / 16 * sqrt(pi * Boltzmann constant/pi) / (sigma^2) 
+                ~ 10^-14 float can't take 10^-28 in sqrt*/
+     _a = CoeffType(0.3125e-14L) * ant_sqrt(CoeffType(1e28) * Constants::Boltzmann_constant<CoeffType>() * _mass / Constants::pi<CoeffType>())
                 / (ant_pow(_LJ.diameter() * Units<CoeffType>("ang").get_SI_factor(),2));
           
 
@@ -291,7 +293,8 @@ namespace Antioch
      os << "Pure species viscosity:\n"
         << "5/16 * sqrt(pi * " << _mass << " * kb * T) / ( pi * " << _LJ.depth() << "^2 * <Omega(2,2)*> )\n"
         << "T* = T / " << _LJ.depth() << "\n"
-        << "delta* = 1/2 * " << _dipole_moment << "^2 / ( " << _LJ.depth() << " * kb * " << _LJ.diameter() << "^3 )";
+        << "delta* = 1/2 * " << _dipole_moment << "^2 / ( " << _LJ.depth() << " * kb * " << _LJ.diameter() << "^3 )\n"
+        << "[factor a = " << _a << "]";
   }
 
   template <typename CoeffType, typename Interpolator>

--- a/src/viscosity/include/antioch/kinetics_theory_viscosity.h
+++ b/src/viscosity/include/antioch/kinetics_theory_viscosity.h
@@ -69,6 +69,22 @@ namespace Antioch
    *              \f]
    * with \f$\epsilon\f$ the Lennard-Jones potential well depth and \f$\alpha\f$ the
    * dipole moment.
+   *
+   * An important remark about precision:
+   * the viscosity is computed as \f$c * s(T)\f$ with \f$c\f$ a coefficient
+   * and \f$s(T)\f$ the Stockmayer potential spline. The expression of \f$c\f$
+   * is
+   * \f[
+   *     c = \frac{5}{16} \sqrt{\frac{\mathrm{k_B} m}{\pi}} \frac{1}{\sigma^2}
+   * \f]
+   *  which roughly scales as
+   * \f[
+   *    10^{-6}  = 10^{-1} \sqrt{\frac{10^{-23} 10^{-27}}{1}} \frac{1}{10^{-20}}
+   * \f]
+   * The main issue lies in the square root, the float precision evaluate
+   * \f$\sqrt{10^{-50}}\f$ to be zero. Therefore some adaptation has been
+   * made by multiplying the factor in the square root by \f$10^{28}\f$ and
+   * multiplying afterwards by \f$10^{-14}\f$.
    */
   template<typename CoeffType = double, typename Interpolator = GSLSpliner>
   class KineticsTheoryViscosity

--- a/test/wilke_transport_unit.C
+++ b/test/wilke_transport_unit.C
@@ -275,14 +275,15 @@ int tester()
    and the reduced temperature falls also on a node (less easy).
    Then we will have a theoretical independant value.
 */
-  const Scalar mu_long_double   = 1.42263765441134073137e-06L;
-  const Scalar k_long_double    = 1.49857974915476905594e-01L;
+  const Scalar mu_long_double   = 4.49877527305932602332e-05L;
+  const Scalar k_long_double    = 8.22050332419571328635e-02L;
+
   std::vector<Scalar> D_long_double(5,0);
-  D_long_double[0] = 6.17968346993552034664e-03L;
-  D_long_double[1] = 6.08349222628094511511e-03L;
-  D_long_double[2] = 9.42378174449347986520e-03L;
-  D_long_double[3] = 9.74548942086199659631e-03L;
-  D_long_double[4] = 6.02441229367125800371e-03L;
+  D_long_double[0] = 1.95418749838889089562e-04L;
+  D_long_double[1] = 1.92376915629762328034e-04L;
+  D_long_double[2] = 2.98006144849143296987e-04L;
+  D_long_double[3] = 3.08179434829991685679e-04L;
+  D_long_double[4] = 1.90508644119203653519e-04L;
   Scalar mu_kt, k_kt;
   std::vector<Scalar> D_kt(5,0);
   wilke_ps_evaluator.mu_and_k_and_D( T, rho, mass_fractions, mu_kt, k_kt, D_kt );
@@ -291,7 +292,7 @@ int tester()
   return_flag = test_val( mu_kt, mu_long_double, tol, "kinetics theory viscosity") || return_flag;
   return_flag = test_val( k_kt, k_long_double, tol, "kinetics theory thermal conduction") || return_flag;
   for(unsigned int s = 0; s < D_kt.size(); s++)
-    return_flag = test_val( D_kt[s], D_long_double[s], tol, "kinetics theory diffusion for a species") || return_flag;
+    return_flag = test_val( D_kt[s], D_long_double[s], tol, "kinetics theory diffusion for species " + species_str_list[s]) || return_flag;
 
 #endif
 


### PR DESCRIPTION
  - in the reset, the float workaround was missing for the
        viscosity, thus the value of the coefficient in front
        of the spline was zero
  - the printing method prints this coefficient for both diffusion
        and viscosity

So this fixes the nan the Wilke evaluator was sending back.  That was the case only for float.

I PR it to the 0.3.0 release as it still qualifies as a bug.