### PR TITLE
Upgrade/sensitivity

### DIFF
--- a/src/core/include/antioch/kinetics_conditions.h
+++ b/src/core/include/antioch/kinetics_conditions.h
@@ -143,6 +143,13 @@ namespace Antioch{
      return _temperature;
   }
 
+ // partial specialization for the return_type
+  template <typename StateType, typename VectorStateType>
+  struct return_type<KineticsConditions<StateType,VectorStateType> >
+  {
+     typedef StateType type;
+  };
+
 } //end namespace Antioch
 
 #endif

--- a/src/kinetics/include/antioch/arrhenius_rate.h
+++ b/src/kinetics/include/antioch/arrhenius_rate.h
@@ -115,22 +115,65 @@ namespace Antioch
     CoeffType rscale() const;
 
     //! \return the rate evaluated at \p T.
-    template <typename StateType>
-    ANTIOCH_AUTO(StateType) 
-    rate(const StateType& T) const
-    ANTIOCH_AUTOFUNC(StateType, _Cf* (ant_exp(-_Ea/T)))
+    template <typename InputType>
+    ANTIOCH_AUTO(typename return_type<InputType>::type) 
+    operator()(const InputType& T) const
+    ANTIOCH_AUTOFUNC(typename return_type<InputType>::type, this->rate(T))
+
+    //! \return the derivative with respect to the parameter evaluated at \p T.
+    template <typename InputType>
+    ANTIOCH_AUTO(typename return_type<InputType>::type) 
+    sensitivity( const InputType& T, KineticsModel::Parameters par ) const;
+
+//
 
     //! \return the rate evaluated at \p T.
     template <typename StateType>
     ANTIOCH_AUTO(StateType) 
-    operator()(const StateType& T) const
-    ANTIOCH_AUTOFUNC(StateType, this->rate(T))
+    rate(const StateType& T) const
+    ANTIOCH_AUTOFUNC(StateType, _Cf* (ant_exp(-_Ea/T)))
 
     //! \return the derivative with respect to temperature evaluated at \p T.
     template <typename StateType>
     ANTIOCH_AUTO(StateType) 
     derivative( const StateType& T ) const
     ANTIOCH_AUTOFUNC(StateType, (*this)(T)*(_Ea/(T*T)))
+
+    //! \return the derivative with respect to the parameter A evaluated at \p T.
+    template <typename StateType>
+    ANTIOCH_AUTO(StateType) 
+    sensitivity_A( const StateType& T) const
+    ANTIOCH_AUTOFUNC(StateType, ant_exp(-_Ea / T))
+
+    //! \return the derivative with respect to the parameter beta evaluated at \p T.
+    template <typename StateType>
+    ANTIOCH_AUTO(StateType) 
+    sensitivity_Ea( const StateType& T) const
+    ANTIOCH_AUTOFUNC(StateType, - this->rate(T) /(_rscale * T) )
+
+    //! \return the derivative with respect to the parameter rscale evaluated at \p T.
+    template <typename StateType>
+    ANTIOCH_AUTO(StateType) 
+    sensitivity_Rscale( const StateType& T) const
+    ANTIOCH_AUTOFUNC(StateType, - this->rate(T) * _Ea /(_rscale * T) ) // Ea = _raw_Ea / rscale
+
+    //! \return the derivative with respect to the parameter A evaluated at \p T.
+    template <typename StateType, typename VectorStateType>
+    ANTIOCH_AUTO(StateType) 
+    sensitivity_A( const KineticsConditions<StateType, VectorStateType> & cond) const
+    ANTIOCH_AUTOFUNC(StateType, ant_exp(-_Ea / cond.T()))
+
+    //! \return the derivative with respect to the parameter beta evaluated at \p T.
+    template <typename StateType, typename VectorStateType>
+    ANTIOCH_AUTO(StateType) 
+    sensitivity_Ea( const KineticsConditions<StateType, VectorStateType>& cond) const
+    ANTIOCH_AUTOFUNC(StateType, - this->rate(cond.T()) /(_rscale * cond.T()) )
+
+    //! \return the derivative with respect to the parameter rscale evaluated at \p T.
+    template <typename StateType, typename VectorStateType>
+    ANTIOCH_AUTO(StateType) 
+    sensitivity_Rscale( const KineticsConditions<StateType, VectorStateType> & cond) const
+    ANTIOCH_AUTOFUNC(StateType, - this->rate(cond.T()) * _Ea /(_rscale * cond.T()) ) // Ea = _raw_Ea / rscale
 
     //! Simultaneously evaluate the rate and its derivative at \p T.
     template <typename StateType>
