### PR TITLE
Huge bugfix in ASCIIParser (unit change was not updated...)

### DIFF
--- a/src/diffusion/include/antioch/molecular_binary_diffusion.h
+++ b/src/diffusion/include/antioch/molecular_binary_diffusion.h
@@ -171,10 +171,10 @@ namespace Antioch{
      _i(si.species()),
      _j(sj.species()),
      _reduced_mass((si.species() == sj.species())?CoeffType(0.5L) * si.M():(si.M() * sj.M()) / (si.M() + sj.M())), // kg/mol
-     _xi((si.polar() == sj.polar())?1L:this->composed_xi(si,sj)),
-     _reduced_LJ_diameter(CoeffType(0.5) * (si.LJ_diameter() + sj.LJ_diameter()) * Units<CoeffType>("ang").get_SI_factor() * ant_pow(_xi,-CoeffType(1)/CoeffType(6))), // 1/2 * (sigma_1 + sigma_2) * xi^(-1/6)
+     _xi((si.polar() == sj.polar())?1:this->composed_xi(si,sj)),
+     _reduced_LJ_diameter(CoeffType(0.5L) * (si.LJ_diameter() + sj.LJ_diameter()) * Units<CoeffType>("ang").get_SI_factor() * ant_pow(_xi,-CoeffType(1)/CoeffType(6))), // 1/2 * (sigma_1 + sigma_2) * xi^(-1/6)
      _reduced_LJ_depth(ant_sqrt(si.LJ_depth() * sj.LJ_depth())  * _xi * _xi), // sqrt(eps_1 * eps_2) * xi^2
-     _reduced_dipole_moment((CoeffType(1e-7) * ant_pow(Constants::light_celerity<CoeffType>(),2)) * 
+     _reduced_dipole_moment((CoeffType(1e-7L) * ant_pow(Constants::light_celerity<CoeffType>(),2)) * 
                               (si.dipole_moment() * sj.dipole_moment() * ant_pow(Units<CoeffType>("D").get_SI_factor(),2 )) / 
                             (2 * _reduced_LJ_depth * Constants::Boltzmann_constant<CoeffType>() * ant_pow(_reduced_LJ_diameter,3) )), // mu^2 / (2*eps*sigma^3)
 /*  = ~ 7.16 10^-25, 
@@ -184,9 +184,9 @@ namespace Antioch{
         3/16 * sqrt ( 2 * kb / (Navo * pi) )
 */
       _coefficient(CoeffType(0.1875e-25L) * ant_sqrt(2 * Constants::Boltzmann_constant<CoeffType>() * CoeffType(1e25)  /
-                                                            (Constants::Avogadro<CoeffType>() * CoeffType(1e-25) * Constants::pi<CoeffType>())
-                                                          )
-                                         / ( sqrt(_reduced_mass) * (_reduced_LJ_diameter * _reduced_LJ_diameter) )
+                                                      (_reduced_mass * Constants::Avogadro<CoeffType>() * CoeffType(1e-25L) * Constants::pi<CoeffType>())
+                                                    )
+                                         / ( _reduced_LJ_diameter * _reduced_LJ_diameter ) 
                   )
   {
      
@@ -210,17 +210,17 @@ namespace Antioch{
 #else
      _i(species[0].species()),
      _j(species[1].species()),
-     _reduced_mass((species[0].species() == species[1].species())?CoeffType(0.5) * species[0].M():(species[0].M() * species[1].M()) / (species[0].M() + species[1].M())), // kg/mol
-     _xi((species[0].polar() == species[1].polar())?1L:this->composed_xi(species[0],species[1])),
-     _reduced_LJ_diameter(CoeffType(0.5) * (species[0].LJ_diameter() + species[1].LJ_diameter()) * Units<CoeffType>("ang").get_SI_factor() * ant_pow(_xi,-CoeffType(1)/CoeffType(6))), // 1/2 * (sigma_1 + sigma_2) * xi^(-1/6)
+     _reduced_mass((species[0].species() == species[1].species())?CoeffType(0.5L) * species[0].M():(species[0].M() * species[1].M()) / (species[0].M() + species[1].M())), // kg/mol
+     _xi((species[0].polar() == species[1].polar())?1:this->composed_xi(species[0],species[1])),
+     _reduced_LJ_diameter(CoeffType(0.5L) * (species[0].LJ_diameter() + species[1].LJ_diameter()) * Units<CoeffType>("ang").get_SI_factor() * ant_pow(_xi,-CoeffType(1)/CoeffType(6))), // 1/2 * (sigma_1 + sigma_2) * xi^(-1/6)
      _reduced_LJ_depth(ant_sqrt(species[0].LJ_depth() * species[1].LJ_depth())  *_xi * _xi), // sqrt(eps_1 * eps_2) * xi^2
-     _reduced_dipole_moment((CoeffType(1e-7) * ant_pow(Constants::light_celerity<CoeffType>(),2)) * 
+     _reduced_dipole_moment((CoeffType(1e-7L) * ant_pow(Constants::light_celerity<CoeffType>(),2)) * 
                               (species[0].dipole_moment() * species[1].dipole_moment() * ant_pow(Units<CoeffType>("D").get_SI_factor(),2 )) / 
                             (2 * _reduced_LJ_depth * Constants::Boltzmann_constant<CoeffType>() * ant_pow(_reduced_LJ_diameter,3) )), // mu^2 / (2*eps*sigma^3)
       _coefficient(CoeffType(0.1875e-25L) * ant_sqrt(2 * Constants::Boltzmann_constant<CoeffType>() * CoeffType(1e25)  /
-                                                            (Constants::Avogadro<CoeffType>() * CoeffType(1e-25) * Constants::pi<CoeffType>())
-                                                          )
-                                         / ( sqrt(_reduced_mass) * (_reduced_LJ_diameter * _reduced_LJ_diameter) )
+                                                       (_reduced_mass * Constants::Avogadro<CoeffType>() * CoeffType(1e-25L) * Constants::pi<CoeffType>())
+                                                    )
+                                         / ( _reduced_LJ_diameter * _reduced_LJ_diameter )
                   )
 #endif
   {
@@ -248,12 +248,11 @@ namespace Antioch{
   {
      _i                     = si.species();
      _j                     = sj.species();
-     _reduced_mass          = (si.species() == sj.species())?si.M():(si.M() * sj.M()) / (si.M() + sj.M());
-     _reduced_dipole_moment = ant_sqrt(si.dipole_moment() * sj.dipole_moment());
+     _reduced_mass          = (si.species() == sj.species())?CoeffType(0.5L) * si.M():(si.M() * sj.M()) / (si.M() + sj.M());
      _xi                    = (si.polar() == sj.polar())?1:this->composed_xi(si,sj);
-     _reduced_LJ_diameter   = CoeffType(0.5) * (si.LJ_diameter() + sj.LJ_diameter()) * Units<CoeffType>("ang").get_SI_factor() * ant_pow(_xi,-CoeffType(1)/CoeffType(6));
+     _reduced_LJ_diameter   = CoeffType(0.5L) * (si.LJ_diameter() + sj.LJ_diameter()) * Units<CoeffType>("ang").get_SI_factor() * ant_pow(_xi,-CoeffType(1)/CoeffType(6));
      _reduced_LJ_depth      = ant_sqrt(si.LJ_depth() * sj.LJ_depth()) *_xi * _xi;
-     _reduced_dipole_moment = CoeffType(1e-7) * ant_pow(Constants::light_celerity<CoeffType>(),2) * // * 1/(4*pi * eps_0) = 10^-7 * c^2 
+     _reduced_dipole_moment = CoeffType(1e-7L) * ant_pow(Constants::light_celerity<CoeffType>(),2) * // * 1/(4*pi * eps_0) = 10^-7 * c^2 
                              (si.dipole_moment() * sj.dipole_moment()) * ant_pow(Units<CoeffType>("D").get_SI_factor(),2)
                                 / ((2 * _reduced_LJ_depth * Constants::Boltzmann_constant<CoeffType>() * ant_pow(_reduced_LJ_diameter,3)));
 /*  = ~ 7.16 10^-25, 
@@ -263,9 +262,9 @@ namespace Antioch{
         3/16 * sqrt ( 2 * kb / (Navo * pi) )
 */
       _coefficient = CoeffType(0.1875e-25L) * ant_sqrt(2 * Constants::Boltzmann_constant<CoeffType>() * CoeffType(1e25)  /
-                                                            (Constants::Avogadro<CoeffType>() * CoeffType(1e-25) * Constants::pi<CoeffType>())
-                                                          )
-                                         / ( sqrt(_reduced_mass) * (_reduced_LJ_diameter * _reduced_LJ_diameter) );
+                                                        (_reduced_mass * Constants::Avogadro<CoeffType>() * CoeffType(1e-25) * Constants::pi<CoeffType>())
+                                                      )
+                                         / ( _reduced_LJ_diameter * _reduced_LJ_diameter );
   }
 
   template <typename CoeffType, typename Interpolator>

--- a/src/diffusion/include/antioch/molecular_binary_diffusion.h
+++ b/src/diffusion/include/antioch/molecular_binary_diffusion.h
@@ -170,9 +170,9 @@ namespace Antioch{
   MolecularBinaryDiffusion<CoeffType,Interpolator>::MolecularBinaryDiffusion(const TransportSpecies<CoeffType> & si, const TransportSpecies<CoeffType> & sj):
      _i(si.species()),
      _j(sj.species()),
-     _reduced_mass((si.species() == sj.species())?CoeffType(0.5L) * si.M():(si.M() * sj.M()) / (si.M() + sj.M())), // kg/mol
+     _reduced_mass((si.species() == sj.species())?CoeffType(0.5) * si.M():(si.M() * sj.M()) / (si.M() + sj.M())), // kg/mol
      _xi((si.polar() == sj.polar())?1:this->composed_xi(si,sj)),
-     _reduced_LJ_diameter(CoeffType(0.5L) * (si.LJ_diameter() + sj.LJ_diameter()) * Units<CoeffType>("ang").get_SI_factor() * ant_pow(_xi,-CoeffType(1)/CoeffType(6))), // 1/2 * (sigma_1 + sigma_2) * xi^(-1/6)
+     _reduced_LJ_diameter(CoeffType(0.5) * (si.LJ_diameter() + sj.LJ_diameter()) * Units<CoeffType>("ang").get_SI_factor() * ant_pow(_xi,-CoeffType(1)/CoeffType(6))), // 1/2 * (sigma_1 + sigma_2) * xi^(-1/6)
      _reduced_LJ_depth(ant_sqrt(si.LJ_depth() * sj.LJ_depth())  * _xi * _xi), // sqrt(eps_1 * eps_2) * xi^2
      _reduced_dipole_moment((CoeffType(1e-7L) * ant_pow(Constants::light_celerity<CoeffType>(),2)) * 
                               (si.dipole_moment() * sj.dipole_moment() * ant_pow(Units<CoeffType>("D").get_SI_factor(),2 )) / 
@@ -210,9 +210,9 @@ namespace Antioch{
 #else
      _i(species[0].species()),
      _j(species[1].species()),
-     _reduced_mass((species[0].species() == species[1].species())?CoeffType(0.5L) * species[0].M():(species[0].M() * species[1].M()) / (species[0].M() + species[1].M())), // kg/mol
+     _reduced_mass((species[0].species() == species[1].species())?CoeffType(0.5) * species[0].M():(species[0].M() * species[1].M()) / (species[0].M() + species[1].M())), // kg/mol
      _xi((species[0].polar() == species[1].polar())?1:this->composed_xi(species[0],species[1])),
-     _reduced_LJ_diameter(CoeffType(0.5L) * (species[0].LJ_diameter() + species[1].LJ_diameter()) * Units<CoeffType>("ang").get_SI_factor() * ant_pow(_xi,-CoeffType(1)/CoeffType(6))), // 1/2 * (sigma_1 + sigma_2) * xi^(-1/6)
+     _reduced_LJ_diameter(CoeffType(0.5) * (species[0].LJ_diameter() + species[1].LJ_diameter()) * Units<CoeffType>("ang").get_SI_factor() * ant_pow(_xi,-CoeffType(1)/CoeffType(6))), // 1/2 * (sigma_1 + sigma_2) * xi^(-1/6)
      _reduced_LJ_depth(ant_sqrt(species[0].LJ_depth() * species[1].LJ_depth())  *_xi * _xi), // sqrt(eps_1 * eps_2) * xi^2
      _reduced_dipole_moment((CoeffType(1e-7L) * ant_pow(Constants::light_celerity<CoeffType>(),2)) * 
                               (species[0].dipole_moment() * species[1].dipole_moment() * ant_pow(Units<CoeffType>("D").get_SI_factor(),2 )) / 
@@ -248,9 +248,9 @@ namespace Antioch{
   {
      _i                     = si.species();
      _j                     = sj.species();
-     _reduced_mass          = (si.species() == sj.species())?CoeffType(0.5L) * si.M():(si.M() * sj.M()) / (si.M() + sj.M());
+     _reduced_mass          = (si.species() == sj.species())?CoeffType(0.5) * si.M():(si.M() * sj.M()) / (si.M() + sj.M());
      _xi                    = (si.polar() == sj.polar())?1:this->composed_xi(si,sj);
-     _reduced_LJ_diameter   = CoeffType(0.5L) * (si.LJ_diameter() + sj.LJ_diameter()) * Units<CoeffType>("ang").get_SI_factor() * ant_pow(_xi,-CoeffType(1)/CoeffType(6));
+     _reduced_LJ_diameter   = CoeffType(0.5) * (si.LJ_diameter() + sj.LJ_diameter()) * Units<CoeffType>("ang").get_SI_factor() * ant_pow(_xi,-CoeffType(1)/CoeffType(6));
      _reduced_LJ_depth      = ant_sqrt(si.LJ_depth() * sj.LJ_depth()) *_xi * _xi;
      _reduced_dipole_moment = CoeffType(1e-7L) * ant_pow(Constants::light_celerity<CoeffType>(),2) * // * 1/(4*pi * eps_0) = 10^-7 * c^2 
                              (si.dipole_moment() * sj.dipole_moment()) * ant_pow(Units<CoeffType>("D").get_SI_factor(),2)

--- a/src/parsing/include/antioch/ascii_parser.h
+++ b/src/parsing/include/antioch/ascii_parser.h
@@ -637,7 +637,6 @@ namespace Antioch
     NumericType dipole_moment;
     NumericType pol;
     NumericType Zrot;
-    NumericType SI_coeff = Antioch::Units<NumericType>("g/mol").get_SI_factor();
 
     const unsigned int n_data = _n_columns_transport_species + _ignored.size(); // we read all those columns
     unsigned int iLJeps(0);
@@ -667,7 +666,7 @@ namespace Antioch
           if(transport.chemical_mixture().species_name_map().count(name))
           {
               unsigned int place = transport.chemical_mixture().species_name_map().at(name);
-              NumericType mass = transport.chemical_mixture().M(place) * SI_coeff;
+              NumericType mass = transport.chemical_mixture().M(place);
 // adding species in mixture
               transport.add_species(place,LJ_eps_kB,LJ_sigma,dipole_moment,pol,Zrot,mass);
           }

--- a/src/viscosity/include/antioch/kinetics_theory_viscosity.h
+++ b/src/viscosity/include/antioch/kinetics_theory_viscosity.h
@@ -172,7 +172,7 @@ namespace Antioch
         _LJ(LJ_depth,LJ_diameter),
         _dipole_moment(dipole_moment),
         _mass(mass),
-        _delta_star(CoeffType(1e-7) * ant_pow(Constants::light_celerity<CoeffType>(),2) * // * 1/(4*pi * eps_0) = 10^-7 * c^2
+        _delta_star(CoeffType(1e-7L) * ant_pow(Constants::light_celerity<CoeffType>(),2) * // * 1/(4*pi * eps_0) = 10^-7 * c^2
                     ant_pow(_dipole_moment * Units<CoeffType>("D").get_SI_factor(),2) /             
                      ( _LJ.depth() * Constants::Boltzmann_constant<CoeffType>() * 2 * ant_pow(_LJ.diameter() * Units<CoeffType>("ang").get_SI_factor(),3) )),
         _a(CoeffType(0.3125e-14L) * ant_sqrt(CoeffType(1e28) * Constants::Boltzmann_constant<CoeffType>() * _mass / Constants::pi<CoeffType>())
@@ -197,7 +197,7 @@ namespace Antioch
         _LJ(coeffs[0],coeffs[1]),
         _dipole_moment(coeffs[2]),
         _mass(coeffs[3]),
-        _delta_star(CoeffType(1e-7) * ant_pow(Constants::light_celerity<CoeffType>(),2) * // * 1/(4*pi * eps_0) = 10^-7 * c^2
+        _delta_star(CoeffType(1e-7L) * ant_pow(Constants::light_celerity<CoeffType>(),2) * // * 1/(4*pi * eps_0) = 10^-7 * c^2
                     ant_pow(_dipole_moment * Units<CoeffType>("D").get_SI_factor(),2) /             
                      ( _LJ.depth() * Constants::Boltzmann_constant<CoeffType>() * 2 * ant_pow(_LJ.diameter() * Units<CoeffType>("ang").get_SI_factor(),3) )),
         _a(CoeffType(0.3125e-14L) * ant_sqrt(CoeffType(1e28) * Constants::Boltzmann_constant<CoeffType>() * _mass / Constants::pi<CoeffType>())
@@ -252,7 +252,7 @@ namespace Antioch
      _LJ.reset_coeffs(LJ_depth,LJ_dia);
      _dipole_moment = dipole_moment;
      _mass = mass;
-     _delta_star = CoeffType(1e-7) * ant_pow(Constants::light_celerity<CoeffType>(),2) * // * 1/(4*pi * eps_0) = 10^-7 * c^2
+     _delta_star = CoeffType(1e-7L) * ant_pow(Constants::light_celerity<CoeffType>(),2) * // * 1/(4*pi * eps_0) = 10^-7 * c^2
                     ant_pow(_dipole_moment * Units<CoeffType>("D").get_SI_factor(),2) /             
                      ( _LJ.depth() * Constants::Boltzmann_constant<CoeffType>() * 2 * ant_pow(_LJ.diameter() * Units<CoeffType>("ang").get_SI_factor(),3) );
      _a = CoeffType(0.3125L) * ant_sqrt(Constants::Boltzmann_constant<CoeffType>() * _mass / Constants::pi<CoeffType>())


### PR DESCRIPTION
This is a very important bug fix: in the ascii parser, I forgot to update the transport mass definition when we switched to SI units (or got mingled in the parsing PR horror).

This corrects this and adds a few optimizations/constant values management upgrade in the viscosities and diffusion kinetics theory models.

This PR should be merged as soon as possible.  It will very probably require to update the values for the new test in the PR#141.