### PR TITLE
Fixes for MixtureDiffusion/SpeciesDiffusionBase Interactions

### DIFF
--- a/src/transport/include/antioch/mixture_diffusion.h
+++ b/src/transport/include/antioch/mixture_diffusion.h
@@ -173,7 +173,7 @@ namespace Antioch
                                     StateType& D,
                                     AntiochPrivate::diffusion_tag<SpeciesDiffusionBase<Diffusion,CoeffType> >& /*tag*/ ) const
     {
-      (*_species_diffusivities[s])(rho,cp,k,D);
+      D = (*_species_diffusivities[s]).D(rho,cp,k);
     }
 
     //! Invalid to call species diffusivity calculation with BinaryDiffusionBase model

--- a/src/transport/include/antioch/wilke_transport_evaluator.h
+++ b/src/transport/include/antioch/wilke_transport_evaluator.h
@@ -311,7 +311,9 @@ namespace Antioch
                                                                               VectorStateType & D_vec ) const
   {
     antioch_static_assert_runtime_fallback( (ConductivityTraits<TherCond>::requires_diffusion &&
-                                             DiffusionTraits<Diff>::is_binary_diffusion) ,
+                                             DiffusionTraits<Diff>::is_binary_diffusion) ||
+                                            (!ConductivityTraits<TherCond>::requires_diffusion &&
+                                             DiffusionTraits<Diff>::is_species_diffusion),
                                             "Incompatible thermal conductivity and diffusion models!" );
 
     mu_mix = zero_clone(T);


### PR DESCRIPTION
There were compile time issues that I uncovered migrating GRINS. We didn't hit them before because of inadequate test coverage in Antioch. There was a logic error in a `static_assert` and an incorrect calling sequence in `MixtureDiffusion`, both related to the `SpeciesDiffusionBase` models. I've fixed both of those problems and have updated the test so that we exercise these paths now.

I will merge once Travis is happy.

With these fixes, GRINS now compiles and passes `make check` with the non-kinetics-theory based transport models (on my [antioch-0.3.0 branch](https://github.com/pbauman/grins/tree/antioch-0.3.0)). I'd like to get the kinetics theory models in there too, but I think this may be the last PR before the 0.3.0 release of Antioch.