@@ -305,6 +348,39 @@ namespace Antioch
     rate     = (*this)(T);
     drate_dT = rate*_Ea/(T*T);
     return;
+  }
+
+  template<typename CoeffType>
+  template <typename InputType>
+  inline
+  ANTIOCH_AUTO(typename return_type<InputType>::type) 
+  ArrheniusRate<CoeffType>::sensitivity( const InputType& T, KineticsModel::Parameters par ) const
+  {
+     switch(par)
+     {
+        case KineticsModel::Parameters::A:
+        {
+           return this->sensitivity_A(T);
+        }
+          break;
+        case KineticsModel::Parameters::E:
+        {
+           return this->sensitivity_Ea(T);
+        }
+          break;
+        case KineticsModel::Parameters::R_SCALE:
+        {
+           return this->sensitivity_Rscale(T);
+        }
+          break;
+        default:
+        {
+          antioch_error();
+        }
+          break;
+     }
+
+    return 0;
   }
 
 } // end namespace Antioch

--- a/src/kinetics/include/antioch/berthelot_rate.h
+++ b/src/kinetics/include/antioch/berthelot_rate.h
@@ -93,16 +93,22 @@ namespace Antioch
     CoeffType D() const;
 
     //! \return the rate evaluated at \p T.
+    template <typename InputType>
+    ANTIOCH_AUTO(typename return_type<InputType>::type) 
+    operator()(const InputType& T) const
+    ANTIOCH_AUTOFUNC(typename return_type<InputType>::type, this->rate(T))
+
+    //! \return the derivative with respect to the parameter evaluated at \p T.
+    template <typename InputType>
+    ANTIOCH_AUTO(typename return_type<InputType>::type) 
+    sensitivity( const InputType& T, KineticsModel::Parameters par ) const;
+
+//
+    //! \return the rate evaluated at \p T.
     template <typename StateType>
     ANTIOCH_AUTO(StateType) 
     rate(const StateType& T) const
     ANTIOCH_AUTOFUNC(StateType, _Cf* (ant_exp(_D*T)))
-
-    //! \return the rate evaluated at \p T.
-    template <typename StateType>
-    ANTIOCH_AUTO(StateType) 
-    operator()(const StateType& T) const
-    ANTIOCH_AUTOFUNC(StateType, this->rate(T))
 
     //! \return the derivative with respect to temperature evaluated at \p T.
     template <typename StateType>
@@ -110,9 +116,33 @@ namespace Antioch
     derivative( const StateType& T ) const
     ANTIOCH_AUTOFUNC(StateType, (*this)(T)*_D)
 
+    //! \return the derivative with respect to the parameter A evaluated at \p T.
+    template <typename StateType>
+    ANTIOCH_AUTO(StateType) 
+    sensitivity_A( const StateType& T) const
+    ANTIOCH_AUTOFUNC(StateType, ant_exp(_D * T))
+
+    //! \return the derivative with respect to the parameter beta evaluated at \p T.
+    template <typename StateType>
+    ANTIOCH_AUTO(StateType) 
+    sensitivity_D( const StateType& T) const
+    ANTIOCH_AUTOFUNC(StateType, this->rate(T) * T)
+
     //! Simultaneously evaluate the rate and its derivative at \p T.
     template <typename StateType>
     void rate_and_derivative(const StateType& T, StateType& rate, StateType& drate_dT) const;
+
+    //! \return the derivative with respect to the parameter A evaluated at \p T.
+    template <typename StateType, typename VectorStateType>
+    ANTIOCH_AUTO(StateType) 
+    sensitivity_A( const KineticsConditions<StateType,VectorStateType> & cond) const
+    ANTIOCH_AUTOFUNC(StateType, ant_exp(_D * cond.T()))
+
+    //! \return the derivative with respect to the parameter beta evaluated at \p T.
+    template <typename StateType, typename VectorStateType>
+    ANTIOCH_AUTO(StateType) 
+    sensitivity_D( const KineticsConditions<StateType,VectorStateType> & cond) const
+    ANTIOCH_AUTOFUNC(StateType, this->rate(cond.T()) * cond.T())
 
     //! print equation
     const std::string numeric() const;
@@ -247,6 +277,34 @@ namespace Antioch
     rate     = (*this)(T);
     drate_dT = rate*_D;
     return;
