### PR TITLE
New Sting Utilities Functions

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -37,6 +37,7 @@ libantioch_la_SOURCES += transport/src/transport_mixture.C
 libantioch_la_SOURCES += utilities/src/antioch_version.C
 libantioch_la_SOURCES += utilities/src/gsl_spliner_impl.C
 libantioch_la_SOURCES += utilities/src/gsl_spliner_shim.C
+libantioch_la_SOURCES += utilities/src/string_utils.C
 
 #----------------------------
 # INCLUDES we want distributed

--- a/src/parsing/src/xml_parser.C
+++ b/src/parsing/src/xml_parser.C
@@ -188,7 +188,7 @@ namespace Antioch
 
     if(_species_block)
       {
-        SplitString(std::string(_species_block->GetText())," ",molecules,false);
+        split_string(std::string(_species_block->GetText())," ",molecules);
       }
 
     return molecules;
@@ -326,13 +326,7 @@ namespace Antioch
 
         // Split the reactant string on whitespace. If no entries were found,
         // there is no whitespace - and assume then only one reactant is listed.
-        if( !SplitString(std::string(molecules->GetText()),
-                         " ",
-                         mol_pairs,
-                         /* include_empties = */ false)     )
-          {
-            mol_pairs.push_back(molecules->GetText());
-          }
+        split_string(std::string(molecules->GetText()), " ", mol_pairs);
 
         for( unsigned int p=0; p < mol_pairs.size(); p++ )
           {
@@ -440,16 +434,15 @@ namespace Antioch
     if(ptr->FirstChildElement(par.c_str()))
       {
         std::vector<std::string> values;
-        if(!SplitString(ptr->FirstChildElement(par.c_str())->GetText()," ",values,false))
-          values.push_back(ptr->FirstChildElement(par.c_str())->GetText());
+        split_string(ptr->FirstChildElement(par.c_str())->GetText()," ",values);
 
         par_values.resize(values.size());
         for(unsigned int i = 0; i < values.size(); i++)
-          {
-            par_values[i] =  std::atof(values[i].c_str());
-          }
+          par_values[i] =  string_to_T<NumericType>(values[i].c_str());
+
         if(ptr->FirstChildElement(par.c_str())->Attribute(_map.at(ParsingKey::UNIT).c_str()))
           par_unit = ptr->FirstChildElement(par.c_str())->Attribute(_map.at(ParsingKey::UNIT).c_str());
+
         out = true;
       }
 
@@ -534,12 +527,13 @@ namespace Antioch
             if(rate_constant->FirstChildElement(_map.at(ParsingKey::EFFICIENCY).c_str()))
               {
                 std::vector<std::string> values;
-                SplitString(std::string((rate_constant->FirstChildElement(_map.at(ParsingKey::EFFICIENCY).c_str())->GetText())?rate_constant->FirstChildElement(_map.at(ParsingKey::EFFICIENCY).c_str())->GetText():""),
-                            " ",values,false);
+                std::string value_string = std::string((rate_constant->FirstChildElement(_map.at(ParsingKey::EFFICIENCY).c_str())->GetText())?rate_constant->FirstChildElement(_map.at(ParsingKey::EFFICIENCY).c_str())->GetText():"");
+
+                split_string(value_string, " ", values);
+
                 for(unsigned int i = 0; i < values.size(); i++)
-                  {
-                    par_values.push_back(split_string_double_on_colon (values[i]));
-                  }
+                  par_values.push_back(split_string_double_on_colon (values[i]));
+
                 out = true;
               }
           }
@@ -611,7 +605,8 @@ namespace Antioch
 
             // now coefs
             std::vector<std::string> coefs_str;
-            SplitString(std::string(nasa->GetText())," ",coefs_str,false);
+            split_string(std::string(nasa->GetText())," ",coefs_str);
+
             for(unsigned int d = 0; d < coefs_str.size(); d++)
               values.push_back(std::atof(coefs_str[d].c_str()));
             // looping
@@ -622,7 +617,7 @@ namespace Antioch
                 temps.push_back(std::atof(nasa->Attribute("Tmax")));
 
                 // now coefs
-                SplitString(std::string(nasa->GetText())," ",coefs_str,false);
+                split_string(std::string(nasa->GetText())," ",coefs_str);
                 for(unsigned int d = 0; d < coefs_str.size(); d++)
                   values.push_back(std::atof(coefs_str[d].c_str()));
 

