### PR TITLE
Setup Default Filenames for Install Tree

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -256,7 +256,10 @@ AC_SUBST(ANTIOCH_STAMPED_FILES)
 # to make it $datadir/antioch_default_files
 # then we define the default files
 ANTIOCH_DEFAULT_FILES_SOURCE_PATH_TMP=$TOP_SEARCH_DIR/share/antioch_default_files/
+ANTIOCH_DEFAULT_FILES_INSTALL_PATH_TMP=$prefix
+
 AC_DEFINE_UNQUOTED(DEFAULT_FILES_SOURCE_PATH,"$ANTIOCH_DEFAULT_FILES_SOURCE_PATH_TMP",[Path to defaults files])
+AC_DEFINE_UNQUOTED(DEFAULT_FILES_INSTALL_PATH,"$ANTIOCH_DEFAULT_FILES_INSTALL_PATH_TMP",[Path to defaults files])
 AC_DEFINE(DEFAULT_SPECIES_LIST,"antioch_default_chemical_species.dat",[Default list of species])
 AC_DEFINE(DEFAULT_CHEMICAL_MIXTURE,"antioch_default_chemical_mixture.dat",[Mandatory default informations on species])
 AC_DEFINE(DEFAULT_VIBRATIONAL_DATA,"antioch_default_vibrational_data.dat",[Vibrational default data])

--- a/configure.ac
+++ b/configure.ac
@@ -255,8 +255,9 @@ AC_SUBST(ANTIOCH_STAMPED_FILES)
 # step (see install-data-hook)
 # to make it $datadir/antioch_default_files
 # then we define the default files
+# Need to make sure to have the `/` at the end
 ANTIOCH_DEFAULT_FILES_SOURCE_PATH_TMP=$TOP_SEARCH_DIR/share/antioch_default_files/
-ANTIOCH_DEFAULT_FILES_INSTALL_PATH_TMP=$prefix
+ANTIOCH_DEFAULT_FILES_INSTALL_PATH_TMP=$prefix/share/antioch_default_files/
 
 AC_DEFINE_UNQUOTED(DEFAULT_FILES_SOURCE_PATH,"$ANTIOCH_DEFAULT_FILES_SOURCE_PATH_TMP",[Path to defaults files])
 AC_DEFINE_UNQUOTED(DEFAULT_FILES_INSTALL_PATH,"$ANTIOCH_DEFAULT_FILES_INSTALL_PATH_TMP",[Path to defaults files])

--- a/configure.ac
+++ b/configure.ac
@@ -255,8 +255,8 @@ AC_SUBST(ANTIOCH_STAMPED_FILES)
 # step (see install-data-hook)
 # to make it $datadir/antioch_default_files
 # then we define the default files
-ANTIOCH_DEFAULT_FILES_PATH_TMP=$TOP_SEARCH_DIR/share/antioch_default_files/
-AC_DEFINE_UNQUOTED(DEFAULT_FILES_PATH,"$ANTIOCH_DEFAULT_FILES_PATH_TMP",[Path to defaults files])
+ANTIOCH_DEFAULT_FILES_SOURCE_PATH_TMP=$TOP_SEARCH_DIR/share/antioch_default_files/
+AC_DEFINE_UNQUOTED(DEFAULT_FILES_SOURCE_PATH,"$ANTIOCH_DEFAULT_FILES_SOURCE_PATH_TMP",[Path to defaults files])
 AC_DEFINE(DEFAULT_SPECIES_LIST,"antioch_default_chemical_species.dat",[Default list of species])
 AC_DEFINE(DEFAULT_CHEMICAL_MIXTURE,"antioch_default_chemical_mixture.dat",[Mandatory default informations on species])
 AC_DEFINE(DEFAULT_VIBRATIONAL_DATA,"antioch_default_vibrational_data.dat",[Vibrational default data])

--- a/src/utilities/include/antioch/default_filename.h
+++ b/src/utilities/include/antioch/default_filename.h
@@ -38,11 +38,15 @@
 // C++ headers
 #include <string>
 