+  }
+
+  template<typename CoeffType>
+  template <typename InputType>
+  inline
+  ANTIOCH_AUTO(typename return_type<InputType>::type) 
+  BerthelotRate<CoeffType>::sensitivity( const InputType& T, KineticsModel::Parameters par ) const
+  {
+     switch(par)
+     {
+        case KineticsModel::Parameters::A:
+        {
+           return this->sensitivity_A(T);
+        }
+          break;
+        case KineticsModel::Parameters::D:
+        {
+           return this->sensitivity_D(T);
+        }
+          break;
+        default:
+        {
+           antioch_error();
+        }
+          break;
+     }
+
+    return 0;
   }
 
 } // end namespace Antioch

--- a/src/kinetics/include/antioch/constant_rate.h
+++ b/src/kinetics/include/antioch/constant_rate.h
@@ -48,7 +48,10 @@ namespace Antioch
    * \f[
    *  \frac{\partial \alpha(T)}{\partial T} = 0
    * \f]
-   * 
+   * and
+   * \f[
+   *  \frac{\partial \alpha(T)}{\partial A} = 1
+   * \f]
    */
   template<typename CoeffType=double>
   class ConstantRate : public KineticsType<CoeffType>
@@ -86,23 +89,44 @@ namespace Antioch
     template <typename VectorCoeffType>
     void set_parameter(KineticsModel::Parameters parameter, VectorCoeffType new_value){antioch_error();}
 
+// fork functions
+    //! \return the rate evaluated at \p T.
+    template <typename InputType>
+    ANTIOCH_AUTO(typename return_type<InputType>::type) 
+    operator()(const InputType& T) const
+    ANTIOCH_AUTOFUNC(typename return_type<InputType>::type, this->rate(T))
+
+    //! \return the derivative with respect to the parameter evaluated at \p T.
+    template <typename InputType>
+    ANTIOCH_AUTO(typename return_type<InputType>::type) 
+    sensitivity( const InputType& T, KineticsModel::Parameters par ) const;
+
+
     //! \return the rate evaluated at \p T.
     template <typename StateType>
     ANTIOCH_AUTO(StateType) 
     rate(const StateType& T) const
     ANTIOCH_AUTOFUNC(StateType, constant_clone(T,_Cf))
 
-    //! \return the rate evaluated at \p T.
-    template <typename StateType>
-    ANTIOCH_AUTO(StateType) 
-    operator()(const StateType& T) const
-    ANTIOCH_AUTOFUNC(StateType, this->rate(T))
-
     //! \return the derivative with respect to temperature evaluated at \p T.
     template <typename StateType>
     ANTIOCH_AUTO(StateType) 
     derivative( const StateType& T ) const
     ANTIOCH_AUTOFUNC(StateType, zero_clone(T))
+
+    //! \return the derivative with respect to the parameter A evaluated at \p T.
+    template <typename StateType>
+    ANTIOCH_AUTO(StateType) 
+    sensitivity_A( const StateType& T ) const
+    ANTIOCH_AUTOFUNC(StateType, constant_clone(T,1))
+
+    //! \return the derivative with respect to the parameter A evaluated at \p T.
+    template <typename StateType, typename VectorStateType>
+    ANTIOCH_AUTO(StateType) 
+    sensitivity_A( const KineticsConditions<StateType,VectorStateType> & cond ) const
+    ANTIOCH_AUTOFUNC(StateType, constant_clone(cond.T(),1))
+
+
 
     //! Simultaneously evaluate the rate and its derivative at \p T.
     template <typename StateType>
@@ -191,6 +215,29 @@ namespace Antioch
     Antioch::constant_fill(rate, _Cf);
     Antioch::set_zero(drate_dT);
     return;
+  }
+
+  template<typename CoeffType>
+  template <typename InputType>
+  inline
+  ANTIOCH_AUTO(typename return_type<InputType>::type) 
+  ConstantRate<CoeffType>::sensitivity( const InputType& T, KineticsModel::Parameters par ) const
+  {
+     switch(par)
+     {
+        case KineticsModel::Parameters::A:
+        {
+           return this->sensitivity_A(T);
+        }
+          break;
+        default:
+        {
+          antioch_error();
+        }
+          break;
+     }
+
+    return 0;
   }
 
 } // end namespace Antioch

--- a/src/kinetics/include/antioch/hercourtessen_rate.h
+++ b/src/kinetics/include/antioch/hercourtessen_rate.h
@@ -101,17 +101,27 @@ namespace Antioch
     CoeffType eta()  const;
     CoeffType Tref() const;
 