--- a/src/utilities/include/antioch/string_utils.h
+++ b/src/utilities/include/antioch/string_utils.h
@@ -45,6 +45,11 @@
 
 namespace Antioch
 {
+  //! All characters in delimiter will be treated as a delimiter
+  void split_string( const std::string& input,
+                     const std::string& delimiter,
+                     std::vector<std::string>& results );
+
   /*!
     Split on colon, and return name, int value pair.
     Taken from FIN-S for XML parsing.

--- a/src/utilities/include/antioch/string_utils.h
+++ b/src/utilities/include/antioch/string_utils.h
@@ -42,6 +42,7 @@
 #include <string>
 #include <vector>
 #include <cstdlib> // atoi
+#include <sstream>
 
 namespace Antioch
 {
@@ -49,6 +50,19 @@ namespace Antioch
   void split_string( const std::string& input,
                      const std::string& delimiter,
                      std::vector<std::string>& results );
+
+
+  template <typename T>
+  inline
+  T string_to_T(const std::string& input)
+  {
+    std::istringstream converter(input);
+    T returnval;
+    converter >> returnval;
+    if (converter.fail())
+      antioch_error();
+    return returnval;
+  }
 
   /*!
     Split on colon, and return name, int value pair.

--- a/src/utilities/src/string_utils.C
+++ b/src/utilities/src/string_utils.C
@@ -1,0 +1,52 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// Antioch - A Gas Dynamics Thermochemistry Library
+//
+// Copyright (C) 2014 Paul T. Bauman, Benjamin S. Kirk, Sylvain Plessis,
+//                    Roy H. Stonger
+// Copyright (C) 2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include "antioch/string_utils.h"
+
+namespace Antioch
+{
+  void split_string( const std::string& input,
+                     const std::string& delimiter,
+                     std::vector<std::string>& results )
+  {
+    // Skip delimiters at beginning.
+    std::string::size_type first_pos = input.find_first_not_of(delimiter, 0);
+
+    std::string::size_type pos = input.find_first_of(delimiter, first_pos);
+
+    while (std::string::npos != pos || std::string::npos != first_pos)
+      {
+        // Found a token, add it to the vector.
+        results.push_back(input.substr(first_pos, pos - first_pos));
+
+        // Skip delimiters.  Note the "not_of"
+        first_pos = input.find_first_not_of(delimiter, pos);
+
+        // Find next delimiter
+        pos = input.find_first_of(delimiter, first_pos);
+      }
+  }
+
+}

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -99,6 +99,7 @@ pkginclude_HEADERS =
 
 standard_unit_tests_SOURCES = standard_unit/arrhenius_rate_test.C        \
                               standard_unit/arrhenius_rate_valarray_test.C \
+                              standard_unit/string_utils_test.C \
                               standard_unit/standard_unit_tests.C
 
 eigen_unit_tests_SOURCES = eigen_unit/arrhenius_rate_eigen_test.C \

--- a/test/standard_unit/string_utils_test.C
+++ b/test/standard_unit/string_utils_test.C
@@ -1,0 +1,133 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// Antioch - A Gas Dynamics Thermochemistry Library
+//
+// Copyright (C) 2014 Paul T. Bauman, Benjamin S. Kirk, Sylvain Plessis,
+//                    Roy H. Stonger
+// Copyright (C) 2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include "antioch_config.h"
+
+#ifdef ANTIOCH_HAVE_CPPUNIT
+
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/TestCase.h>
+
+// Antioch
+#include "antioch/string_utils.h"
+
+namespace AntiochTesting
+{
+  class StringUtilitiesTest : public CppUnit::TestCase
+  {
+  public:
+
+    void setUp(){}
+
+    void tearDown(){}
+
+    CPPUNIT_TEST_SUITE( StringUtilitiesTest );
+
+    CPPUNIT_TEST(test_split_string);
+
+    CPPUNIT_TEST_SUITE_END();
+
+  private:
+
+    void test_split_string()
+    {
+      {
+        std::string str("N->N2");
+        std::vector<std::string> str_split;
+        Antioch::split_string( str, "->", str_split);
+
+        CPPUNIT_ASSERT_EQUAL(2,(int)str_split.size());
+        CPPUNIT_ASSERT_EQUAL(str_split[0],std::string("N"));
+        CPPUNIT_ASSERT_EQUAL(str_split[1],std::string("N2"));
+      }
+
+      {
+        std::string str("N+C(s)->CN");
+        std::vector<std::string> str_split;
+        Antioch::split_string( str, "->", str_split);
+
+        CPPUNIT_ASSERT_EQUAL(2,(int)str_split.size());
+        CPPUNIT_ASSERT_EQUAL(str_split[0],std::string("N+C(s)"));
+        CPPUNIT_ASSERT_EQUAL(str_split[1],std::string("CN"));
+      }
+
+      {
+        std::string str("u:v:w:T:p:w_N:w_N2:p0");
+        std::vector<std::string> str_split;
+        Antioch::split_string( str, ":", str_split);
+
+        CPPUNIT_ASSERT_EQUAL(8,(int)str_split.size());
+        CPPUNIT_ASSERT_EQUAL(str_split[0],std::string("u"));
+        CPPUNIT_ASSERT_EQUAL(str_split[1],std::string("v"));
+        CPPUNIT_ASSERT_EQUAL(str_split[2],std::string("w"));
+        CPPUNIT_ASSERT_EQUAL(str_split[3],std::string("T"));
+        CPPUNIT_ASSERT_EQUAL(str_split[4],std::string("p"));
+        CPPUNIT_ASSERT_EQUAL(str_split[5],std::string("w_N"));
+        CPPUNIT_ASSERT_EQUAL(str_split[6],std::string("w_N2"));
+        CPPUNIT_ASSERT_EQUAL(str_split[7],std::string("p0"));
+      }
+
+      {
+        std::string str("u v w T p w_N w_N2 p0");
+        std::vector<std::string> str_split;
+        Antioch::split_string( str, " ", str_split);
+
+        CPPUNIT_ASSERT_EQUAL(8,(int)str_split.size());
+        CPPUNIT_ASSERT_EQUAL(str_split[0],std::string("u"));
+        CPPUNIT_ASSERT_EQUAL(str_split[1],std::string("v"));
+        CPPUNIT_ASSERT_EQUAL(str_split[2],std::string("w"));
+        CPPUNIT_ASSERT_EQUAL(str_split[3],std::string("T"));
+        CPPUNIT_ASSERT_EQUAL(str_split[4],std::string("p"));
+        CPPUNIT_ASSERT_EQUAL(str_split[5],std::string("w_N"));
+        CPPUNIT_ASSERT_EQUAL(str_split[6],std::string("w_N2"));
+        CPPUNIT_ASSERT_EQUAL(str_split[7],std::string("p0"));
+      }
+
+      {
+        std::string str("2.25853318e+03,    -1.57454401e+00,    2.50363759e+00,    -5.20253954e-06, ");
+        str += "   4.51647956e-09,  -2.18115104e-12,   4.49430845e-16, 2.16895191e+05, 4.34577527e+00";
+
+        std::vector<std::string> str_split;
+        Antioch::split_string( str, " ,", str_split);
+
+        CPPUNIT_ASSERT_EQUAL(9,(int)str_split.size());
+        CPPUNIT_ASSERT_EQUAL(str_split[0],std::string("2.25853318e+03"));
+        CPPUNIT_ASSERT_EQUAL(str_split[1],std::string("-1.57454401e+00"));
+        CPPUNIT_ASSERT_EQUAL(str_split[2],std::string("2.50363759e+00"));
+        CPPUNIT_ASSERT_EQUAL(str_split[3],std::string("-5.20253954e-06"));
+        CPPUNIT_ASSERT_EQUAL(str_split[4],std::string("4.51647956e-09"));
+        CPPUNIT_ASSERT_EQUAL(str_split[5],std::string("-2.18115104e-12"));
+        CPPUNIT_ASSERT_EQUAL(str_split[6],std::string("4.49430845e-16"));
+        CPPUNIT_ASSERT_EQUAL(str_split[7],std::string("2.16895191e+05"));
+        CPPUNIT_ASSERT_EQUAL(str_split[8],std::string("4.34577527e+00"));
+      }
+    }
+  };
+
+  CPPUNIT_TEST_SUITE_REGISTRATION( StringUtilitiesTest );
+
+} // end namespace AntiochTesting
+
+#endif // ANTIOCH_HAVE_CPPUNIT

--- a/test/standard_unit/string_utils_test.C
+++ b/test/standard_unit/string_utils_test.C
@@ -46,6 +46,7 @@ namespace AntiochTesting
     CPPUNIT_TEST_SUITE( StringUtilitiesTest );
 
     CPPUNIT_TEST(test_split_string);
+    CPPUNIT_TEST(test_string_to_T);
 
     CPPUNIT_TEST_SUITE_END();
 
@@ -123,6 +124,28 @@ namespace AntiochTesting
         CPPUNIT_ASSERT_EQUAL(str_split[7],std::string("2.16895191e+05"));
         CPPUNIT_ASSERT_EQUAL(str_split[8],std::string("4.34577527e+00"));
       }
+    }
+
+    void test_string_to_T()
+    {
+      {
+        std::string str("1");
+        int test = Antioch::string_to_T<int>(str);
+        CPPUNIT_ASSERT_EQUAL(1,test);
+      }
+
+      {
+        std::string str("1.0");
+        double test = Antioch::string_to_T<double>(str);
+        CPPUNIT_ASSERT_EQUAL(1.0,test);
+      }
+
+      {
+        std::string str("4.34577527e+00");
+        double test = Antioch::string_to_T<double>(str);
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(4.34577527e+00, test, 1.0e-8);
+      }
+
     }
   };
 


### PR DESCRIPTION
Adds a new `split_string` that will ignore *any* of the delimiter characters (and is much shorter code than the `SplitString` function). Also added `string_to_T` function for converting string to the templated type. Added CppUnit tests for both. Updated `XMLParser` to use the new `split_string` function. Going to use this in fixing the thermo XML parsing (which is currently borked).