### PR TITLE
Xml parser

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -220,6 +220,8 @@ AC_CONFIG_FILES(test/kinetics_regression_air_5sp.sh,     [chmod +x test/kinetics
 AC_CONFIG_FILES(test/kinetics_regression_vec_air_5sp.sh, [chmod +x test/kinetics_regression_vec_air_5sp.sh])
 AC_CONFIG_FILES(test/photochemical_rate_unit.sh,         [chmod +x test/photochemical_rate_unit.sh])
 AC_CONFIG_FILES(test/parsing_xml.sh,                     [chmod +x test/parsing_xml.sh])
+AC_CONFIG_FILES(test/fail_parsing_xml_1.sh,              [chmod +x test/fail_parsing_xml_1.sh])
+AC_CONFIG_FILES(test/fail_parsing_xml_2.sh,              [chmod +x test/fail_parsing_xml_2.sh])
 AC_CONFIG_FILES(test/parsing_chemkin.sh,                 [chmod +x test/parsing_chemkin.sh])
 AC_CONFIG_FILES(test/kinetics_reactive_scheme_unit.sh,   [chmod +x test/kinetics_reactive_scheme_unit.sh])
 AC_CONFIG_FILES(test/nasa_evaluator_unit.sh,             [chmod +x test/nasa_evaluator_unit.sh])

--- a/src/parsing/include/antioch/xml_parser.h
+++ b/src/parsing/include/antioch/xml_parser.h
@@ -139,7 +139,16 @@ namespace Antioch{
          /*! return pairs of products and stoichiometric coefficients*/
          bool products_pairs(std::vector<std::pair<std::string,int> > & products_pair) const;
 
-         /*! return true if "name" attribute is found with value "k0"*/
+         /*! return true if the concerned reaction rate is the low pressure limit
+          *
+          * In the case of falloff reactions, there is the attribute "name" to 
+          * specify which rate constant is the low pressure limit.  This attribute
+          * should have "k0" as value, and nothing else.
+          *
+          * If no "name" attribute is provided, the first rate constant is the low
+          * pressure limit, if two "name" attribute are provided, or if the value
+          * is not "k0", an exception is thrown.
+          */
          bool is_k0(unsigned int nrc, const std::string & kin_model) const;
 
          /*! return index of k0 (0 or 1)*/

--- a/src/parsing/src/read_reaction_set_data.C
+++ b/src/parsing/src/read_reaction_set_data.C
@@ -313,6 +313,8 @@ namespace Antioch
 
             Units<NumericType> def_unit;
             int pow_unit(order_reaction - 1);
+            bool is_falloff(false);
+            bool is_k0(false);
             //threebody always
             if(my_rxn->type() == ReactionType::THREE_BODY)pow_unit++;
             //falloff for k0
@@ -321,8 +323,13 @@ namespace Antioch
                my_rxn->type() == ReactionType::LINDEMANN_FALLOFF_THREE_BODY ||
                my_rxn->type() == ReactionType::TROE_FALLOFF_THREE_BODY)
               {
+                is_falloff = verbose;
                 //k0 is either determined by an explicit name, or is the first of unnamed rate constants
-                if(parser->is_k0(my_rxn->n_rate_constants(),reading_kinetics_model))pow_unit++;
+                if(parser->is_k0(my_rxn->n_rate_constants(),reading_kinetics_model))
+                {
+                  pow_unit++;
+                  is_k0 = verbose;
+                }
               }
 
             NumericType par_value(-1.);
@@ -333,6 +340,9 @@ namespace Antioch
 
             // verbose as we read along
             if(verbose)std::cout << " rate: " << models[kinetics_model_map[kineticsModel]] << " model\n";
+            if(is_falloff){
+              (is_k0)?std::cout << "  Low pressure limit rate constant\n":std::cout << "  High pressure limit rate constant\n";
+            }
 
             // pre-exponential
             if(parser->rate_constant_preexponential_parameter(par_value, par_unit, default_unit))

--- a/src/parsing/src/xml_parser.C
+++ b/src/parsing/src/xml_parser.C
@@ -354,7 +354,32 @@ namespace Antioch
     bool k0(false);
     if(_rate_constant->Attribute(_map.at(ParsingKey::FALLOFF_LOW_NAME).c_str()))
       {
-        if(std::string(_rate_constant->Attribute(_map.at(ParsingKey::FALLOFF_LOW_NAME).c_str())) == _map.at(ParsingKey::FALLOFF_LOW))k0 = true;
+        if(std::string(_rate_constant->Attribute(_map.at(ParsingKey::FALLOFF_LOW_NAME).c_str())) == _map.at(ParsingKey::FALLOFF_LOW))
+        {
+          k0 = true;
+        // now verifying the second one
+          if(nrc == 0) // first reaction rate block
+          {
+            antioch_assert(_rate_constant->NextSiblingElement(kin_model.c_str()));
+            if(_rate_constant->NextSiblingElement(kin_model.c_str())->Attribute(_map.at(ParsingKey::FALLOFF_LOW_NAME).c_str())) // HAHA
+            {
+               std::string error = "I can understand the need to put attributes everywhere, really, but in this case, I'm ";
+               error += "afraid that it's not a good idea to have two \'name\' attributes: only the low pressure limit should have it.";
+               antioch_parsing_error(error);
+            }
+          }
+        }else
+        {
+          std::string error = "The keyword associated with the \'name\' attribute within the description of a falloff should be, and only be, ";
+          error += "\'k0\' to specify the low pressure limit.  It seems that the one you provided, \'";
+          error += std::string(_rate_constant->Attribute(_map.at(ParsingKey::FALLOFF_LOW_NAME).c_str()));
+          error += "\' is not this one.  Please correct it at reaction"; 
+          error += this->reaction_id();
+          error += ": ";
+          error += this->reaction_equation();
+          error += ".";
+          antioch_parsing_error(error);
+        }
       }else if(nrc == 0) // if we're indeed at the first reading
       {
         antioch_assert(_rate_constant->NextSiblingElement(kin_model.c_str()));

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -190,6 +190,7 @@ stat_mech_thermo_unit_eigen_SOURCES = stat_mech_thermo_unit_eigen.C
 
 #Define tests to actually be run
 TESTS  =
+XFAIL_TESTS  =
 TESTS += standard_unit_tests
 TESTS += eigen_unit_tests
 TESTS += vexcl_unit_tests
@@ -238,6 +239,8 @@ TESTS += troe_falloff_unit
 TESTS += photochemical_rate_unit.sh
 TESTS += kinetics_reversibility_unit
 TESTS += parsing_xml.sh
+TESTS += fail_parsing_xml_1.sh
+TESTS += fail_parsing_xml_2.sh
 TESTS += parsing_chemkin.sh
 TESTS += units_unit
 TESTS += kinetics_reactive_scheme_unit.sh
@@ -252,6 +255,8 @@ TESTS += ideal_gas_micro_thermo_unit
 TESTS += ascii_parser_unit.sh
 TESTS += lindemann_falloff_threebody_unit
 TESTS += troe_falloff_threebody_unit
+XFAIL_TESTS += fail_parsing_xml_1.sh
+XFAIL_TESTS += fail_parsing_xml_2.sh
 
 # GSL Tests
 TESTS += molecular_binary_diffusion_unit

--- a/test/fail_parsing_xml_1.sh.in
+++ b/test/fail_parsing_xml_1.sh.in
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+PROG="@top_builddir@/test/parsing_xml"
+
+INPUT="@top_srcdir@/test/input_files/fail_parsing_1.xml  @top_srcdir@/test/input_files/solar_flux.dat @top_srcdir@/test/input_files/CH4_hv_cs.dat"
+
+$PROG $INPUT
+

--- a/test/fail_parsing_xml_2.sh.in
+++ b/test/fail_parsing_xml_2.sh.in
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+PROG="@top_builddir@/test/parsing_xml"
+
+INPUT="@top_srcdir@/test/input_files/fail_parsing_2.xml  @top_srcdir@/test/input_files/solar_flux.dat @top_srcdir@/test/input_files/CH4_hv_cs.dat"
+
+$PROG $INPUT
+

--- a/test/input_files/fail_parsing_1.xml
+++ b/test/input_files/fail_parsing_1.xml
@@ -1,0 +1,743 @@
+<?xml version="1.0"?>
+<!-- Reaction rate parameters from: -->
+<!-- Park, Chul. "Review of Chemical-Kinetic Problems of Future NASA Missions, I : Earth Entries." -->
+<!-- AIAA Journal of Thermophysics and Heat Transfer, Vol. 7, No. 3, July-Sept 1993, pp. 385-397. -->
+
+<!-- park_jaffe_partridge_JTHT_2001 - Park, Jaffe, Partridge "Chemical-Kinetic Parameters of Hyperbolic Earth Entry," JTHT, Vol 15, No 1, pp 76-90, 2001. -->
+<!-- Olynick_Chen_Tauber_SRC_Sizing - Olynick, Chen, Tauber, "Forebody TPS Sizing with Radiation and Ablation for the Stardust Sample Return Capsule," AIAA-1997-2474  -->
+
+<ctml>
+  <validate reactions="yes" species="yes"/>
+
+  <!-- phase air5sp     -->
+  <phase dim="3" id="air5sp">
+    <elementArray datasrc="elements.xml">N O</elementArray>
+    <speciesArray datasrc="#FINS_r13324">N2 O2 NO N O</speciesArray>
+    <reactionArray datasrc="#park_jaffe_partridge_JTHT_2001">
+      <skip species="undeclared"/>
+    </reactionArray>
+    <state>
+      <temperature units="K">300.0</temperature>
+      <pressure units="Pa">101325.0</pressure>
+      <moleFractions>O2:0.22, N2:0.78</moleFractions>
+    </state>
+    <thermo model="IdealGas"/>
+    <kinetics model="GasKinetics"/>
+    <transport model="Pecos"/>
+  </phase>
+
+
+  <!-- park_jaffe_partridge_JTHT_2001 - Park, Jaffe, Partridge "Chemical-Kinetic Parameters of Hyperbolic Earth Entry," JTHT, Vol 15, No 1, pp 76-90, 2001. -->
+  <reactionData id="park_jaffe_partridge_JTHT_2001">
+
+<!--Elementary reactions-->
+    <!-- reaction 0001    -->
+    <reaction reversible="yes" type="Elementary" id="0001">
+      <equation>N2 [=] 2 N </equation>
+      <rateCoeff>
+        <HercourtEssen>
+           <A>7.e+18</A>
+           <b>-1.6</b>
+        </HercourtEssen>
+      </rateCoeff>
+      <reactants>N2:1.0</reactants>
+      <products>N:2.0</products>
+    </reaction>
+
+    <!-- reaction 0002    -->
+    <reaction reversible="yes" type="Elementary" id="0002">
+      <equation>O2 [=] 2 O </equation>
+      <rateCoeff>
+        <Berthelot>
+           <A>2.e+18</A>
+           <D>-5e-3</D>
+        </Berthelot>
+      </rateCoeff>
+      <reactants>O2:1.0</reactants>
+      <products>O:2.0</products>
+    </reaction>
+
+    <!-- reaction 0003    -->
+    <reaction reversible="yes" type="Elementary" id="0003">
+      <equation>NO [=] N + O </equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.e+12</A>
+           <E units="cal/mol">149943.0</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>NO:1</reactants>
+      <products>N:1 O:1</products>
+    </reaction>
+
+    <reaction reversible="yes" type="Elementary" id="0003">
+      <equation>NO [=] N + O </equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.e+12</A>
+           <b>0.42</b>
+           <E units="cal/mol">149943.0</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>NO:1</reactants>
+      <products>N:1 O:1</products>
+    </reaction>
+
+    <!-- reaction 0004    -->
+    <reaction reversible="yes" id="0004">
+      <equation>N2 + O [=] NO + N</equation>
+      <rateCoeff>
+        <BerthelotHercourtEssen>
+           <A>5.7e+9</A>
+           <b>0.42</b>
+           <D>-5e-3</D>
+        </BerthelotHercourtEssen>
+      </rateCoeff>
+      <reactants>N2:1 O:1</reactants>
+      <products>NO:1 N:1</products>
+    </reaction>
+
+    <!-- reaction 0005    -->
+    <reaction reversible="yes" id="0005">
+      <equation>NO + O [=] O2 + N</equation>
+      <rateCoeff>
+        <Kooij>
+           <A>8.4e+09</A>
+           <b>0.40</b>
+           <E units="cal/mol">38526.0</E>
+        </Kooij>
+      </rateCoeff>
+      <reactants>NO:1 O:1</reactants>
+      <products>O2:1 N:1</products>
+    </reaction>
+
+    <!-- reaction 0005bis -->
+    <reaction reversible="yes" id="0005">
+      <equation>NO + O [=] O2 + N</equation>
+      <rateCoeff>
+        <Kooij>
+           <A>8.4e+09</A>
+           <b>0.00</b>
+           <E units="cal/mol">38526.0</E>
+        </Kooij>
+      </rateCoeff>
+      <reactants>NO:1 O:1</reactants>
+      <products>O2:1 N:1</products>
+    </reaction>
+    
+    
+    <!-- reaction 0006 <E units="cal/mol"> 138812.8</E>, computed with bc    -->
+    <reaction reversible="yes" type="Elementary" id="0006">
+      <equation>C2 [=] 2 C </equation>
+      <rateCoeff>
+        <ModifiedArrhenius>
+           <A>3.7e+11</A>
+           <b>-0.42</b>
+           <E units="K">69900</E>
+        </ModifiedArrhenius>
+      </rateCoeff>
+      <reactants>C2:1</reactants>
+      <products>C:2</products>
+    </reaction>
+
+    <!-- reaction 0007    -->
+    <reaction reversible="yes" type="Elementary" id="0007">
+      <equation>CN [=] C + N </equation>
+      <rateCoeff>
+        <VantHoff>
+           <A>2.5e+11</A>
+           <b>0.40</b>
+           <D>0.050</D>
+           <E units="cal/mol">174240.9</E>
+        </VantHoff>
+      </rateCoeff>
+      <reactants>CN:1</reactants>
+      <products>C:1 N:1</products>
+    </reaction>
+
+<!--Duplicate reactions-->
+    <!-- reaction 0008    -->
+    <reaction reversible="yes" type="Duplicate" id="0008">
+      <equation>N2 [=] 2 N </equation>
+      <rateCoeff>
+        <HercourtEssen>
+           <A>7.e+18</A>
+           <b>-1.6</b>
+        </HercourtEssen>
+        <HercourtEssen>
+           <A>5.e+17</A>
+           <b>0.5</b>
+        </HercourtEssen>
+        <HercourtEssen>
+           <A>3.e+18</A>
+           <b>-0.6</b>
+        </HercourtEssen>
+      </rateCoeff>
+      <reactants>N2:1.0</reactants>
+      <products>N:2.0</products>
+    </reaction>
+
+    <!-- reaction 0009    -->
+    <reaction reversible="yes" type="Duplicate" id="0009">
+      <equation>O2 [=] 2 O </equation>
+      <rateCoeff>
+        <Berthelot>
+           <A>2.e+18</A>
+           <D>-5e-2</D>
+        </Berthelot>
+        <Berthelot>
+           <A>2.e+16</A>
+           <D>0.003</D>
+        </Berthelot>
+      </rateCoeff>
+      <reactants>O2:1.0</reactants>
+      <products>O:2.0</products>
+    </reaction>
+
+    <!-- reaction 0010    -->
+    <reaction reversible="yes" type="Duplicate" id="0010">
+      <equation>NO [=] N + O </equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.e+12</A>
+           <E units="cal/mol">149943.0</E>
+        </Arrhenius>
+        <Arrhenius>
+           <A>3.5e+10</A>
+           <E units="cal/mol">1943.0</E>
+        </Arrhenius>
+        <Arrhenius>
+           <A>1.5e+8</A>
+           <E units="cal/mol">149.0</E>
+        </Arrhenius>
+        <Arrhenius>
+           <A>5.5e+8</A>
+           <E units="cal/mol">943.0</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>NO:1</reactants>
+      <products>N:1 O:1</products>
+    </reaction>
+
+    <!-- reaction 0011    -->
+    <reaction reversible="yes" type="Duplicate" id="0011">
+      <equation>N2 + O [=] NO + N</equation>
+      <rateCoeff>
+        <BerthelotHercourtEssen>
+           <A>5.7e+9</A>
+           <b>0.42</b>
+           <D>-5e-3</D>
+        </BerthelotHercourtEssen>
+        <BerthelotHercourtEssen>
+           <A>7e+7</A>
+           <b>0.5</b>
+           <D>2.5e-5</D>
+        </BerthelotHercourtEssen>
+      </rateCoeff>
+      <reactants>N2:1 O:1</reactants>
+      <products>NO:1 N:1</products>
+    </reaction>
+
+    <!-- reaction 0012    -->
+    <reaction reversible="yes" type="Duplicate" id="0012">
+      <equation>NO + O [=] O2 + N</equation>
+      <rateCoeff>
+        <Kooij>
+           <A>8.4e+09</A>
+           <b>0.40</b>
+           <E units="cal/mol">38526.0</E>
+        </Kooij>
+        <Kooij>
+           <A>4e+07</A>
+           <b>0.50</b>
+           <E units="cal/mol">40500.0</E>
+        </Kooij>
+        <Kooij>
+           <A>5e+10</A>
+           <b>0.10</b>
+           <E units="cal/mol">15000.0</E>
+        </Kooij>
+      </rateCoeff>
+      <reactants>NO:1 O:1</reactants>
+      <products>O2:1 N:1</products>
+    </reaction>
+    
+    <!-- reaction 0013    -->
+    <reaction reversible="yes" type="Duplicate" id="0013">
+      <equation>C2 [=] 2 C </equation>
+      <rateCoeff>
+        <ModifiedArrhenius>
+           <A>3.7e+11</A>
+           <b>-0.42</b>
+           <E units="cal/mol">138812.8</E>
+        </ModifiedArrhenius>
+        <ModifiedArrhenius>
+           <A>5.0e+10</A>
+           <b>1.32</b>
+           <E units="cal/mol">150500.8</E>
+        </ModifiedArrhenius>
+      </rateCoeff>
+      <reactants>C2:1</reactants>
+      <products>C:2</products>
+    </reaction>
+
+    <!-- reaction 0014    -->
+    <reaction reversible="yes" type="Duplicate" id="0014">
+      <equation>CN [=] C + N </equation>
+      <rateCoeff>
+        <VantHoff>
+           <A>2.5e+11</A>
+           <b>0.40</b>
+           <D>-5e-3</D>
+           <E units="cal/mol">174240.9</E>
+        </VantHoff>
+        <VantHoff>
+           <A>5e+10</A>
+           <b>0.50</b>
+           <D>-1.5e-2</D>
+           <E units="cal/mol">4240.9</E>
+        </VantHoff>
+        <VantHoff>
+           <A>3.2e+10</A>
+           <b>1.20</b>
+           <D>-2.5e-5</D>
+           <E units="cal/mol">174.9</E>
+        </VantHoff>
+      </rateCoeff>
+      <reactants>CN:1</reactants>
+      <products>C:1 N:1</products>
+    </reaction>
+
+<!-- ThreeBody -->
+    <!-- reaction 0014    -->
+    <reaction reversible="yes" type="ThreeBody" id="0014">
+      <equation>N2 + M [=] 2 N + M </equation>
+      <rateCoeff>
+        <HercourtEssen>
+           <A>7.e+18</A>
+           <b>-1.6</b>
+        </HercourtEssen>
+        <efficiencies default="1.0">N:4.2857 O:4.2857 </efficiencies>
+      </rateCoeff>
+      <reactants>N2:1.0</reactants>
+      <products>N:2.0</products>
+    </reaction>
+
+    <!-- reaction 0015    -->
+    <reaction reversible="yes" type="ThreeBody" id="0015">
+      <equation>O2 + M [=] 2 O + M </equation>
+      <rateCoeff>
+        <Berthelot>
+           <A>2.e+18</A>
+           <D>-5e-3</D>
+        </Berthelot>
+        <efficiencies default="1.0">N:5.0 O:5.0</efficiencies>
+      </rateCoeff>
+      <reactants>O2:1.0</reactants>
+      <products>O:2.0</products>
+    </reaction>
+
+    <!-- reaction 0016    -->
+    <reaction reversible="yes" type="ThreeBody" id="0016">
+      <equation>NO + M [=] N + O + M </equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.e+12</A>
+           <E units="cal/mol">149943.0</E>
+        </Arrhenius>
+        <efficiencies default="1.0">NO:22 N:22 O:22</efficiencies>
+      </rateCoeff>
+      <reactants>NO:1</reactants>
+      <products>N:1 O:1</products>
+    </reaction>
+
+    <!-- reaction 0017    -->
+    <reaction reversible="yes" type="ThreeBody" id="0017">
+      <equation>N2 + O + M [=] NO + N + M</equation>
+      <rateCoeff>
+        <BerthelotHercourtEssen>
+           <A>5.7e+9</A>
+           <b>0.42</b>
+           <D>-5e-3</D>
+        </BerthelotHercourtEssen>
+        <efficiencies default="1.0">NO:22 N:22 O:22</efficiencies>
+      </rateCoeff>
+      <reactants>N2:1 O:1</reactants>
+      <products>NO:1 N:1</products>
+    </reaction>
+
+    <!-- reaction 0018    -->
+    <reaction reversible="yes" type="ThreeBody" id="0018">
+      <equation>NO + O + M [=] O2 + N + M</equation>
+      <rateCoeff>
+        <Kooij>
+           <A>8.4e+09</A>
+           <b>0.40</b>
+           <E units="cal/mol">38526.0</E>
+        </Kooij>
+        <efficiencies default="1.0">NO:22 N:22 O:22</efficiencies>
+      </rateCoeff>
+      <reactants>NO:1 O:1</reactants>
+      <products>O2:1 N:1</products>
+    </reaction>
+    
+    <!-- reaction 0019    -->
+    <reaction reversible="yes" type="ThreeBody" id="0019">
+      <equation>C2 + M [=] 2 C + M </equation>
+      <rateCoeff>
+        <ModifiedArrhenius>
+           <A>3.7e+11</A>
+           <b>-0.42</b>
+           <E units="cal/mol">138812.8</E>
+        </ModifiedArrhenius>
+        <efficiencies default="1.0"></efficiencies>
+      </rateCoeff>
+      <reactants>C2:1</reactants>
+      <products>C:2</products>
+    </reaction>
+
+    <!-- reaction 0020    -->
+    <reaction reversible="yes" type="ThreeBody" id="0020">
+      <equation>CN + M [=] C + N + M </equation>
+      <rateCoeff>
+        <VantHoff>
+           <A>2.5e+11</A>
+           <b>0.40</b>
+           <D>0.005</D>
+           <E>729372.4</E>
+        </VantHoff>
+        <efficiencies default="1.0"></efficiencies>
+      </rateCoeff>
+      <reactants>CN:1</reactants>
+      <products>C:1 N:1</products>
+    </reaction>
+
+<!-- Lindemann Falloff -->
+    <!-- reaction 0021    -->
+    <reaction reversible="yes" type="LindemannFalloff" id="0021">
+      <equation>N2 [=] 2 N </equation>
+      <rateCoeff>
+        <HercourtEssen name="k0">
+           <A>7.e+18</A>
+           <b>-1.6</b>
+        </HercourtEssen>
+        <HercourtEssen name="k0">
+           <A>5.e+15</A>
+           <b>0.5</b>
+        </HercourtEssen>
+      </rateCoeff>
+      <reactants>N2:1.0</reactants>
+      <products>N:2.0</products>
+    </reaction>
+
+    <!-- reaction 0022    -->
+    <reaction reversible="yes" type="LindemannFalloff" id="0022">
+      <equation>O2 [=] 2 O </equation>
+      <rateCoeff>
+        <Berthelot>
+           <A>2.e+18</A>
+           <D>-5e-3</D>
+        </Berthelot>
+        <Berthelot name="k0">
+           <A>5.e+17</A>
+           <D>-2.5e-5</D>
+        </Berthelot>
+      </rateCoeff>
+      <reactants>O2:1.0</reactants>
+      <products>O:2.0</products>
+    </reaction>
+
+    <!-- reaction 0023    -->
+    <reaction reversible="yes" type="LindemannFalloff" id="0023">
+      <equation>NO [=] N + O </equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.e+12</A>
+           <E units="cal/mol">149943.0</E>
+        </Arrhenius>
+        <Arrhenius>
+           <A>3e+15</A>
+           <E units="cal/mol">200000.0</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>NO:1</reactants>
+      <products>N:1 O:1</products>
+    </reaction>
+
+    <!-- reaction 0024    -->
+    <reaction reversible="yes" type="LindemannFalloff" id="0024">
+      <equation>N2 + O [=] NO + N</equation>
+      <rateCoeff>
+        <BerthelotHercourtEssen>
+           <A>5.7e+9</A>
+           <b>-0.42</b>
+           <D>-5e-3</D>
+        </BerthelotHercourtEssen>
+        <BerthelotHercourtEssen name="k0">
+           <A>5e+9</A>
+           <b>0.6</b>
+           <D>-5e-4</D>
+        </BerthelotHercourtEssen>
+      </rateCoeff>
+      <reactants>N2:1 O:1</reactants>
+      <products>NO:1 N:1</products>
+    </reaction>
+
+    <!-- reaction 0025    -->
+    <reaction reversible="yes" type="LindemannFalloff" id="0025">
+      <equation>NO + O [=] O2 + N</equation>
+      <rateCoeff>
+        <Kooij>
+           <A>8.4e+09</A>
+           <b>0.40</b>
+           <E units="cal/mol">38526.0</E>
+        </Kooij>
+        <Kooij>
+           <A>8.4e+05</A>
+           <b>0.02</b>
+           <E units="cal/mol">3526.0</E>
+        </Kooij>
+      </rateCoeff>
+      <reactants>NO:1 O:1</reactants>
+      <products>O2:1 N:1</products>
+    </reaction>
+    
+    <!-- reaction 0026    -->
+    <reaction reversible="yes" type="LindemannFalloff" id="0026">
+      <equation>C2 [=] 2 C </equation>
+      <rateCoeff>
+        <ModifiedArrhenius>
+           <A>3.7e+11</A>
+           <b>-0.42</b>
+           <E units="cal/mol">138812.8</E>
+        </ModifiedArrhenius>
+        <ModifiedArrhenius>
+           <A>3.7e+12</A>
+           <b>-0.52</b>
+           <E units="cal/mol">135000.8</E>
+        </ModifiedArrhenius>
+      </rateCoeff>
+      <reactants>C2:1</reactants>
+      <products>C:2</products>
+    </reaction>
+
+    <!-- reaction 0027    -->
+    <reaction reversible="yes" type="LindemannFalloff" id="0027">
+      <equation>CN [=] C + N </equation>
+      <rateCoeff>
+        <VantHoff>
+           <A>2.5e+11</A>
+           <b>0.40</b>
+           <D>-0.005</D>
+           <E units="cal/mol">174240.9</E>
+        </VantHoff>
+        <VantHoff name="k0">
+           <A>5e+10</A>
+           <b>-0.10</b>
+           <D>1.5e-3</D>
+           <E units="cal/mol">150240.9</E>
+        </VantHoff>
+      </rateCoeff>
+      <reactants>CN:1</reactants>
+      <products>C:1 N:1</products>
+    </reaction>
+
+<!-- Troe Falloff -->
+    <!-- reaction 0028    -->
+    <reaction reversible="yes" type="TroeFalloff" id="0028">
+      <equation>N2 [=] 2 N </equation>
+      <rateCoeff>
+        <HercourtEssen name="k0">
+           <A>7.e+18</A>
+           <b>-1.6</b>
+        </HercourtEssen>
+        <HercourtEssen>
+           <A>5.e+15</A>
+           <b>0.5</b>
+        </HercourtEssen>
+        <Troe>
+          <alpha> 0.562</alpha> 
+          <T1> 5836 </T1> 
+          <T2> 8552 </T2> 
+          <T3> 91   </T3> 
+        </Troe>
+      </rateCoeff>
+      <reactants>N2:1.0</reactants>
+      <products>N:2.0</products>
+    </reaction>
+
+    <!-- reaction 0029    -->
+    <reaction reversible="yes" type="TroeFalloff" id="0029">
+      <equation>O2 [=] 2 O </equation>
+      <rateCoeff>
+        <Berthelot>
+           <A>2.e+18</A>
+           <D>-5e-3</D>
+        </Berthelot>
+        <Berthelot name="k0">
+           <A>5.e+17</A>
+           <D>-2.5e-5</D>
+        </Berthelot>
+        <Troe>
+          <alpha> 0.562</alpha> 
+          <T1> 5836 </T1> 
+          <T2> 8552 </T2> 
+          <T3> 91   </T3> 
+        </Troe>
+      </rateCoeff>
+      <reactants>O2:1.0</reactants>
+      <products>O:2.0</products>
+    </reaction>
+
+    <!-- reaction 0030    -->
+    <reaction reversible="yes" type="TroeFalloff" id="0030">
+      <equation>NO [=] N + O </equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.e+12</A>
+           <E units="cal/mol">149943.0</E>
+        </Arrhenius>
+        <Arrhenius>
+           <A>3e+15</A>
+           <E units="cal/mol">200000.0</E>
+        </Arrhenius>
+        <Troe>
+          <alpha> 0.562</alpha> 
+          <T1> 5836 </T1> 
+          <T2> 8552 </T2> 
+          <T3> 91   </T3> 
+        </Troe>
+      </rateCoeff>
+      <reactants>NO:1</reactants>
+      <products>N:1 O:1</products>
+    </reaction>
+
+    <!-- reaction 0031    -->
+    <reaction reversible="yes" type="TroeFalloff" id="0031">
+      <equation>N2 + O [=] NO + N</equation>
+      <rateCoeff>
+        <BerthelotHercourtEssen>
+           <A>5.7e+9</A>
+           <b>-0.42</b>
+           <D>-5e-3</D>
+        </BerthelotHercourtEssen>
+        <BerthelotHercourtEssen name="k0">
+           <A>5e+9</A>
+           <b>0.6</b>
+           <D>-5e-4</D>
+        </BerthelotHercourtEssen>
+        <Troe>
+          <alpha> 0.562</alpha> 
+          <T1> 5836 </T1> 
+          <T2> 8552 </T2> 
+          <T3> 91   </T3> 
+        </Troe>
+      </rateCoeff>
+      <reactants>N2:1 O:1</reactants>
+      <products>NO:1 N:1</products>
+    </reaction>
+
+    <!-- reaction 0032    -->
+    <reaction reversible="yes" type="TroeFalloff" id="0032">
+      <equation>NO + O [=] O2 + N</equation>
+      <rateCoeff>
+        <Kooij name="k0">
+           <A>8.4e+09</A>
+           <b>0.40</b>
+           <E units="cal/mol">38526.0</E>
+        </Kooij>
+        <Kooij>
+           <A>8.4e+05</A>
+           <b>0.02</b>
+           <E units="cal/mol">3526.0</E>
+        </Kooij>
+        <Troe>
+          <alpha> 0.562</alpha> 
+          <T1> 5836 </T1> 
+          <T2> 8552 </T2> 
+          <T3> 91   </T3> 
+        </Troe>
+      </rateCoeff>
+      <reactants>NO:1 O:1</reactants>
+      <products>O2:1 N:1</products>
+    </reaction>
+    
+    <!-- reaction 0033    -->
+    <reaction reversible="yes" type="TroeFalloff" id="0033">
+      <equation>C2 [=] 2 C </equation>
+      <rateCoeff>
+        <ModifiedArrhenius>
+           <A>3.7e+11</A>
+           <b>-0.42</b>
+           <E units="cal/mol">138812.8</E>
+        </ModifiedArrhenius>
+        <ModifiedArrhenius>
+           <A>3.7e+12</A>
+           <b>-0.52</b>
+           <E units="cal/mol">135000.8</E>
+        </ModifiedArrhenius>
+        <Troe>
+          <alpha> 0.562</alpha> 
+          <T1> 5836 </T1> 
+          <T2> 8552 </T2> 
+          <T3> 91   </T3> 
+        </Troe>
+      </rateCoeff>
+      <reactants>C2:1</reactants>
+      <products>C:2</products>
+    </reaction>
+
+    <!-- reaction 0034    -->
+    <reaction reversible="yes" type="TroeFalloff" id="0034">
+      <equation>CN [=] C + N </equation>
+      <rateCoeff>
+        <VantHoff>
+           <A>2.5e+11</A>
+           <b>0.40</b>
+           <D>-0.005</D>
+           <E units="cal/mol">174240.9</E>
+        </VantHoff>
+        <VantHoff name="k0">
+           <A>5e+10</A>
+           <b>-0.10</b>
+           <D>1.5e-3</D>
+           <E units="cal/mol">150240.9</E>
+        </VantHoff>
+        <Troe>
+          <alpha> 0.562</alpha> 
+          <T1> 5836 </T1> 
+          <T2> 8552 </T2> 
+          <T3> 91   </T3> 
+        </Troe>
+      </rateCoeff>
+      <reactants>CN:1</reactants>
+      <products>C:1 N:1</products>
+    </reaction>
+
+    <!-- reaction 0035    -->
+    <reaction reversible="yes" type="Elementary" id="0035">
+      <equation>CH4 [=] CH3 H </equation>
+      <rateCoeff>
+        <photochemistry>
+           <lambda units="ang">1.0 23.6 31.6 39.8 40.0 42.7 63.0 100.0 158.0 250.0 278.0 303.7 358.4 363.0 374.0 418.8 434.0 452.0 459.6 475.0 508.4 525.8 529.5 533.6 539.0 555.0 574.7 580.7 599.6 604.2 616.3 629.3 637.3 660.3 661.9 671.4 671.6 679.4 685.8 688.4 698.5 718.5 746.4 764.0 769.3 773.0 796.7 806.0 827.0 833.0 840.0 843.8 850.6 858.3 871.1 875.5 878.7 883.1 887.4 906.0 916.0 919.8 932.1 945.0 951.9 954.8 955.5 958.5 961.5 977.0 978.0 979.8 988.8 989.8 991.5 1025.0 1036.3 1037.0 1065.9 1071.8 1084.6 1084.9 1085.5 1134.4 1135.0 1152.0 1152.1 1175.5 1176.4 1176.5 1183.0 1184.5 1189.0 1199.5 1200.7 1200.7 1206.9 1215.5 1215.7 1217.6 1243.3 1275.1 1302.2 1304.9 1306.0 1324.0 1330.0 1336.0 1362.0 1370.0 1380.0 1390.0 1400.0 1410.0 1420.0 1430.0 1440.0 1450.0 1460.0 1470.0 1480.0 1490.0 1500.0 1510.0 1520.0 1530.0 1540.0 1550.0 1560.0 1570.0 1580.0 1590.0 1600.0 1850.0 2100.0 2373.0 2770.0</lambda>
+           <cross_section units="cm2/ang">1.00E-21 2.60E-19 5.30E-19 1.00E-18 5.90E-20 1.30E-18 1.50E-19 3.70E-19 1.30E-18 3.70E-18 4.00E-18 4.00E-18 1.17E-17 9.80E-18 1.31E-17 1.68E-17 1.61E-17 1.96E-17 1.82E-17 1.97E-17 2.30E-17 2.38E-17 2.16E-17 2.12E-17 2.50E-17 2.50E-17 2.97E-17 2.79E-17 3.13E-17 2.98E-17 3.41E-17 3.52E-17 3.53E-17 3.66E-17 3.56E-17 3.78E-17 3.96E-17 3.61E-17 3.94E-17 4.04E-17 3.78E-17 4.20E-17 4.14E-17 4.77E-17 4.30E-17 4.62E-17 4.74E-17 4.70E-17 4.82E-17 4.85E-17 4.75E-17 5.20E-17 5.10E-17 5.12E-17 5.24E-17 5.07E-17 5.10E-17 5.10E-17 5.20E-17 4.95E-17 4.65E-17 5.17E-17 5.20E-17 5.46E-17 5.60E-17 5.60E-17 5.60E-17 6.00E-17 5.60E-17 4.40E-17 4.10E-17 4.10E-17 3.36E-17 3.80E-17 2.91E-17  3.30E-17  3.10E-17  2.95E-17  3.10E-17  3.20E-17  2.70E-17  2.62E-17  2.91E-17  1.75E-17  1.89E-17  1.84E-17  1.89E-17  2.30E-17  2.51E-17  1.70E-17  2.30E-17  2.00E-17  1.61E-17  1.90E-17  1.75E-17  1.90E-17  1.80E-17  1.75E-17  1.60E-17  1.90E-17  1.80E-17  1.60E-17  1.40E-17  1.40E-17  1.40E-17  1.30E-17  1.10E-17  1.00E-17  6.85E-18  3.20E-18  2.20E-18  1.20E-18  6.80E-19  3.60E-19  1.60E-19  7.80E-20  2.20E-20  8.00E-21  2.80E-21  7.90E-22  2.80E-22  8.60E-23  3.80E-23  2.30E-23  1.60E-23  1.20E-23  9.20E-24  8.10E-24  7.40E-24  7.10E-24  6.80E-24  6.40E-24  6.00E-24  4.00E-24  1.00E-25  3.00E-26  1.00E-28</cross_section>
+        </photochemistry>
+      </rateCoeff>
+      <reactants>CH4:1.0</reactants>
+      <products>CH3:1.0 H:1</products>
+    </reaction>
+
+    <!-- reaction 0036    -->
+    <reaction reversible="yes" type="Elementary" id="0036">
+      <equation>CH4 [=] CH3 H </equation>
+      <rateCoeff>
+        <Constant>
+           <A>2.5e11</A>
+        </Constant>
+      </rateCoeff>
+      <reactants>CH4:1.0</reactants>
+      <products>CH3:1.0 H:1</products>
+    </reaction>
+  </reactionData>
+
+</ctml>

--- a/test/input_files/fail_parsing_2.xml
+++ b/test/input_files/fail_parsing_2.xml
@@ -1,0 +1,743 @@
+<?xml version="1.0"?>
+<!-- Reaction rate parameters from: -->
+<!-- Park, Chul. "Review of Chemical-Kinetic Problems of Future NASA Missions, I : Earth Entries." -->
+<!-- AIAA Journal of Thermophysics and Heat Transfer, Vol. 7, No. 3, July-Sept 1993, pp. 385-397. -->
+
+<!-- park_jaffe_partridge_JTHT_2001 - Park, Jaffe, Partridge "Chemical-Kinetic Parameters of Hyperbolic Earth Entry," JTHT, Vol 15, No 1, pp 76-90, 2001. -->
+<!-- Olynick_Chen_Tauber_SRC_Sizing - Olynick, Chen, Tauber, "Forebody TPS Sizing with Radiation and Ablation for the Stardust Sample Return Capsule," AIAA-1997-2474  -->
+
+<ctml>
+  <validate reactions="yes" species="yes"/>
+
+  <!-- phase air5sp     -->
+  <phase dim="3" id="air5sp">
+    <elementArray datasrc="elements.xml">N O</elementArray>
+    <speciesArray datasrc="#FINS_r13324">N2 O2 NO N O</speciesArray>
+    <reactionArray datasrc="#park_jaffe_partridge_JTHT_2001">
+      <skip species="undeclared"/>
+    </reactionArray>
+    <state>
+      <temperature units="K">300.0</temperature>
+      <pressure units="Pa">101325.0</pressure>
+      <moleFractions>O2:0.22, N2:0.78</moleFractions>
+    </state>
+    <thermo model="IdealGas"/>
+    <kinetics model="GasKinetics"/>
+    <transport model="Pecos"/>
+  </phase>
+
+
+  <!-- park_jaffe_partridge_JTHT_2001 - Park, Jaffe, Partridge "Chemical-Kinetic Parameters of Hyperbolic Earth Entry," JTHT, Vol 15, No 1, pp 76-90, 2001. -->
+  <reactionData id="park_jaffe_partridge_JTHT_2001">
+
+<!--Elementary reactions-->
+    <!-- reaction 0001    -->
+    <reaction reversible="yes" type="Elementary" id="0001">
+      <equation>N2 [=] 2 N </equation>
+      <rateCoeff>
+        <HercourtEssen>
+           <A>7.e+18</A>
+           <b>-1.6</b>
+        </HercourtEssen>
+      </rateCoeff>
+      <reactants>N2:1.0</reactants>
+      <products>N:2.0</products>
+    </reaction>
+
+    <!-- reaction 0002    -->
+    <reaction reversible="yes" type="Elementary" id="0002">
+      <equation>O2 [=] 2 O </equation>
+      <rateCoeff>
+        <Berthelot>
+           <A>2.e+18</A>
+           <D>-5e-3</D>
+        </Berthelot>
+      </rateCoeff>
+      <reactants>O2:1.0</reactants>
+      <products>O:2.0</products>
+    </reaction>
+
+    <!-- reaction 0003    -->
+    <reaction reversible="yes" type="Elementary" id="0003">
+      <equation>NO [=] N + O </equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.e+12</A>
+           <E units="cal/mol">149943.0</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>NO:1</reactants>
+      <products>N:1 O:1</products>
+    </reaction>
+
+    <reaction reversible="yes" type="Elementary" id="0003">
+      <equation>NO [=] N + O </equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.e+12</A>
+           <b>0.42</b>
+           <E units="cal/mol">149943.0</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>NO:1</reactants>
+      <products>N:1 O:1</products>
+    </reaction>
+
+    <!-- reaction 0004    -->
+    <reaction reversible="yes" id="0004">
+      <equation>N2 + O [=] NO + N</equation>
+      <rateCoeff>
+        <BerthelotHercourtEssen>
+           <A>5.7e+9</A>
+           <b>0.42</b>
+           <D>-5e-3</D>
+        </BerthelotHercourtEssen>
+      </rateCoeff>
+      <reactants>N2:1 O:1</reactants>
+      <products>NO:1 N:1</products>
+    </reaction>
+
+    <!-- reaction 0005    -->
+    <reaction reversible="yes" id="0005">
+      <equation>NO + O [=] O2 + N</equation>
+      <rateCoeff>
+        <Kooij>
+           <A>8.4e+09</A>
+           <b>0.40</b>
+           <E units="cal/mol">38526.0</E>
+        </Kooij>
+      </rateCoeff>
+      <reactants>NO:1 O:1</reactants>
+      <products>O2:1 N:1</products>
+    </reaction>
+
+    <!-- reaction 0005bis -->
+    <reaction reversible="yes" id="0005">
+      <equation>NO + O [=] O2 + N</equation>
+      <rateCoeff>
+        <Kooij>
+           <A>8.4e+09</A>
+           <b>0.00</b>
+           <E units="cal/mol">38526.0</E>
+        </Kooij>
+      </rateCoeff>
+      <reactants>NO:1 O:1</reactants>
+      <products>O2:1 N:1</products>
+    </reaction>
+    
+    
+    <!-- reaction 0006 <E units="cal/mol"> 138812.8</E>, computed with bc    -->
+    <reaction reversible="yes" type="Elementary" id="0006">
+      <equation>C2 [=] 2 C </equation>
+      <rateCoeff>
+        <ModifiedArrhenius>
+           <A>3.7e+11</A>
+           <b>-0.42</b>
+           <E units="K">69900</E>
+        </ModifiedArrhenius>
+      </rateCoeff>
+      <reactants>C2:1</reactants>
+      <products>C:2</products>
+    </reaction>
+
+    <!-- reaction 0007    -->
+    <reaction reversible="yes" type="Elementary" id="0007">
+      <equation>CN [=] C + N </equation>
+      <rateCoeff>
+        <VantHoff>
+           <A>2.5e+11</A>
+           <b>0.40</b>
+           <D>0.050</D>
+           <E units="cal/mol">174240.9</E>
+        </VantHoff>
+      </rateCoeff>
+      <reactants>CN:1</reactants>
+      <products>C:1 N:1</products>
+    </reaction>
+
+<!--Duplicate reactions-->
+    <!-- reaction 0008    -->
+    <reaction reversible="yes" type="Duplicate" id="0008">
+      <equation>N2 [=] 2 N </equation>
+      <rateCoeff>
+        <HercourtEssen>
+           <A>7.e+18</A>
+           <b>-1.6</b>
+        </HercourtEssen>
+        <HercourtEssen>
+           <A>5.e+17</A>
+           <b>0.5</b>
+        </HercourtEssen>
+        <HercourtEssen>
+           <A>3.e+18</A>
+           <b>-0.6</b>
+        </HercourtEssen>
+      </rateCoeff>
+      <reactants>N2:1.0</reactants>
+      <products>N:2.0</products>
+    </reaction>
+
+    <!-- reaction 0009    -->
+    <reaction reversible="yes" type="Duplicate" id="0009">
+      <equation>O2 [=] 2 O </equation>
+      <rateCoeff>
+        <Berthelot>
+           <A>2.e+18</A>
+           <D>-5e-2</D>
+        </Berthelot>
+        <Berthelot>
+           <A>2.e+16</A>
+           <D>0.003</D>
+        </Berthelot>
+      </rateCoeff>
+      <reactants>O2:1.0</reactants>
+      <products>O:2.0</products>
+    </reaction>
+
+    <!-- reaction 0010    -->
+    <reaction reversible="yes" type="Duplicate" id="0010">
+      <equation>NO [=] N + O </equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.e+12</A>
+           <E units="cal/mol">149943.0</E>
+        </Arrhenius>
+        <Arrhenius>
+           <A>3.5e+10</A>
+           <E units="cal/mol">1943.0</E>
+        </Arrhenius>
+        <Arrhenius>
+           <A>1.5e+8</A>
+           <E units="cal/mol">149.0</E>
+        </Arrhenius>
+        <Arrhenius>
+           <A>5.5e+8</A>
+           <E units="cal/mol">943.0</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>NO:1</reactants>
+      <products>N:1 O:1</products>
+    </reaction>
+
+    <!-- reaction 0011    -->
+    <reaction reversible="yes" type="Duplicate" id="0011">
+      <equation>N2 + O [=] NO + N</equation>
+      <rateCoeff>
+        <BerthelotHercourtEssen>
+           <A>5.7e+9</A>
+           <b>0.42</b>
+           <D>-5e-3</D>
+        </BerthelotHercourtEssen>
+        <BerthelotHercourtEssen>
+           <A>7e+7</A>
+           <b>0.5</b>
+           <D>2.5e-5</D>
+        </BerthelotHercourtEssen>
+      </rateCoeff>
+      <reactants>N2:1 O:1</reactants>
+      <products>NO:1 N:1</products>
+    </reaction>
+
+    <!-- reaction 0012    -->
+    <reaction reversible="yes" type="Duplicate" id="0012">
+      <equation>NO + O [=] O2 + N</equation>
+      <rateCoeff>
+        <Kooij>
+           <A>8.4e+09</A>
+           <b>0.40</b>
+           <E units="cal/mol">38526.0</E>
+        </Kooij>
+        <Kooij>
+           <A>4e+07</A>
+           <b>0.50</b>
+           <E units="cal/mol">40500.0</E>
+        </Kooij>
+        <Kooij>
+           <A>5e+10</A>
+           <b>0.10</b>
+           <E units="cal/mol">15000.0</E>
+        </Kooij>
+      </rateCoeff>
+      <reactants>NO:1 O:1</reactants>
+      <products>O2:1 N:1</products>
+    </reaction>
+    
+    <!-- reaction 0013    -->
+    <reaction reversible="yes" type="Duplicate" id="0013">
+      <equation>C2 [=] 2 C </equation>
+      <rateCoeff>
+        <ModifiedArrhenius>
+           <A>3.7e+11</A>
+           <b>-0.42</b>
+           <E units="cal/mol">138812.8</E>
+        </ModifiedArrhenius>
+        <ModifiedArrhenius>
+           <A>5.0e+10</A>
+           <b>1.32</b>
+           <E units="cal/mol">150500.8</E>
+        </ModifiedArrhenius>
+      </rateCoeff>
+      <reactants>C2:1</reactants>
+      <products>C:2</products>
+    </reaction>
+
+    <!-- reaction 0014    -->
+    <reaction reversible="yes" type="Duplicate" id="0014">
+      <equation>CN [=] C + N </equation>
+      <rateCoeff>
+        <VantHoff>
+           <A>2.5e+11</A>
+           <b>0.40</b>
+           <D>-5e-3</D>
+           <E units="cal/mol">174240.9</E>
+        </VantHoff>
+        <VantHoff>
+           <A>5e+10</A>
+           <b>0.50</b>
+           <D>-1.5e-2</D>
+           <E units="cal/mol">4240.9</E>
+        </VantHoff>
+        <VantHoff>
+           <A>3.2e+10</A>
+           <b>1.20</b>
+           <D>-2.5e-5</D>
+           <E units="cal/mol">174.9</E>
+        </VantHoff>
+      </rateCoeff>
+      <reactants>CN:1</reactants>
+      <products>C:1 N:1</products>
+    </reaction>
+
+<!-- ThreeBody -->
+    <!-- reaction 0014    -->
+    <reaction reversible="yes" type="ThreeBody" id="0014">
+      <equation>N2 + M [=] 2 N + M </equation>
+      <rateCoeff>
+        <HercourtEssen>
+           <A>7.e+18</A>
+           <b>-1.6</b>
+        </HercourtEssen>
+        <efficiencies default="1.0">N:4.2857 O:4.2857 </efficiencies>
+      </rateCoeff>
+      <reactants>N2:1.0</reactants>
+      <products>N:2.0</products>
+    </reaction>
+
+    <!-- reaction 0015    -->
+    <reaction reversible="yes" type="ThreeBody" id="0015">
+      <equation>O2 + M [=] 2 O + M </equation>
+      <rateCoeff>
+        <Berthelot>
+           <A>2.e+18</A>
+           <D>-5e-3</D>
+        </Berthelot>
+        <efficiencies default="1.0">N:5.0 O:5.0</efficiencies>
+      </rateCoeff>
+      <reactants>O2:1.0</reactants>
+      <products>O:2.0</products>
+    </reaction>
+
+    <!-- reaction 0016    -->
+    <reaction reversible="yes" type="ThreeBody" id="0016">
+      <equation>NO + M [=] N + O + M </equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.e+12</A>
+           <E units="cal/mol">149943.0</E>
+        </Arrhenius>
+        <efficiencies default="1.0">NO:22 N:22 O:22</efficiencies>
+      </rateCoeff>
+      <reactants>NO:1</reactants>
+      <products>N:1 O:1</products>
+    </reaction>
+
+    <!-- reaction 0017    -->
+    <reaction reversible="yes" type="ThreeBody" id="0017">
+      <equation>N2 + O + M [=] NO + N + M</equation>
+      <rateCoeff>
+        <BerthelotHercourtEssen>
+           <A>5.7e+9</A>
+           <b>0.42</b>
+           <D>-5e-3</D>
+        </BerthelotHercourtEssen>
+        <efficiencies default="1.0">NO:22 N:22 O:22</efficiencies>
+      </rateCoeff>
+      <reactants>N2:1 O:1</reactants>
+      <products>NO:1 N:1</products>
+    </reaction>
+
+    <!-- reaction 0018    -->
+    <reaction reversible="yes" type="ThreeBody" id="0018">
+      <equation>NO + O + M [=] O2 + N + M</equation>
+      <rateCoeff>
+        <Kooij>
+           <A>8.4e+09</A>
+           <b>0.40</b>
+           <E units="cal/mol">38526.0</E>
+        </Kooij>
+        <efficiencies default="1.0">NO:22 N:22 O:22</efficiencies>
+      </rateCoeff>
+      <reactants>NO:1 O:1</reactants>
+      <products>O2:1 N:1</products>
+    </reaction>
+    
+    <!-- reaction 0019    -->
+    <reaction reversible="yes" type="ThreeBody" id="0019">
+      <equation>C2 + M [=] 2 C + M </equation>
+      <rateCoeff>
+        <ModifiedArrhenius>
+           <A>3.7e+11</A>
+           <b>-0.42</b>
+           <E units="cal/mol">138812.8</E>
+        </ModifiedArrhenius>
+        <efficiencies default="1.0"></efficiencies>
+      </rateCoeff>
+      <reactants>C2:1</reactants>
+      <products>C:2</products>
+    </reaction>
+
+    <!-- reaction 0020    -->
+    <reaction reversible="yes" type="ThreeBody" id="0020">
+      <equation>CN + M [=] C + N + M </equation>
+      <rateCoeff>
+        <VantHoff>
+           <A>2.5e+11</A>
+           <b>0.40</b>
+           <D>0.005</D>
+           <E>729372.4</E>
+        </VantHoff>
+        <efficiencies default="1.0"></efficiencies>
+      </rateCoeff>
+      <reactants>CN:1</reactants>
+      <products>C:1 N:1</products>
+    </reaction>
+
+<!-- Lindemann Falloff -->
+    <!-- reaction 0021    -->
+    <reaction reversible="yes" type="LindemannFalloff" id="0021">
+      <equation>N2 [=] 2 N </equation>
+      <rateCoeff>
+        <HercourtEssen name="k0">
+           <A>7.e+18</A>
+           <b>-1.6</b>
+        </HercourtEssen>
+        <HercourtEssen>
+           <A>5.e+15</A>
+           <b>0.5</b>
+        </HercourtEssen>
+      </rateCoeff>
+      <reactants>N2:1.0</reactants>
+      <products>N:2.0</products>
+    </reaction>
+
+    <!-- reaction 0022    -->
+    <reaction reversible="yes" type="LindemannFalloff" id="0022">
+      <equation>O2 [=] 2 O </equation>
+      <rateCoeff>
+        <Berthelot>
+           <A>2.e+18</A>
+           <D>-5e-3</D>
+        </Berthelot>
+        <Berthelot name="k0">
+           <A>5.e+17</A>
+           <D>-2.5e-5</D>
+        </Berthelot>
+      </rateCoeff>
+      <reactants>O2:1.0</reactants>
+      <products>O:2.0</products>
+    </reaction>
+
+    <!-- reaction 0023    -->
+    <reaction reversible="yes" type="LindemannFalloff" id="0023">
+      <equation>NO [=] N + O </equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.e+12</A>
+           <E units="cal/mol">149943.0</E>
+        </Arrhenius>
+        <Arrhenius>
+           <A>3e+15</A>
+           <E units="cal/mol">200000.0</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>NO:1</reactants>
+      <products>N:1 O:1</products>
+    </reaction>
+
+    <!-- reaction 0024    -->
+    <reaction reversible="yes" type="LindemannFalloff" id="0024">
+      <equation>N2 + O [=] NO + N</equation>
+      <rateCoeff>
+        <BerthelotHercourtEssen name="k1">
+           <A>5.7e+9</A>
+           <b>-0.42</b>
+           <D>-5e-3</D>
+        </BerthelotHercourtEssen>
+        <BerthelotHercourtEssen>
+           <A>5e+9</A>
+           <b>0.6</b>
+           <D>-5e-4</D>
+        </BerthelotHercourtEssen>
+      </rateCoeff>
+      <reactants>N2:1 O:1</reactants>
+      <products>NO:1 N:1</products>
+    </reaction>
+
+    <!-- reaction 0025    -->
+    <reaction reversible="yes" type="LindemannFalloff" id="0025">
+      <equation>NO + O [=] O2 + N</equation>
+      <rateCoeff>
+        <Kooij>
+           <A>8.4e+09</A>
+           <b>0.40</b>
+           <E units="cal/mol">38526.0</E>
+        </Kooij>
+        <Kooij>
+           <A>8.4e+05</A>
+           <b>0.02</b>
+           <E units="cal/mol">3526.0</E>
+        </Kooij>
+      </rateCoeff>
+      <reactants>NO:1 O:1</reactants>
+      <products>O2:1 N:1</products>
+    </reaction>
+    
+    <!-- reaction 0026    -->
+    <reaction reversible="yes" type="LindemannFalloff" id="0026">
+      <equation>C2 [=] 2 C </equation>
+      <rateCoeff>
+        <ModifiedArrhenius>
+           <A>3.7e+11</A>
+           <b>-0.42</b>
+           <E units="cal/mol">138812.8</E>
+        </ModifiedArrhenius>
+        <ModifiedArrhenius>
+           <A>3.7e+12</A>
+           <b>-0.52</b>
+           <E units="cal/mol">135000.8</E>
+        </ModifiedArrhenius>
+      </rateCoeff>
+      <reactants>C2:1</reactants>
+      <products>C:2</products>
+    </reaction>
+
+    <!-- reaction 0027    -->
+    <reaction reversible="yes" type="LindemannFalloff" id="0027">
+      <equation>CN [=] C + N </equation>
+      <rateCoeff>
+        <VantHoff>
+           <A>2.5e+11</A>
+           <b>0.40</b>
+           <D>-0.005</D>
+           <E units="cal/mol">174240.9</E>
+        </VantHoff>
+        <VantHoff name="k0">
+           <A>5e+10</A>
+           <b>-0.10</b>
+           <D>1.5e-3</D>
+           <E units="cal/mol">150240.9</E>
+        </VantHoff>
+      </rateCoeff>
+      <reactants>CN:1</reactants>
+      <products>C:1 N:1</products>
+    </reaction>
+
+<!-- Troe Falloff -->
+    <!-- reaction 0028    -->
+    <reaction reversible="yes" type="TroeFalloff" id="0028">
+      <equation>N2 [=] 2 N </equation>
+      <rateCoeff>
+        <HercourtEssen name="k0">
+           <A>7.e+18</A>
+           <b>-1.6</b>
+        </HercourtEssen>
+        <HercourtEssen>
+           <A>5.e+15</A>
+           <b>0.5</b>
+        </HercourtEssen>
+        <Troe>
+          <alpha> 0.562</alpha> 
+          <T1> 5836 </T1> 
+          <T2> 8552 </T2> 
+          <T3> 91   </T3> 
+        </Troe>
+      </rateCoeff>
+      <reactants>N2:1.0</reactants>
+      <products>N:2.0</products>
+    </reaction>
+
+    <!-- reaction 0029    -->
+    <reaction reversible="yes" type="TroeFalloff" id="0029">
+      <equation>O2 [=] 2 O </equation>
+      <rateCoeff>
+        <Berthelot>
+           <A>2.e+18</A>
+           <D>-5e-3</D>
+        </Berthelot>
+        <Berthelot name="k0">
+           <A>5.e+17</A>
+           <D>-2.5e-5</D>
+        </Berthelot>
+        <Troe>
+          <alpha> 0.562</alpha> 
+          <T1> 5836 </T1> 
+          <T2> 8552 </T2> 
+          <T3> 91   </T3> 
+        </Troe>
+      </rateCoeff>
+      <reactants>O2:1.0</reactants>
+      <products>O:2.0</products>
+    </reaction>
+
+    <!-- reaction 0030    -->
+    <reaction reversible="yes" type="TroeFalloff" id="0030">
+      <equation>NO [=] N + O </equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.e+12</A>
+           <E units="cal/mol">149943.0</E>
+        </Arrhenius>
+        <Arrhenius>
+           <A>3e+15</A>
+           <E units="cal/mol">200000.0</E>
+        </Arrhenius>
+        <Troe>
+          <alpha> 0.562</alpha> 
+          <T1> 5836 </T1> 
+          <T2> 8552 </T2> 
+          <T3> 91   </T3> 
+        </Troe>
+      </rateCoeff>
+      <reactants>NO:1</reactants>
+      <products>N:1 O:1</products>
+    </reaction>
+
+    <!-- reaction 0031    -->
+    <reaction reversible="yes" type="TroeFalloff" id="0031">
+      <equation>N2 + O [=] NO + N</equation>
+      <rateCoeff>
+        <BerthelotHercourtEssen>
+           <A>5.7e+9</A>
+           <b>-0.42</b>
+           <D>-5e-3</D>
+        </BerthelotHercourtEssen>
+        <BerthelotHercourtEssen name="k0">
+           <A>5e+9</A>
+           <b>0.6</b>
+           <D>-5e-4</D>
+        </BerthelotHercourtEssen>
+        <Troe>
+          <alpha> 0.562</alpha> 
+          <T1> 5836 </T1> 
+          <T2> 8552 </T2> 
+          <T3> 91   </T3> 
+        </Troe>
+      </rateCoeff>
+      <reactants>N2:1 O:1</reactants>
+      <products>NO:1 N:1</products>
+    </reaction>
+
+    <!-- reaction 0032    -->
+    <reaction reversible="yes" type="TroeFalloff" id="0032">
+      <equation>NO + O [=] O2 + N</equation>
+      <rateCoeff>
+        <Kooij name="k0">
+           <A>8.4e+09</A>
+           <b>0.40</b>
+           <E units="cal/mol">38526.0</E>
+        </Kooij>
+        <Kooij>
+           <A>8.4e+05</A>
+           <b>0.02</b>
+           <E units="cal/mol">3526.0</E>
+        </Kooij>
+        <Troe>
+          <alpha> 0.562</alpha> 
+          <T1> 5836 </T1> 
+          <T2> 8552 </T2> 
+          <T3> 91   </T3> 
+        </Troe>
+      </rateCoeff>
+      <reactants>NO:1 O:1</reactants>
+      <products>O2:1 N:1</products>
+    </reaction>
+    
+    <!-- reaction 0033    -->
+    <reaction reversible="yes" type="TroeFalloff" id="0033">
+      <equation>C2 [=] 2 C </equation>
+      <rateCoeff>
+        <ModifiedArrhenius>
+           <A>3.7e+11</A>
+           <b>-0.42</b>
+           <E units="cal/mol">138812.8</E>
+        </ModifiedArrhenius>
+        <ModifiedArrhenius>
+           <A>3.7e+12</A>
+           <b>-0.52</b>
+           <E units="cal/mol">135000.8</E>
+        </ModifiedArrhenius>
+        <Troe>
+          <alpha> 0.562</alpha> 
+          <T1> 5836 </T1> 
+          <T2> 8552 </T2> 
+          <T3> 91   </T3> 
+        </Troe>
+      </rateCoeff>
+      <reactants>C2:1</reactants>
+      <products>C:2</products>
+    </reaction>
+
+    <!-- reaction 0034    -->
+    <reaction reversible="yes" type="TroeFalloff" id="0034">
+      <equation>CN [=] C + N </equation>
+      <rateCoeff>
+        <VantHoff>
+           <A>2.5e+11</A>
+           <b>0.40</b>
+           <D>-0.005</D>
+           <E units="cal/mol">174240.9</E>
+        </VantHoff>
+        <VantHoff name="k0">
+           <A>5e+10</A>
+           <b>-0.10</b>
+           <D>1.5e-3</D>
+           <E units="cal/mol">150240.9</E>
+        </VantHoff>
+        <Troe>
+          <alpha> 0.562</alpha> 
+          <T1> 5836 </T1> 
+          <T2> 8552 </T2> 
+          <T3> 91   </T3> 
+        </Troe>
+      </rateCoeff>
+      <reactants>CN:1</reactants>
+      <products>C:1 N:1</products>
+    </reaction>
+
+    <!-- reaction 0035    -->
+    <reaction reversible="yes" type="Elementary" id="0035">
+      <equation>CH4 [=] CH3 H </equation>
+      <rateCoeff>
+        <photochemistry>
+           <lambda units="ang">1.0 23.6 31.6 39.8 40.0 42.7 63.0 100.0 158.0 250.0 278.0 303.7 358.4 363.0 374.0 418.8 434.0 452.0 459.6 475.0 508.4 525.8 529.5 533.6 539.0 555.0 574.7 580.7 599.6 604.2 616.3 629.3 637.3 660.3 661.9 671.4 671.6 679.4 685.8 688.4 698.5 718.5 746.4 764.0 769.3 773.0 796.7 806.0 827.0 833.0 840.0 843.8 850.6 858.3 871.1 875.5 878.7 883.1 887.4 906.0 916.0 919.8 932.1 945.0 951.9 954.8 955.5 958.5 961.5 977.0 978.0 979.8 988.8 989.8 991.5 1025.0 1036.3 1037.0 1065.9 1071.8 1084.6 1084.9 1085.5 1134.4 1135.0 1152.0 1152.1 1175.5 1176.4 1176.5 1183.0 1184.5 1189.0 1199.5 1200.7 1200.7 1206.9 1215.5 1215.7 1217.6 1243.3 1275.1 1302.2 1304.9 1306.0 1324.0 1330.0 1336.0 1362.0 1370.0 1380.0 1390.0 1400.0 1410.0 1420.0 1430.0 1440.0 1450.0 1460.0 1470.0 1480.0 1490.0 1500.0 1510.0 1520.0 1530.0 1540.0 1550.0 1560.0 1570.0 1580.0 1590.0 1600.0 1850.0 2100.0 2373.0 2770.0</lambda>
+           <cross_section units="cm2/ang">1.00E-21 2.60E-19 5.30E-19 1.00E-18 5.90E-20 1.30E-18 1.50E-19 3.70E-19 1.30E-18 3.70E-18 4.00E-18 4.00E-18 1.17E-17 9.80E-18 1.31E-17 1.68E-17 1.61E-17 1.96E-17 1.82E-17 1.97E-17 2.30E-17 2.38E-17 2.16E-17 2.12E-17 2.50E-17 2.50E-17 2.97E-17 2.79E-17 3.13E-17 2.98E-17 3.41E-17 3.52E-17 3.53E-17 3.66E-17 3.56E-17 3.78E-17 3.96E-17 3.61E-17 3.94E-17 4.04E-17 3.78E-17 4.20E-17 4.14E-17 4.77E-17 4.30E-17 4.62E-17 4.74E-17 4.70E-17 4.82E-17 4.85E-17 4.75E-17 5.20E-17 5.10E-17 5.12E-17 5.24E-17 5.07E-17 5.10E-17 5.10E-17 5.20E-17 4.95E-17 4.65E-17 5.17E-17 5.20E-17 5.46E-17 5.60E-17 5.60E-17 5.60E-17 6.00E-17 5.60E-17 4.40E-17 4.10E-17 4.10E-17 3.36E-17 3.80E-17 2.91E-17  3.30E-17  3.10E-17  2.95E-17  3.10E-17  3.20E-17  2.70E-17  2.62E-17  2.91E-17  1.75E-17  1.89E-17  1.84E-17  1.89E-17  2.30E-17  2.51E-17  1.70E-17  2.30E-17  2.00E-17  1.61E-17  1.90E-17  1.75E-17  1.90E-17  1.80E-17  1.75E-17  1.60E-17  1.90E-17  1.80E-17  1.60E-17  1.40E-17  1.40E-17  1.40E-17  1.30E-17  1.10E-17  1.00E-17  6.85E-18  3.20E-18  2.20E-18  1.20E-18  6.80E-19  3.60E-19  1.60E-19  7.80E-20  2.20E-20  8.00E-21  2.80E-21  7.90E-22  2.80E-22  8.60E-23  3.80E-23  2.30E-23  1.60E-23  1.20E-23  9.20E-24  8.10E-24  7.40E-24  7.10E-24  6.80E-24  6.40E-24  6.00E-24  4.00E-24  1.00E-25  3.00E-26  1.00E-28</cross_section>
+        </photochemistry>
+      </rateCoeff>
+      <reactants>CH4:1.0</reactants>
+      <products>CH3:1.0 H:1</products>
+    </reaction>
+
+    <!-- reaction 0036    -->
+    <reaction reversible="yes" type="Elementary" id="0036">
+      <equation>CH4 [=] CH3 H </equation>
+      <rateCoeff>
+        <Constant>
+           <A>2.5e11</A>
+        </Constant>
+      </rateCoeff>
+      <reactants>CH4:1.0</reactants>
+      <products>CH3:1.0 H:1</products>
+    </reaction>
+  </reactionData>
+
+</ctml>

--- a/test/input_files/test_parsing.xml
+++ b/test/input_files/test_parsing.xml
@@ -417,7 +417,7 @@
     <reaction reversible="yes" type="LindemannFalloff" id="0021">
       <equation>N2 [=] 2 N </equation>
       <rateCoeff>
-        <HercourtEssen>
+        <HercourtEssen name="k0">
            <A>7.e+18</A>
            <b>-1.6</b>
         </HercourtEssen>
@@ -547,7 +547,7 @@
     <reaction reversible="yes" type="TroeFalloff" id="0028">
       <equation>N2 [=] 2 N </equation>
       <rateCoeff>
-        <HercourtEssen>
+        <HercourtEssen name="k0">
            <A>7.e+18</A>
            <b>-1.6</b>
         </HercourtEssen>
@@ -641,7 +641,7 @@
     <reaction reversible="yes" type="TroeFalloff" id="0032">
       <equation>NO + O [=] O2 + N</equation>
       <rateCoeff>
-        <Kooij>
+        <Kooij name="k0">
            <A>8.4e+09</A>
            <b>0.40</b>
            <E units="cal/mol">38526.0</E>

--- a/test/parsing_xml.C
+++ b/test/parsing_xml.C
@@ -132,7 +132,7 @@ typename Antioch::value_type<VectorScalar>::type k_photo(const VectorScalar &sol
 }
 
 template<typename Scalar>
-int tester(const std::string &root_name)
+int tester(const std::string &kin_file, const std::string &solar_file, const std::string & CH4_cs_file)
 {
 
   std::vector<std::string> species_str_list;
@@ -151,11 +151,11 @@ int tester(const std::string &root_name)
 
   Antioch::ChemicalMixture<Scalar> chem_mixture( species_str_list );
   Antioch::ReactionSet<Scalar> reaction_set( chem_mixture );
-  Antioch::read_reaction_set_data_xml<Scalar>( root_name + "/test_parsing.xml", true, reaction_set );
+  Antioch::read_reaction_set_data_xml<Scalar>( kin_file, true, reaction_set );
 
 //photochemistry set here
   std::vector<Scalar> hv,lambda;
-  std::ifstream solar_flux(root_name + "/solar_flux.dat");
+  std::ifstream solar_flux(solar_file);
   std::string line;
 
 
@@ -180,7 +180,7 @@ int tester(const std::string &root_name)
   solar_flux.close();
 
   std::vector<Scalar> CH4_s,CH4_lambda;
-  std::ifstream CH4_file(root_name + "/CH4_hv_cs.dat");
+  std::ifstream CH4_file(CH4_cs_file);
 
   Scalar T = 2000.L;
   Scalar Tr = 1.;
@@ -561,7 +561,7 @@ int tester(const std::string &root_name)
 
 int main(int argc, char* argv[])
 {
-  return (tester<float>(std::string(argv[1])) ||
-          tester<double>(std::string(argv[1])) ||
-          tester<long double>(std::string(argv[1])));
+  return (tester<float>(std::string(argv[1]),std::string(argv[2]),std::string(argv[3])) ||
+          tester<double>(std::string(argv[1]),std::string(argv[2]),std::string(argv[3])) ||
+          tester<long double>(std::string(argv[1]),std::string(argv[2]),std::string(argv[3])));
 }

--- a/test/parsing_xml.sh.in
+++ b/test/parsing_xml.sh.in
@@ -2,7 +2,7 @@
 
 PROG="@top_builddir@/test/parsing_xml"
 
-INPUT="@top_srcdir@/test/input_files"
+INPUT="@top_srcdir@/test/input_files/test_parsing.xml @top_srcdir@/test/input_files/solar_flux.dat @top_srcdir@/test/input_files/CH4_hv_cs.dat"
 
 $PROG $INPUT
 


### PR DESCRIPTION
Here is the PR related to issue #173.

It has all the discussed features:

 - if verbose, it says which rate constant is the low pressure and which is the  high pressure limit
 - within a falloff environment, no other value than ``k0`` is allowed for a ``name`` attribute
 - within a falloff environment, no more than one ``name`` attribute is allowed
 - doxygen docs have been updated

Two expected failures tests have been added to test for these two new restrictions, the existing test have been somewhat expanded, meaning some ``name="k0"`` have been put in the first rate constant's block to test for this configuration.

The XFAIL tests are clones of the normal test, with one reaction containing one feature that Antioch now find to be offensive.