+// fork method
+
+    //! \return the rate evaluated at \p T.
+    template <typename InputType>
+    ANTIOCH_AUTO(typename return_type<InputType>::type) 
+    operator()(const InputType& T) const
+    ANTIOCH_AUTOFUNC(typename return_type<InputType>::type, this->rate(T))
+
+    //! \return the derivative with respect to the parameter evaluated at \p T.
+    template <typename InputType>
+    ANTIOCH_AUTO(typename return_type<InputType>::type) 
+    sensitivity( const InputType& T, KineticsModel::Parameters par ) const;
+
+
+// overloads
+
     //! \return the rate evaluated at \p T.
     template <typename StateType>
     ANTIOCH_AUTO(StateType) 
     rate(const StateType& T) const
     ANTIOCH_AUTOFUNC(StateType, _Cf* (ant_pow(T,_eta)))
-
-    //! \return the rate evaluated at \p T.
-    template <typename StateType>
-    ANTIOCH_AUTO(StateType) 
-    operator()(const StateType& T) const
-    ANTIOCH_AUTOFUNC(StateType, this->rate(T))
 
     //! \return the derivative with respect to temperature evaluated at \p T.
     template <typename StateType>
@@ -119,9 +129,48 @@ namespace Antioch
     derivative( const StateType& T ) const
     ANTIOCH_AUTOFUNC(StateType, (*this)(T)/T*(_eta))
 
+    //! \return the derivative with respect to the parameter A evaluated at \p T.
+    template <typename StateType>
+    ANTIOCH_AUTO(StateType) 
+    sensitivity_A( const StateType& T) const
+    ANTIOCH_AUTOFUNC(StateType, ant_pow(T/_Tref,_eta))
+
+    //! \return the derivative with respect to the parameter beta evaluated at \p T.
+    template <typename StateType>
+    ANTIOCH_AUTO(StateType) 
+    sensitivity_beta( const StateType& T) const
+    ANTIOCH_AUTOFUNC(StateType, this->rate(T) * ant_log(T/_Tref))
+
+    //! \return the derivative with respect to the parameter Tref evaluated at \p T.
+    template <typename StateType>
+    ANTIOCH_AUTO(StateType) 
+    sensitivity_Tref( const StateType& T) const
+    ANTIOCH_AUTOFUNC(StateType, - _eta /_Tref * this->rate(T) )
+
+
     //! Simultaneously evaluate the rate and its derivative at \p T.
     template <typename StateType>
     void rate_and_derivative(const StateType& T, StateType& rate, StateType& drate_dT) const;
+
+
+    //! \return the derivative with respect to the parameter A evaluated at \p T.
+    template <typename StateType, typename VectorStateType>
+    ANTIOCH_AUTO(StateType) 
+    sensitivity_A( const KineticsConditions<StateType,VectorStateType> & cond) const
+    ANTIOCH_AUTOFUNC(StateType, ant_pow(cond.T()/_Tref,_eta))
+
+    //! \return the derivative with respect to the parameter beta evaluated at \p T.
+    template <typename StateType, typename VectorStateType>
+    ANTIOCH_AUTO(StateType) 
+    sensitivity_beta( const KineticsConditions<StateType, VectorStateType> & cond) const
+    ANTIOCH_AUTOFUNC(StateType, this->rate(cond) * (cond.temp_cache().lnT - ant_log(_Tref)) )
+
+    //! \return the derivative with respect to the parameter Tref evaluated at \p T.
+    template <typename StateType, typename VectorStateType>
+    ANTIOCH_AUTO(StateType) 
+    sensitivity_Tref( const KineticsConditions<StateType, VectorStateType> & cond) const
+    ANTIOCH_AUTOFUNC(StateType, - _eta /_Tref * this->rate(cond) )
+
 
     //! print equation
     const std::string numeric() const;
@@ -296,6 +345,39 @@ namespace Antioch
     _Cf = _raw_Cf * ant_pow(KineticsModel::Tref<CoeffType>()/_Tref,_eta);
 
     return;
+  }
+
+  template<typename CoeffType>
+  template <typename InputType>
+  inline
+  ANTIOCH_AUTO(typename return_type<InputType>::type) 
+  HercourtEssenRate<CoeffType>::sensitivity( const InputType& T, KineticsModel::Parameters par ) const
+  {
+     switch(par)
+     {
+        case KineticsModel::Parameters::A:
+        {
+           return this->sensitivity_A(T);
+        }
+          break;
+        case KineticsModel::Parameters::B:
+        {
+           return this->sensitivity_beta(T);
+        }
+          break;
+        case KineticsModel::Parameters::T_REF:
+        {
+           return this->sensitivity_Tref(T);
+        }
+          break;
+        default:
+        {
+          antioch_error();
+        }
+          break;
+     }
+
+    return 0;
   }
 
 } // end namespace Antioch

