### PR TITLE
Fix for ConstantLewisDiffusivity

### DIFF
--- a/src/diffusion/include/antioch/constant_lewis_diffusivity.h
+++ b/src/diffusion/include/antioch/constant_lewis_diffusivity.h
@@ -64,7 +64,7 @@ namespace Antioch
     template<typename StateType>
     ANTIOCH_AUTO(StateType)
     D_impl( const StateType& rho, const StateType& cp, const StateType& k ) const
-    ANTIOCH_AUTOFUNC(StateType, _Le*k/(rho*cp))
+    ANTIOCH_AUTOFUNC(StateType, k/(_Le*rho*cp))
   };
 
   template<typename CoeffType>

--- a/test/constant_lewis_unit.C
+++ b/test/constant_lewis_unit.C
@@ -75,7 +75,7 @@ int tester()
 
   const Scalar D = diff.D( rho, cp, k );
 
-  const Scalar D_exact = Le*k/(rho*cp);
+  const Scalar D_exact = k/(Le*rho*cp);
 
   return test_val( D, D_exact, tol, std::string("D") );
 }


### PR DESCRIPTION
Found this during the documentation pass in #148. This is just embarrassing. Fail.

If your Lewis number not equal to 1, then this affects you. We'll have to update all the GRINS/Antioch regression tests.