### PR TITLE
Fix incorrect logic for DiffusionTrait check

### DIFF
--- a/src/transport/include/antioch/mixture_diffusion.h
+++ b/src/transport/include/antioch/mixture_diffusion.h
@@ -198,7 +198,7 @@ namespace Antioch
 
   {
     // This class currenltly only supports species or binary diffusion models
-    if( !DiffusionTraits<Diffusion>::is_species_diffusion ||
+    if( !DiffusionTraits<Diffusion>::is_species_diffusion &&
         !DiffusionTraits<Diffusion>::is_binary_diffusion )
       {
         antioch_static_assert( DiffusionTraits<Diffusion>::is_species_diffusion ||


### PR DESCRIPTION
Forgot to negate the || to an &&

This showed up in GRINS testing. Since this is a simple fix, I'll merge once Travis is happy.