--- a/src/kinetics/include/antioch/kooij_rate.h
+++ b/src/kinetics/include/antioch/kooij_rate.h
@@ -115,23 +115,64 @@ namespace Antioch
     CoeffType Tref()   const;
     CoeffType rscale() const;
 
+// global functions
+
+    //! \return the rate evaluated at \p T.
+    template <typename InputType>
+    ANTIOCH_AUTO(typename return_type<InputType>::type) 
+    operator()(const InputType& T) const
+    ANTIOCH_AUTOFUNC(InputType, this->rate(T))
+
+    template <typename InputType>
+    ANTIOCH_AUTO(typename return_type<InputType>::type) 
+    sensitivity( const InputType& T, KineticsModel::Parameters par ) const;
+
+// now the KineticsConditions and T versions
+
     //! \return the rate evaluated at \p T.
     template <typename StateType>
     ANTIOCH_AUTO(StateType) 
     rate(const StateType& T) const
     ANTIOCH_AUTOFUNC(StateType, _Cf* (ant_exp(_eta * ant_log(T) - _Ea/T)))
 
-    //! \return the rate evaluated at \p T.
-    template <typename StateType>
-    ANTIOCH_AUTO(StateType) 
-    operator()(const StateType& T) const
-    ANTIOCH_AUTOFUNC(StateType, this->rate(T))
 
     //! \return the derivative with respect to temperature evaluated at \p T.
     template <typename StateType>
     ANTIOCH_AUTO(StateType) 
     derivative( const StateType& T ) const
     ANTIOCH_AUTOFUNC(StateType, (*this)(T)/T*(_eta + _Ea/T))
+
+
+    //! \return the derivative with respect to parameter A evaluated at \p T.
+    template <typename StateType>
+    ANTIOCH_AUTO(StateType) 
+    sensitivity_A( const StateType& T ) const
+    ANTIOCH_AUTOFUNC(StateType, ant_exp(_eta * ant_log(T) - _Ea/T))
+
+    //! \return the derivative with respect to parameter beta evaluated at \p T.
+    template <typename StateType>
+    ANTIOCH_AUTO(StateType) 
+    sensitivity_beta( const StateType& T ) const
+    ANTIOCH_AUTOFUNC(StateType, this->rate(T) * ant_log(T/_Tref))
+
+    //! \return the derivative with respect to parameter Ea evaluated at \p T.
+    template <typename StateType>
+    ANTIOCH_AUTO(StateType) 
+    sensitivity_Ea( const StateType& T ) const
+    ANTIOCH_AUTOFUNC(StateType, - this->rate(T) /(_rscale * T) )
+
+    //! \return the derivative with respect to parameter Tref evaluated at \p T.
+    template <typename StateType>
+    ANTIOCH_AUTO(StateType) 
+    sensitivity_Tref( const StateType& T ) const
+    ANTIOCH_AUTOFUNC(StateType, - _eta /_Tref * this->rate(T) )
+
+    //! \return the derivative with respect to the parameter rscale evaluated at \p T.
+    template <typename StateType>
+    ANTIOCH_AUTO(StateType) 
+    sensitivity_Rscale( const StateType& T) const
+    ANTIOCH_AUTOFUNC(StateType, - this->rate(T) * _Ea /(_rscale * T) ) // Ea = _raw_Ea / rscale
+
 
     //! Simultaneously evaluate the rate and its derivative at \p T.
     template <typename StateType>
@@ -145,17 +186,41 @@ namespace Antioch
     rate(const KineticsConditions<StateType,VectorStateType>& T) const
     ANTIOCH_AUTOFUNC(StateType, _Cf * ant_exp(_eta * T.temp_cache().lnT - _Ea/T.T()))
 
-    //! \return the rate evaluated at \p T.
-    template <typename StateType, typename VectorStateType>
-    ANTIOCH_AUTO(StateType) 
-    operator()(const KineticsConditions<StateType,VectorStateType>& T) const
-    ANTIOCH_AUTOFUNC(StateType, this->rate(T))
-
     //! \return the derivative with respect to temperature evaluated at \p T.
     template <typename StateType, typename VectorStateType>
     ANTIOCH_AUTO(StateType) 
     derivative( const KineticsConditions<StateType,VectorStateType>& T ) const
     ANTIOCH_AUTOFUNC(StateType, (*this)(T)/T.T()*(_eta + _Ea/T.T()))