-// Create shim methods Antioch::ant_exp() for exp(), etcetera.
-
 namespace Antioch
 {
 
+  //! Default filenames in the source tree
+  /*! These include the full path to default files in
+   *  in the Antioch *source* tree. If you decide to use
+   *  these in your application, you must *not* delete the
+   *  source tree.
+   */
 class DefaultSourceFilename {
 public:
   static const std::string& species_list() {

--- a/src/utilities/include/antioch/default_filename.h
+++ b/src/utilities/include/antioch/default_filename.h
@@ -109,6 +109,72 @@ public:
 // Backward Compatibility
 typedef DefaultSourceFilename DefaultFilename;
 
+
+  //! Default filenames in the install tree
+  /*! These include the full path to default files in
+   *  in the Antioch *install* tree. These *must not*
+   *  be used internally in Antioch; these are meant
+   *  *only* for applications.
+   */
+class DefaultInstallFilename {
+public:
+  static const std::string& species_list() {
+    static const std::string filename =
+      std::string(ANTIOCH_DEFAULT_FILES_INSTALL_PATH) +
+      std::string(ANTIOCH_DEFAULT_SPECIES_LIST);
+    return filename;
+  }
+
+  static const std::string& chemical_mixture() {
+    static const std::string filename =
+      std::string(ANTIOCH_DEFAULT_FILES_INSTALL_PATH) +
+      std::string(ANTIOCH_DEFAULT_CHEMICAL_MIXTURE);
+    return filename;
+  }
+
+  static const std::string& vibrational_data() {
+    static const std::string filename =
+      std::string(ANTIOCH_DEFAULT_FILES_INSTALL_PATH) +
+      std::string(ANTIOCH_DEFAULT_VIBRATIONAL_DATA);
+    return filename;
+  }
+
+  static const std::string& electronic_data() {
+    static const std::string filename =
+      std::string(ANTIOCH_DEFAULT_FILES_INSTALL_PATH) +
+      std::string(ANTIOCH_DEFAULT_ELECTRONIC_DATA);
+    return filename;
+  }
+
+  static const std::string& thermo_data() {
+    static const std::string filename =
+      std::string(ANTIOCH_DEFAULT_FILES_INSTALL_PATH) +
+      std::string(ANTIOCH_DEFAULT_THERMO_DATA);
+    return filename;
+  }
+
+  static const std::string& sutherland_data() {
+    static const std::string filename =
+      std::string(ANTIOCH_DEFAULT_FILES_INSTALL_PATH) +
+      std::string(ANTIOCH_DEFAULT_SUTHERLAND_DATA);
+    return filename;
+  }
+
+  static const std::string& blottner_data() {
+    static const std::string filename =
+      std::string(ANTIOCH_DEFAULT_FILES_INSTALL_PATH) +
+      std::string(ANTIOCH_DEFAULT_BLOTTNER_DATA);
+    return filename;
+  }
+
+  static const std::string& transport_mixture() {
+    static const std::string filename =
+      std::string(ANTIOCH_DEFAULT_FILES_INSTALL_PATH) +
+      std::string(ANTIOCH_DEFAULT_TRANSPORT_DATA);
+    return filename;
+  }
+};
+
 } // end namespace Antioch
 
 #endif //ANTIOCH_DEFAULT_FILENAME_H

--- a/src/utilities/include/antioch/default_filename.h
+++ b/src/utilities/include/antioch/default_filename.h
@@ -43,7 +43,7 @@
 namespace Antioch
 {
 
-class DefaultFilename {
+class DefaultSourceFilename {
 public:
   static const std::string& species_list() {
     static const std::string filename =
@@ -101,6 +101,9 @@ public:
     return filename;
   }
 };
+
+// Backward Compatibility
+typedef DefaultSourceFilename DefaultFilename;
 
 } // end namespace Antioch
 

--- a/src/utilities/include/antioch/default_filename.h
+++ b/src/utilities/include/antioch/default_filename.h
@@ -47,56 +47,56 @@ class DefaultFilename {
 public:
   static const std::string& species_list() {
     static const std::string filename =
-      std::string(ANTIOCH_DEFAULT_FILES_PATH) +
+      std::string(ANTIOCH_DEFAULT_FILES_SOURCE_PATH) +
       std::string(ANTIOCH_DEFAULT_SPECIES_LIST);
     return filename;
   }
 
   static const std::string& chemical_mixture() {
     static const std::string filename =
-      std::string(ANTIOCH_DEFAULT_FILES_PATH) +
+      std::string(ANTIOCH_DEFAULT_FILES_SOURCE_PATH) +
       std::string(ANTIOCH_DEFAULT_CHEMICAL_MIXTURE);
     return filename;
   }
 
   static const std::string& vibrational_data() {
     static const std::string filename =
-      std::string(ANTIOCH_DEFAULT_FILES_PATH) +
+      std::string(ANTIOCH_DEFAULT_FILES_SOURCE_PATH) +
       std::string(ANTIOCH_DEFAULT_VIBRATIONAL_DATA);
     return filename;
   }
 
   static const std::string& electronic_data() {
     static const std::string filename =
-      std::string(ANTIOCH_DEFAULT_FILES_PATH) +
+      std::string(ANTIOCH_DEFAULT_FILES_SOURCE_PATH) +
       std::string(ANTIOCH_DEFAULT_ELECTRONIC_DATA);
     return filename;
   }
 
   static const std::string& thermo_data() {
     static const std::string filename =
-      std::string(ANTIOCH_DEFAULT_FILES_PATH) +
+      std::string(ANTIOCH_DEFAULT_FILES_SOURCE_PATH) +
       std::string(ANTIOCH_DEFAULT_THERMO_DATA);
     return filename;
   }
 
   static const std::string& sutherland_data() {
     static const std::string filename =
-      std::string(ANTIOCH_DEFAULT_FILES_PATH) +
+      std::string(ANTIOCH_DEFAULT_FILES_SOURCE_PATH) +
       std::string(ANTIOCH_DEFAULT_SUTHERLAND_DATA);
     return filename;
   }
 
   static const std::string& blottner_data() {
     static const std::string filename =
-      std::string(ANTIOCH_DEFAULT_FILES_PATH) +
+      std::string(ANTIOCH_DEFAULT_FILES_SOURCE_PATH) +
       std::string(ANTIOCH_DEFAULT_BLOTTNER_DATA);
     return filename;
   }
 
   static const std::string& transport_mixture() {
     static const std::string filename =
-      std::string(ANTIOCH_DEFAULT_FILES_PATH) +
+      std::string(ANTIOCH_DEFAULT_FILES_SOURCE_PATH) +
       std::string(ANTIOCH_DEFAULT_TRANSPORT_DATA);
     return filename;
   }


### PR DESCRIPTION
Before this PR, `DefaultFilename` always pointed toward the source tree of Antioch for the default data files, with nothing able to point to the install tree. This is fine if you always have the source tree lying around, but this is a restrictive assumption. Here, we rename `DefaultFilename` to `DefaultSourceFilename` (with a typedef for `DefaultFilename` for backward compatibility) and add `DefaultInstallFilename`.

I'd talked about this with @roystgnr in IM a week or two ago and we'd settled on something like this PR.