+
+    //! \return the derivative with respect to parameter A evaluated at \p T.
+    template <typename StateType, typename VectorStateType>
+    ANTIOCH_AUTO(StateType) 
+    sensitivity_A( const KineticsConditions<StateType,VectorStateType>& cond ) const
+    ANTIOCH_AUTOFUNC(StateType, ant_exp(_eta * cond.temp_cache().lnT - _Ea/cond.T()))
+
+    //! \return the derivative with respect to parameter beta evaluated at \p T.
+    template <typename StateType, typename VectorStateType>
+    ANTIOCH_AUTO(StateType) 
+    sensitivity_beta( const KineticsConditions<StateType,VectorStateType>& cond ) const
+    ANTIOCH_AUTOFUNC(StateType, this->rate(cond) * (cond.temp_cache().lnT - ant_log(_Tref) ) )
+
+    //! \return the derivative with respect to parameter Ea evaluated at \p T.
+    template <typename StateType, typename VectorStateType>
+    ANTIOCH_AUTO(StateType) 
+    sensitivity_Ea( const KineticsConditions<StateType, VectorStateType> & cond ) const
+    ANTIOCH_AUTOFUNC(StateType, - this->rate(cond) /(_rscale * cond.T()) )
+
+    //! \return the derivative with respect to parameter Tref evaluated at \p T.
+    template <typename StateType, typename VectorStateType>
+    ANTIOCH_AUTO(StateType) 
+    sensitivity_Tref( const KineticsConditions<StateType, VectorStateType> & cond ) const
+    ANTIOCH_AUTOFUNC(StateType, - _eta /_Tref * this->rate(cond) )
+
+    //! \return the derivative with respect to the parameter rscale evaluated at \p T.
+    template <typename StateType, typename VectorStateType>
+    ANTIOCH_AUTO(StateType) 
+    sensitivity_Rscale( const KineticsConditions<StateType,VectorStateType> & cond) const
+    ANTIOCH_AUTOFUNC(StateType, - this->rate(cond) * _Ea /(_rscale * cond.T()) ) // Ea = _raw_Ea / rscale
 
     //! Simultaneously evaluate the rate and its derivative at \p T.
     template <typename StateType,typename VectorStateType>
@@ -422,6 +487,49 @@ namespace Antioch
   {
     _Cf = _raw_Cf * ant_pow(KineticsModel::Tref<CoeffType>()/_Tref,_eta);
     return;
+  }
+
+  template<typename CoeffType>
+  template <typename InputType>
+  inline
+  ANTIOCH_AUTO(typename return_type<InputType>::type) 
+  KooijRate<CoeffType>::sensitivity( const InputType& T, KineticsModel::Parameters par ) const
+  {
+     switch(par)
+     {
+        case KineticsModel::Parameters::A:
+        {
+           return this->sensitivity_A(T);
+        }
+          break;
+        case KineticsModel::Parameters::B:
+        {
+           return this->sensitivity_beta(T);
+        }
+          break;
+        case KineticsModel::Parameters::E:
+        {
+           return this->sensitivity_Ea(T);
+        }
+          break;
+        case KineticsModel::Parameters::T_REF:
+        {
+           return this->sensitivity_Tref(T);
+        }
+          break;
+        case KineticsModel::Parameters::R_SCALE:
+        {
+           return this->sensitivity_Rscale(T);
+        }
+          break;
+        default:
+        {
+          antioch_error();
+        }
+          break;
+     }
+
+    return 0;
   }
 
 } // end namespace Antioch

--- a/src/kinetics/include/antioch/vanthoff_rate.h
+++ b/src/kinetics/include/antioch/vanthoff_rate.h
@@ -120,17 +120,26 @@ namespace Antioch
     CoeffType Tref()   const;
     CoeffType rscale() const;
 
+// fork methods
+
+    //! \return the rate evaluated at \p T.
+    template <typename InputType>
+    ANTIOCH_AUTO(typename return_type<InputType>::type) 
+    operator()(const InputType& T) const
+    ANTIOCH_AUTOFUNC(typename return_type<InputType>::type, this->rate(T))
+
+    //! \return the derivative with respect to the parameter evaluated at \p T.
+    template <typename InputType>
+    ANTIOCH_AUTO(typename return_type<InputType>::type) 
+    sensitivity( const InputType& T, KineticsModel::Parameters par) const;
+
+//
+
     //! \return the rate evaluated at \p T.
     template <typename StateType>
     ANTIOCH_AUTO(StateType) 
     rate(const StateType& T) const
     ANTIOCH_AUTOFUNC(StateType, _Cf* (ant_pow(T,_eta)*ant_exp(-_Ea/T + _D*T)))
-
-    //! \return the rate evaluated at \p T.
-    template <typename StateType>
-    ANTIOCH_AUTO(StateType) 
-    operator()(const StateType& T) const
-    ANTIOCH_AUTOFUNC(StateType, this->rate(T))
 
     //! \return the derivative with respect to temperature evaluated at \p T.
     template <typename StateType>
@@ -142,6 +151,43 @@ namespace Antioch
     template <typename StateType>
     void rate_and_derivative(const StateType& T, StateType& rate, StateType& drate_dT) const;
 
+    //! \return the derivative with respect to the parameter A evaluated at \p T.
+    template <typename StateType>
+    ANTIOCH_AUTO(StateType) 
+    sensitivity_A( const StateType& T) const
+    ANTIOCH_AUTOFUNC(StateType, ant_pow(T/_Tref,_eta) * ant_exp(-_Ea/T + _D * T))
+
+    //! \return the derivative with respect to the parameter beta evaluated at \p T.
+    template <typename StateType>
+    ANTIOCH_AUTO(StateType) 
+    sensitivity_beta( const StateType& T) const
+    ANTIOCH_AUTOFUNC(StateType, ant_log(T/_Tref) * this->rate(T))
+
+    //! \return the derivative with respect to the parameter Ea evaluated at \p T.
+    template <typename StateType>
+    ANTIOCH_AUTO(StateType) 
+    sensitivity_Ea( const StateType& T) const
+    ANTIOCH_AUTOFUNC(StateType, - this->rate(T) /(_rscale * T) )
+
+    //! \return the derivative with respect to the parameter D evaluated at \p T.
+    template <typename StateType>
+    ANTIOCH_AUTO(StateType) 
+    sensitivity_D( const StateType& T) const
+    ANTIOCH_AUTOFUNC(StateType, T * this->rate(T) )
+
+    //! \return the derivative with respect to the parameter Tref evaluated at \p T.
+    template <typename StateType>
+    ANTIOCH_AUTO(StateType) 
+    sensitivity_Tref( const StateType& T) const
+    ANTIOCH_AUTOFUNC(StateType, - _eta /_Tref * this->rate(T) )
+
+    //! \return the derivative with respect to the parameter Rscale evaluated at \p T.
+    template <typename StateType>
+    ANTIOCH_AUTO(StateType) 
+    sensitivity_Rscale( const StateType& T) const
+    ANTIOCH_AUTOFUNC(StateType, - this->rate(T) * _Ea /(_rscale * T) ) // Ea = _raw_Ea / rscale
+
+
 // KineticsConditions overloads
 
     //! \return the rate evaluated at \p T.
@@ -149,12 +195,6 @@ namespace Antioch
     ANTIOCH_AUTO(StateType) 
     rate(const KineticsConditions<StateType,VectorStateType>& T) const
     ANTIOCH_AUTOFUNC(StateType, _Cf * ant_exp(_eta * T.temp_cache().lnT - _Ea/T.T() + _D*T.T()))
-
-    //! \return the rate evaluated at \p T.
-    template <typename StateType, typename VectorStateType>
-    ANTIOCH_AUTO(StateType) 
-    operator()(const KineticsConditions<StateType,VectorStateType>& T) const
-    ANTIOCH_AUTOFUNC(StateType, this->rate(T))
 
     //! \return the derivative with respect to temperature evaluated at \p T.
     template <typename StateType, typename VectorStateType>
@@ -165,6 +205,42 @@ namespace Antioch
     //! Simultaneously evaluate the rate and its derivative at \p T.
     template <typename StateType, typename VectorStateType>
     void rate_and_derivative(const KineticsConditions<StateType,VectorStateType>& T, StateType& rate, StateType& drate_dT) const;
+
+    //! \return the derivative with respect to the parameter A evaluated at \p T.
+    template <typename StateType, typename VectorStateType>
+    ANTIOCH_AUTO(StateType) 
+    sensitivity_A( const KineticsConditions<StateType,VectorStateType>& cond) const
+    ANTIOCH_AUTOFUNC(StateType, ant_pow(cond.T()/_Tref,_eta) * ant_exp(_D * cond.T()))
+
+    //! \return the derivative with respect to the parameter beta evaluated at \p T.
+    template <typename StateType, typename VectorStateType>
+    ANTIOCH_AUTO(StateType)
+    sensitivity_beta(const KineticsConditions<StateType,VectorStateType> & cond) const
+    ANTIOCH_AUTOFUNC(StateType,this->rate(cond) * (cond.temp_cache().lnT - ant_log(_Tref)) )
+
+    //! \return the derivative with respect to parameter Ea evaluated at \p T.
+    template <typename StateType, typename VectorStateType>
+    ANTIOCH_AUTO(StateType) 
+    sensitivity_Ea( const KineticsConditions<StateType, VectorStateType> & cond ) const
+    ANTIOCH_AUTOFUNC(StateType, - this->rate(cond) /(_rscale * cond.T()) )
+
+    //! \return the derivative with respect to the parameter D evaluated at \p T.
+    template <typename StateType, typename VectorStateType>
+    ANTIOCH_AUTO(StateType) 
+    sensitivity_D( const KineticsConditions<StateType,VectorStateType> & cond) const
+    ANTIOCH_AUTOFUNC(StateType, this->rate(cond) * cond.T())
+
+    //! \return the derivative with respect to the parameter Tref evaluated at \p T.
+    template <typename StateType, typename VectorStateType>
+    ANTIOCH_AUTO(StateType) 
+    sensitivity_Tref( const KineticsConditions<StateType,VectorStateType> & cond) const
+    ANTIOCH_AUTOFUNC(StateType, - _eta /_Tref * this->rate(cond) )
+
+    //! \return the derivative with respect to the parameter rscale evaluated at \p T.
+    template <typename StateType, typename VectorStateType>
+    ANTIOCH_AUTO(StateType) 
+    sensitivity_Rscale( const KineticsConditions<StateType,VectorStateType> & cond) const
+    ANTIOCH_AUTOFUNC(StateType, - this->rate(cond) * _Ea /(_rscale * cond.T()) ) // Ea = _raw_Ea / rscale
 
     //! print equation
     const std::string numeric() const;
@@ -449,6 +525,55 @@ namespace Antioch
   {
     _Cf = _raw_Cf * ant_pow(KineticsModel::Tref<CoeffType>()/_Tref,_eta);
     return;
+  }
+
+  template<typename CoeffType>
+  template <typename InputType>
+  inline
+  ANTIOCH_AUTO(typename return_type<InputType>::type) 
+  VantHoffRate<CoeffType>::sensitivity( const InputType& T, KineticsModel::Parameters par) const
+  {
+    switch(par)
+    {
+      case KineticsModel::Parameters::A:
+      {
+        return this->sensitivity_A(T);
+      }
+        break;
+      case KineticsModel::Parameters::B:
+      {
+        return this->sensitivity_beta(T);
+      }
+        break;
+      case KineticsModel::Parameters::E:
+      {
+        return this->sensitivity_Ea(T);
+      }
+        break;
+      case KineticsModel::Parameters::D:
+      {
+        return this->sensitivity_D(T);
+      }
+        break;
+      case KineticsModel::Parameters::T_REF:
+      {
+        return this->sensitivity_Tref(T);
+      }
+        break;
+      case KineticsModel::Parameters::R_SCALE:
+      {
+        return this->sensitivity_Rscale(T);
+      }
+        break;
+      default:
+      {
+        antioch_error();
+      }
+      break;
+    }
+
+    return 0;
+
   }
 
 } // end namespace Antioch

--- a/src/utilities/include/antioch/metaprogramming_decl.h
+++ b/src/utilities/include/antioch/metaprogramming_decl.h
@@ -156,6 +156,12 @@ namespace Antioch
     typedef T & type;
   };
 
+  template <typename T>
+  struct return_type
+  {
+     typedef T type;
+  };
+
 
   // A function for zero-initializing vectorized numeric types
   // while resizing them to match the example input


### PR DESCRIPTION
Same remark for the tag than the get/set PR.  This is a work in progress, but quite big so it comes slowly and progressively.

This is the first implementation of the derivative with respect to parameters for the kinetics.  Except for the photochemistry, all models have the ```sensitivity_*PARAMETER*``` implemented, both with the ```StateType T``` and the ```KineticsConditions cond``` version.  To limit overloading, I've also added a structure, ```return_type<T>```.  This returns ```T``` except if ```T``` is a ```KineticsConditions``` object, in which case it returns a ```StateType```.

So this enables to have two fork methods for every kinetics models:
```
typename return_type<InputType>.::type
  operator(const InputType & T) const {return this->rate(T);}

typename return_type<InputType>::type
  sensitivity(const InputType & T, KineticsModel::Parameters parameter) const;
```

The used methods within theses (```rate``` and ```sensitivity_*PARAMETER*```) are overloaded to enable both versions of the temperature.   A good idea for the future would be to use a similar design for ```derivative```.