### PR TITLE
Kin/orders reactions Rebased

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -226,6 +226,7 @@ AC_CONFIG_FILES(test/parsing_chemkin.sh,                 [chmod +x test/parsing_
 AC_CONFIG_FILES(test/kinetics_reactive_scheme_unit.sh,   [chmod +x test/kinetics_reactive_scheme_unit.sh])
 AC_CONFIG_FILES(test/nasa_evaluator_unit.sh,             [chmod +x test/nasa_evaluator_unit.sh])
 AC_CONFIG_FILES(test/ascii_parser_unit.sh,               [chmod +x test/ascii_parser_unit.sh])
+AC_CONFIG_FILES(test/kinetics_partial_order_unit.sh,     [chmod +x test/kinetics_partial_order_unit.sh])
 
 dnl-----------------------------------------------
 dnl Generate header files

--- a/src/kinetics/include/antioch/reaction.h
+++ b/src/kinetics/include/antioch/reaction.h
@@ -210,13 +210,13 @@ namespace Antioch
     void add_reactant( const std::string &name,
                        const unsigned int r_id,
                        const unsigned int stoichiometric_coeff,
-                       const CoeffType partial_order = static_cast<CoeffType>(stoichiometric_coeff));
+                       const CoeffType partial_order = std::numeric_limits<CoeffType>::infinity());// what test could be reliable?
 
     //!
     void add_product( const std::string &name,
                       const unsigned int p_id,
                       const unsigned int stoichiometric_coeff,
-                      const CoeffType partial_order = static_cast<CoeffType>(stoichiometric_coeff));
+                      const CoeffType partial_order = std::numeric_limits<CoeffType>::infinity()); // what test could be reliable?
 
     //!
     void clear_reactant();
@@ -572,18 +572,18 @@ namespace Antioch
   inline
   CoeffType Reaction<CoeffType,VectorCoeffType>::reactant_partial_order(const unsigned int r) const
   {      
-    antioch_assert_less(r, _reactant_partial_order.size());
+    antioch_assert_less(r, _species_reactant_partial_order.size());
     antioch_assert_less(_reactant_ids[r], this->n_species());
-    return _reactant_partial_order[r];
+    return _species_reactant_partial_order[r];
   }
 
   template<typename CoeffType, typename VectorCoeffType>
   inline
-  unsigned int Reaction<CoeffType,VectorCoeffType>::product_partial_order(const unsigned int p) const
+  CoeffType Reaction<CoeffType,VectorCoeffType>::product_partial_order(const unsigned int p) const
   {
-    antioch_assert_less(p, _product_partial_order.size());
+    antioch_assert_less(p, _species_product_partial_order.size());
     antioch_assert_less(_product_ids[p], this->n_species());
-    return _product_partial_order[p];
+    return _species_product_partial_order[p];
   }
 
   template<typename CoeffType, typename VectorCoeffType>
@@ -597,7 +597,9 @@ namespace Antioch
     _reactant_names.push_back(name);
     _reactant_ids.push_back(r_id);
     _reactant_stoichiometry.push_back(stoichiometric_coeff);
-    _reactant_partial_order.push_back(partial_order);
+
+   CoeffType order = (partial_order == std::numeric_limits<CoeffType>::infinity() )?static_cast<CoeffType>(stoichiometric_coeff):partial_order;
+    _species_reactant_partial_order.push_back(order);
     return;
   }
 
@@ -612,7 +614,9 @@ namespace Antioch
     _product_names.push_back(name);
     _product_ids.push_back(p_id);
     _product_stoichiometry.push_back(stoichiometric_coeff);
-    _product_partial_order.push_back(partial_order);
+
+   CoeffType order = (partial_order == std::numeric_limits<CoeffType>::infinity() )?static_cast<CoeffType>(stoichiometric_coeff):partial_order;
+    _species_product_partial_order.push_back(order);
     return;
   }
 
@@ -829,12 +833,14 @@ namespace Antioch
         os << "#   reactants: ";
         for (unsigned int r=0; r<this->n_reactants(); r++)
           os << this->reactant_name(r) << ":"
-             << this->reactant_stoichiometric_coefficient(r) << " ";
+             << this->reactant_stoichiometric_coefficient(r) << ","
+             << this->reactant_partial_order(r) << " ";
         os << "\n"
            << "#   products:  ";
         for (unsigned int p=0; p<this->n_products(); p++)
           os << this->product_name(p) << ":"
-             << this->product_stoichiometric_coefficient(p) << " ";
+             << this->product_stoichiometric_coefficient(p) << ","
+             << this->product_partial_order(p) << " ";
       }
     os << "\n#   Chemical process: " << _type;
     os << "\n#   Kinetics model: "   << _kintype;

--- a/src/kinetics/include/antioch/reaction.h
+++ b/src/kinetics/include/antioch/reaction.h
@@ -201,14 +201,22 @@ namespace Antioch
     unsigned int product_stoichiometric_coefficient(const unsigned int p) const;
 
     //!
+    CoeffType reactant_partial_order(const unsigned int r) const;
+
+    //!
+    CoeffType product_partial_order(const unsigned int p) const;
+
+    //!
     void add_reactant( const std::string &name,
                        const unsigned int r_id,
-                       const unsigned int stoichiometric_coeff);
+                       const unsigned int stoichiometric_coeff,
+                       const CoeffType partial_order = static_cast<CoeffType>(stoichiometric_coeff));
 
     //!
     void add_product( const std::string &name,
                       const unsigned int p_id,
-                      const unsigned int stoichiometric_coeff);
+                      const unsigned int stoichiometric_coeff,
+                      const CoeffType partial_order = static_cast<CoeffType>(stoichiometric_coeff));
 
     //!
     void clear_reactant();
@@ -358,6 +366,8 @@ namespace Antioch
     std::vector<unsigned int> _product_stoichiometry;
     std::vector<unsigned int> _species_reactant_stoichiometry;
     std::vector<unsigned int> _species_product_stoichiometry;
+    std::vector<CoeffType>    _species_reactant_partial_order;
+    std::vector<CoeffType>    _species_product_partial_order;
     std::vector<int>          _species_delta_stoichiometry;
     int _gamma;
     bool _initialized;
@@ -560,14 +570,34 @@ namespace Antioch
 
   template<typename CoeffType, typename VectorCoeffType>
   inline
+  CoeffType Reaction<CoeffType,VectorCoeffType>::reactant_partial_order(const unsigned int r) const
+  {      
+    antioch_assert_less(r, _reactant_partial_order.size());
+    antioch_assert_less(_reactant_ids[r], this->n_species());
+    return _reactant_partial_order[r];
+  }
+
+  template<typename CoeffType, typename VectorCoeffType>
+  inline
+  unsigned int Reaction<CoeffType,VectorCoeffType>::product_partial_order(const unsigned int p) const
+  {
+    antioch_assert_less(p, _product_partial_order.size());
+    antioch_assert_less(_product_ids[p], this->n_species());
+    return _product_partial_order[p];
+  }
+
+  template<typename CoeffType, typename VectorCoeffType>
+  inline
   void Reaction<CoeffType,VectorCoeffType>::add_reactant (const std::string &name,
                                           const unsigned int r_id,
-                                          const unsigned int stoichiometric_coeff)
+                                          const unsigned int stoichiometric_coeff,
+                                          const CoeffType partial_order)
   {
     antioch_assert_less(r_id, this->n_species());
     _reactant_names.push_back(name);
     _reactant_ids.push_back(r_id);
     _reactant_stoichiometry.push_back(stoichiometric_coeff);
+    _reactant_partial_order.push_back(partial_order);
     return;
   }
 
@@ -575,12 +605,14 @@ namespace Antioch
   inline
   void Reaction<CoeffType,VectorCoeffType>::add_product (const std::string &name,
                                          const unsigned int p_id,
-                                         const unsigned int stoichiometric_coeff)
+                                         const unsigned int stoichiometric_coeff,
+                                         const CoeffType partial_order)
   {
     antioch_assert_less(p_id, this->n_species());
     _product_names.push_back(name);
     _product_ids.push_back(p_id);
     _product_stoichiometry.push_back(stoichiometric_coeff);
+    _product_partial_order.push_back(partial_order);
     return;
   }
 
@@ -996,7 +1028,7 @@ namespace Antioch
       {
         kfwd_times_reactants     *= 
           ant_pow( molar_densities[this->reactant_id(ro)],
-            static_cast<int>(this->reactant_stoichiometric_coefficient(ro)) );
+            this->reactant_partial_order(ro));
       }
 
     StateType kbkwd_times_products = Antioch::zero_clone(kfwd_times_reactants);
@@ -1011,7 +1043,7 @@ namespace Antioch
         {
           kbkwd_times_products     *= 
             ant_pow( molar_densities[this->product_id(po)],
-              static_cast<int>(this->product_stoichiometric_coefficient(po)) );
+              this->product_partial_order(po));
          
         }
     }

--- a/src/kinetics/include/antioch/reaction.h
+++ b/src/kinetics/include/antioch/reaction.h
@@ -778,7 +778,6 @@ namespace Antioch
         exppower -= ( static_cast<CoeffType>(_product_stoichiometry[s])*
                        h_RT_minus_s_R[_product_ids[s]] );
       }
-
     return ant_pow( P0_RT, static_cast<CoeffType>(this->gamma()) ) * ant_exp(exppower);
   }
 
@@ -1125,12 +1124,12 @@ namespace Antioch
       {
         const StateType val = 
           ant_pow( molar_densities[this->reactant_id(ro)],
-            static_cast<int>(this->reactant_stoichiometric_coefficient(ro)) );
+            this->reactant_partial_order(ro));
           
         const StateType dval = 
           ( static_cast<CoeffType>(this->reactant_stoichiometric_coefficient(ro))*
             ant_pow( molar_densities[this->reactant_id(ro)],
-              static_cast<int>(this->reactant_stoichiometric_coefficient(ro))-1 ) 
+              this->reactant_partial_order(ro) - 1)
             );
 
         facfwd   *= val;
@@ -1203,12 +1202,12 @@ namespace Antioch
         {
           const StateType val = 
             ant_pow( molar_densities[this->product_id(po)],
-              static_cast<int>(this->product_stoichiometric_coefficient(po)) );
+              this->product_partial_order(po));
           
           const StateType dval = 
             ( static_cast<CoeffType>(this->product_stoichiometric_coefficient(po))*
               ant_pow( molar_densities[this->product_id(po)],
-                static_cast<int>(this->product_stoichiometric_coefficient(po))-1 )
+              this->product_partial_order(po) - 1)
               );
         
           facbkwd   *= val;

--- a/src/kinetics/include/antioch/reaction_set.h
+++ b/src/kinetics/include/antioch/reaction_set.h
@@ -822,13 +822,13 @@ namespace Antioch
     // useful constants
     const StateType P0_RT = _P0_R/conditions.T(); // used to transform equilibrium constant from pressure units
 
-    net_rates.resize(this->n_reactions(),0.);
-    kfwd_const.resize(this->n_reactions(),0.);
-    kfwd.resize(this->n_reactions(),0.);
-    kbkwd_const.resize(this->n_reactions(),0.);
-    kbkwd.resize(this->n_reactions(),0.);
-    fwd_conc.resize(this->n_reactions(),1.);
-    bkwd_conc.resize(this->n_reactions(),1.);
+    net_rates.resize(this->n_reactions(),0);
+    kfwd_const.resize(this->n_reactions(),0);
+    kfwd.resize(this->n_reactions(),0);
+    kbkwd_const.resize(this->n_reactions(),0);
+    kbkwd.resize(this->n_reactions(),0);
+    fwd_conc.resize(this->n_reactions(),1);
+    bkwd_conc.resize(this->n_reactions(),1);
 
     // compute reaction forward rates & other reaction-sized arrays
     for (unsigned int rxn=0; rxn<this->n_reactions(); rxn++)
@@ -840,7 +840,7 @@ namespace Antioch
         for (unsigned int r=0; r<reaction.n_reactants(); r++)
           {
             fwd_conc[rxn] *= pow( molar_densities[reaction.reactant_id(r)],
-                              static_cast<int>(reaction.reactant_stoichiometric_coefficient(r)) );
+                              reaction.reactant_partial_order(r));
           }
         kfwd[rxn] *= fwd_conc[rxn];
 
@@ -853,7 +853,7 @@ namespace Antioch
           for (unsigned int p=0; p<reaction.n_products(); p++)
             {
               bkwd_conc[rxn] *= pow( molar_densities[reaction.product_id(p)],
-                               static_cast<int>(reaction.product_stoichiometric_coefficient(p)) );
+                                  reaction.product_partial_order(p));
             }
           kbkwd[rxn] *= bkwd_conc[rxn];
         }

--- a/src/parsing/include/antioch/chemkin_definitions.h
+++ b/src/parsing/include/antioch/chemkin_definitions.h
@@ -51,8 +51,10 @@ namespace Antioch
                  TB = 0,
                  FAL,
                  PHOTO,
-                 ELECTRO 
-               };
+                 ELECTRO,
+                 FORD,
+                 RORD
+             };
 
     const std::map<Delim,std::string> & delim()   const;
 
@@ -102,6 +104,8 @@ namespace Antioch
     _symbol[FAL]     = "(+M)";
     _symbol[PHOTO]   = "HV";
     _symbol[ELECTRO] = "E";
+    _symbol[FORD]    = "FORD";
+    _symbol[RORD]    = "RORD";
   }
 
   inline

--- a/src/parsing/include/antioch/chemkin_definitions.h
+++ b/src/parsing/include/antioch/chemkin_definitions.h
@@ -102,8 +102,6 @@ namespace Antioch
     _symbol[FAL]     = "(+M)";
     _symbol[PHOTO]   = "HV";
     _symbol[ELECTRO] = "E";
-    _symbol[FORD]    = "FORD";
-    _symbol[RORD]    = "RORD";
   }
 
   inline

--- a/src/parsing/include/antioch/chemkin_definitions.h
+++ b/src/parsing/include/antioch/chemkin_definitions.h
@@ -51,9 +51,7 @@ namespace Antioch
                  TB = 0,
                  FAL,
                  PHOTO,
-                 ELECTRO,
-                 FORD,
-                 RORD
+                 ELECTRO
              };
 
     const std::map<Delim,std::string> & delim()   const;

--- a/src/parsing/include/antioch/chemkin_parser.h
+++ b/src/parsing/include/antioch/chemkin_parser.h
@@ -155,6 +155,12 @@ namespace Antioch{
          /*! return pairs of products and stoichiometric coefficients*/
          bool products_pairs(std::vector<std::pair<std::string,int> > & products_pair) const;
 
+         /*! return a map between reactants' name and found partial orders */
+         const std::map<std::string,NumericType> reactants_orders() const;
+
+         /*! return a map between products' name and found partial orders */
+         const std::map<std::string,NumericType> products_orders() const;
+
          /*! return true if "name" attribute is found with value "k0"*/
          bool is_k0(unsigned int nrc, const std::string & kin_model) const;
 
@@ -222,6 +228,15 @@ namespace Antioch{
           void parse_coefficients_line(const std::string &line);
 
           /*! Convenient method */
+          void parse_forward_orders(const std::string & line);
+
+          /*! Convenient method */
+          void parse_backward_orders(const std::string & line);
+
+          /*! Convenient method */
+          void parse_orders(const std::string & line, std::vector<std::pair<std::string, NumericType> > & reaction_orders);
+
+          /*! Convenient method */
           std::pair<std::string,NumericType> parse_molecule(const std::string & molecule);
 
           /*! Convenient method */
@@ -256,6 +271,9 @@ namespace Antioch{
           // ChemKin allows real stoichiometric coefficients
           std::vector<std::pair<std::string,NumericType> > _reactants;
           std::vector<std::pair<std::string,NumericType> > _products;
+
+          std::vector<std::pair<std::string,NumericType> > _reactants_orders;
+          std::vector<std::pair<std::string,NumericType> > _products_orders;
 
           std::string                      _equation;
           std::string                      _chemical_process;

--- a/src/parsing/include/antioch/nasa_mixture_parsing.h
+++ b/src/parsing/include/antioch/nasa_mixture_parsing.h
@@ -32,6 +32,7 @@
 
 // Antioch
 #include "antioch/parsing_enum.h"
+#include "antioch/default_filename.h"
 
 namespace Antioch
 {
@@ -51,7 +52,7 @@ namespace Antioch
   class ASCIIParser;
 
   template<class NumericType, typename CurveType >
-  void read_nasa_mixture_data( NASAThermoMixture<NumericType, CurveType > & thermo, const std::string &filename, ParsingType = ASCII, bool verbose = true );
+  void read_nasa_mixture_data( NASAThermoMixture<NumericType, CurveType > & thermo, const std::string &filename = DefaultSourceFilename::thermo_data(), ParsingType = ASCII, bool verbose = true );
 
 } // end namespace Antioch
 

--- a/src/parsing/include/antioch/parser_base.h
+++ b/src/parsing/include/antioch/parser_base.h
@@ -35,6 +35,7 @@
 #include <vector>
 #include <string>
 #include <sstream>
+#include <map>
 
 namespace Antioch
 {
@@ -184,6 +185,12 @@ namespace Antioch
 
          /*! \return pairs of products and stoichiometric coefficients*/
          virtual bool products_pairs(std::vector<std::pair<std::string,int> > & /*products_pair*/) const {antioch_not_implemented_msg(_not_implemented); return false;}
+
+         /*! return a map between reactants' name and found partial orders */
+         virtual const std::map<std::string,NumericType> reactants_orders() const {antioch_not_implemented_msg(_not_implemented); return std::map<std::string,NumericType>();}
+
+         /*! return a map between products' name and found partial orders */
+         virtual const std::map<std::string,NumericType> products_orders() const {antioch_not_implemented_msg(_not_implemented); return std::map<std::string,NumericType>();}
 
          /*! \return true if "name" attribute is found with value "k0"*/
          virtual bool is_k0(unsigned int /*nrc*/, const std::string & /*kin_model*/) const {antioch_not_implemented_msg(_not_implemented); return false;}

--- a/src/parsing/include/antioch/parsing_enum.h
+++ b/src/parsing/include/antioch/parsing_enum.h
@@ -45,6 +45,8 @@ namespace Antioch
                   KINETICS_MODEL,
                   REACTANTS,
                   PRODUCTS,
+                  FORWARD_ORDER,
+                  BACKWARD_ORDER,
                   PREEXP,
                   POWER,
                   ACTIVATION_ENERGY,

--- a/src/parsing/include/antioch/xml_parser.h
+++ b/src/parsing/include/antioch/xml_parser.h
@@ -139,9 +139,15 @@ namespace Antioch{
          /*! return pairs of products and stoichiometric coefficients*/
          bool products_pairs(std::vector<std::pair<std::string,int> > & products_pair) const;
 
+         /*! return a map between reactants' name and found partial orders */
+         const std::map<std::string,NumericType> reactants_orders() const;
+
+         /*! return a map between products' name and found partial orders */
+         const std::map<std::string,NumericType> products_orders() const;
+
          /*! return true if the concerned reaction rate is the low pressure limit
           *
-          * In the case of falloff reactions, there is the attribute "name" to 
+          * In the case of falloff reactions, there is the attribute "name" to
           * specify which rate constant is the low pressure limit.  This attribute
           * should have "k0" as value, and nothing else.
           *
@@ -200,7 +206,8 @@ namespace Antioch{
          void read_thermodynamic_data_root(ThermoType & thermo);
 
          /*! return pairs of molecules and stoichiometric coefficients*/
-         bool molecules_pairs(tinyxml2::XMLElement * molecules, std::vector<std::pair<std::string,int> > & products_pair) const;
+         template <typename PairedType>
+         bool molecules_pairs(tinyxml2::XMLElement * molecules, std::vector<std::pair<std::string,PairedType> > & products_pair) const;
 
          /*! return a parameter's value*/
          bool get_parameter(const tinyxml2::XMLElement * ptr, const std::string & par, NumericType & par_value, std::string & par_unit) const;

--- a/src/parsing/src/chemkin_parser.C
+++ b/src/parsing/src/chemkin_parser.C
@@ -61,7 +61,7 @@ namespace Antioch
     _map[ParsingKey::BACKWARD_ORDER]   = "RORD";
 
     // typically chemkin files list
-    //      pre-exponential parameters in (m3/kmol)^(m-1)/s
+    //      pre-exponential parameters in (cm3/mol)^(m-1)/s
     //      activation energy in cal/mol, but we want it in K.
     //      power parameter without unit
     // if falloff, we need to know who's k0 and kinfty

--- a/src/parsing/src/chemkin_parser.C
+++ b/src/parsing/src/chemkin_parser.C
@@ -58,7 +58,7 @@ namespace Antioch
     _map[ParsingKey::FALLOFF_LOW_NAME] = "LOW";
     _map[ParsingKey::TROE_FALLOFF]     = "TROE";
     _map[ParsingKey::FORWARD_ORDER]    = "FORD";
-    _map[ParsingKey::BACKWARD_ORDER]   = "BORD";
+    _map[ParsingKey::BACKWARD_ORDER]   = "RORD";
 
     // typically chemkin files list
     //      pre-exponential parameters in (m3/kmol)^(m-1)/s
@@ -487,11 +487,11 @@ namespace Antioch
         _duplicate_process = true;
 
       // custom forward orders
-      }else if(capital_line.find(_spec.symbol().at(_spec.FORD)) != std::string::npos) // forward order, "FORD"
+      }else if(capital_line.find(_map.at(ParsingKey::FORWARD_ORDER)) != std::string::npos) // forward order,
       {
         this->parse_forward_orders(line);
       // custom backward orders
-      }else if(capital_line.find(_spec.symbol().at(_spec.RORD)) != std::string::npos) // backward order, "RORD" (for 'reverse')
+      }else if(capital_line.find(_map.at(ParsingKey::BACKWARD_ORDER)) != std::string::npos) // backward order,
       {
         this->parse_backward_orders(line);
       // data about pressure dependence

--- a/src/parsing/src/read_reaction_set_data.C
+++ b/src/parsing/src/read_reaction_set_data.C
@@ -229,11 +229,16 @@ namespace Antioch
 
         if(parser->reactants_pairs(molecules_pairs))
           {
+
+            std::map<std::string,NumericType> orders = parser->reactants_orders();
             if (verbose)
               {
                 std::cout << "\n   reactants: ";
                 for(unsigned int ir = 0; ir < molecules_pairs.size(); ir++)
-                  std::cout << molecules_pairs[ir].first << ":" << molecules_pairs[ir].second << " ";
+                {
+                  NumericType order = (orders.count(molecules_pairs[ir].first))?orders.at(molecules_pairs[ir].first):static_cast<NumericType>(molecules_pairs[ir].second);
+                  std::cout << molecules_pairs[ir].first << ":" << molecules_pairs[ir].second << "," << order << ", ";
+                }
               }
 
             for( unsigned int p=0; p < molecules_pairs.size(); p++ )
@@ -249,10 +254,11 @@ namespace Antioch
                   }
                 else
                   {
+                    NumericType order = (orders.count(molecules_pairs[p].first))?orders.at(molecules_pairs[p].first):static_cast<NumericType>(molecules_pairs[p].second);
                     my_rxn->add_reactant( molecules_pairs[p].first,
                                           chem_mixture.species_name_map().find( molecules_pairs[p].first )->second,
-                                          molecules_pairs[p].second );
-                    order_reaction += molecules_pairs[p].second;
+                                          molecules_pairs[p].second, order );
+                    order_reaction += order;
                   }
               }
           }
@@ -260,9 +266,14 @@ namespace Antioch
         molecules_pairs.clear();
         if(parser->products_pairs(molecules_pairs))
           {
+
+            std::map<std::string,NumericType> orders = parser->products_orders();
             if(verbose) std::cout << "\n   products: ";
             for(unsigned int ir = 0; ir < molecules_pairs.size(); ir++)
-              std::cout << molecules_pairs[ir].first << ":" << molecules_pairs[ir].second << " ";
+            {
+              NumericType order = (orders.count(molecules_pairs[ir].first))?orders.at(molecules_pairs[ir].first):static_cast<NumericType>(molecules_pairs[ir].second);
+              std::cout << molecules_pairs[ir].first << ":" << molecules_pairs[ir].second << "," << order << ", ";
+            }
 
             for (unsigned int p=0; p < molecules_pairs.size(); p++)
               {
@@ -277,9 +288,10 @@ namespace Antioch
                   }
                 else
                   {
+                    NumericType order = (orders.count(molecules_pairs[p].first))?orders.at(molecules_pairs[p].first):static_cast<NumericType>(molecules_pairs[p].second);
                     my_rxn->add_product( molecules_pairs[p].first,
                                          chem_mixture.species_name_map().find( molecules_pairs[p].first )->second,
-                                         molecules_pairs[p].second );
+                                         molecules_pairs[p].second, order );
                   }
               }
             if(verbose) std::cout << std::endl;

--- a/src/parsing/src/read_reaction_set_data.C
+++ b/src/parsing/src/read_reaction_set_data.C
@@ -224,7 +224,7 @@ namespace Antioch
         // We will add the reaction, unless we do not have a
         // reactant or product
         bool relevant_reaction = true;
-        unsigned int order_reaction(0);
+        NumericType order_reaction(0);
         std::vector<std::pair<std::string,int> > molecules_pairs;
 
         if(parser->reactants_pairs(molecules_pairs))

--- a/src/parsing/src/xml_parser.C
+++ b/src/parsing/src/xml_parser.C
@@ -332,6 +332,7 @@ namespace Antioch
          }
       }
     }
+
     return map;
   }
 
@@ -370,7 +371,7 @@ namespace Antioch
 
         for( unsigned int p=0; p < mol_pairs.size(); p++ )
           {
-            std::pair<std::string,PairedType> pair( split_string_int_on_colon(mol_pairs[p]) );
+            std::pair<std::string,PairedType> pair( split_string_on_colon<PairedType>(mol_pairs[p]) );
 
             molecules_pairs.push_back(pair);
           }
@@ -407,7 +408,7 @@ namespace Antioch
           std::string error = "The keyword associated with the \'name\' attribute within the description of a falloff should be, and only be, ";
           error += "\'k0\' to specify the low pressure limit.  It seems that the one you provided, \'";
           error += std::string(_rate_constant->Attribute(_map.at(ParsingKey::FALLOFF_LOW_NAME).c_str()));
-          error += "\' is not this one.  Please correct it at reaction"; 
+          error += "\' is not this one.  Please correct it at reaction";
           error += this->reaction_id();
           error += ": ";
           error += this->reaction_equation();
@@ -572,7 +573,7 @@ namespace Antioch
                 split_string(value_string, " ", values);
 
                 for(unsigned int i = 0; i < values.size(); i++)
-                  par_values.push_back(split_string_double_on_colon (values[i]));
+                    par_values.push_back(split_string_on_colon<NumericType>(values[i]));
 
                 out = true;
               }

--- a/src/parsing/src/xml_parser.C
+++ b/src/parsing/src/xml_parser.C
@@ -80,7 +80,7 @@ namespace Antioch
     _map[ParsingKey::REACTANTS]             = "reactants";
     _map[ParsingKey::PRODUCTS]              = "products";
     _map[ParsingKey::FORWARD_ORDER]         = "ford";
-    _map[ParsingKey::BACKWARD_ORDER]        = "bord";
+    _map[ParsingKey::BACKWARD_ORDER]        = "rord";
     _map[ParsingKey::PREEXP]                = "A";
     _map[ParsingKey::POWER]                 = "b";
     _map[ParsingKey::ACTIVATION_ENERGY]     = "E";

--- a/src/parsing/src/xml_parser.C
+++ b/src/parsing/src/xml_parser.C
@@ -79,6 +79,8 @@ namespace Antioch
     _map[ParsingKey::KINETICS_MODEL]        = "rateCoeff";
     _map[ParsingKey::REACTANTS]             = "reactants";
     _map[ParsingKey::PRODUCTS]              = "products";
+    _map[ParsingKey::FORWARD_ORDER]         = "ford";
+    _map[ParsingKey::BACKWARD_ORDER]        = "bord";
     _map[ParsingKey::PREEXP]                = "A";
     _map[ParsingKey::POWER]                 = "b";
     _map[ParsingKey::ACTIVATION_ENERGY]     = "E";
@@ -316,7 +318,45 @@ namespace Antioch
   }
 
   template <typename NumericType>
-  bool XMLParser<NumericType>::molecules_pairs(tinyxml2::XMLElement * molecules, std::vector<std::pair<std::string,int> > & molecules_pairs) const
+  const std::map<std::string,NumericType> XMLParser<NumericType>::reactants_orders() const
+  {
+    tinyxml2::XMLElement* orders = _reaction->FirstChildElement(_map.at(ParsingKey::FORWARD_ORDER).c_str());
+    std::map<std::string,NumericType> map;
+    if(orders){
+      std::vector<std::pair<std::string,NumericType> > pairs;
+      if(this->molecules_pairs(orders,pairs))
+      {
+         for(unsigned int s = 0; s < pairs.size(); s++)
+         {
+            map.insert(pairs[s]);
+         }
+      }
+    }
+    return map;
+  }
+
+  template <typename NumericType>
+  const std::map<std::string,NumericType> XMLParser<NumericType>::products_orders() const
+  {
+    tinyxml2::XMLElement* orders = _reaction->FirstChildElement(_map.at(ParsingKey::BACKWARD_ORDER).c_str());
+    std::map<std::string,NumericType> map;
+    if(orders){
+      std::vector<std::pair<std::string,NumericType> > pairs;
+      if(this->molecules_pairs(orders,pairs))
+      {
+         for(unsigned int s = 0; s < pairs.size(); s++)
+         {
+            map.insert(pairs[s]);
+         }
+      }
+    }
+    return map;
+  }
+
+
+  template <typename NumericType>
+  template <typename PairedType>
+  bool XMLParser<NumericType>::molecules_pairs(tinyxml2::XMLElement * molecules, std::vector<std::pair<std::string,PairedType> > & molecules_pairs) const
   {
     bool out(true);
     if(molecules)
@@ -330,7 +370,7 @@ namespace Antioch
 
         for( unsigned int p=0; p < mol_pairs.size(); p++ )
           {
-            std::pair<std::string,int> pair( split_string_int_on_colon(mol_pairs[p]) );
+            std::pair<std::string,PairedType> pair( split_string_int_on_colon(mol_pairs[p]) );
 
             molecules_pairs.push_back(pair);
           }

--- a/src/utilities/include/antioch/string_utils.h
+++ b/src/utilities/include/antioch/string_utils.h
@@ -41,7 +41,6 @@
 #include <iostream>
 #include <string>
 #include <vector>
-#include <cstdlib> // atoi
 #include <sstream>
 
 namespace Antioch
@@ -64,56 +63,36 @@ namespace Antioch
     return returnval;
   }
 
-  /*!
-    Split on colon, and return name, int value pair.
-    Taken from FIN-S for XML parsing.
-   */
+  template <typename Type>
   inline
-  std::pair<std::string, int> split_string_int_on_colon(const std::string &token)
+  std::pair<std::string, Type> split_string_on_colon(const std::string &token)
   {
-    std::pair<std::string, int> ret = std::make_pair(std::string(), 0);
+    std::pair<std::string, Type> ret = std::make_pair(std::string(), 0);
     std::string::size_type colon_position = token.find(":");
     antioch_assert (colon_position != std::string::npos);
     ret.first  = token.substr(0, colon_position);
-    ret.second = std::atoi(token.substr(colon_position + 1).c_str());
+    ret.second = string_to_T<Type>(token.substr(colon_position + 1));
     return ret;
   }
-
-
-  /*!
-    Split on colon, and return name, double value pair.
-    Taken from FIN-S for XML parsing.
-   */
-  inline
-  std::pair<std::string, double> split_string_double_on_colon(const std::string &token)
-  {
-    std::pair<std::string, double> ret = std::make_pair(std::string(), 0.0);
-    std::string::size_type colon_position = token.find(":");
-    antioch_assert (colon_position != std::string::npos);
-    ret.first  = token.substr(0, colon_position);
-    ret.second = std::atof(token.substr(colon_position + 1).c_str());
-    return ret;
-  }
-
 
   /*!
     Taken from FIN-S for XML parsing.
    */
   inline
-  int SplitString(const std::string& input, 
-		  const std::string& delimiter, 
-		  std::vector<std::string>& results, 
+  int SplitString(const std::string& input,
+		  const std::string& delimiter,
+		  std::vector<std::string>& results,
 		  bool includeEmpties = true)
   {
     using std::vector;
     using std::string;
-    
+
     int iPos = 0;
     int newPos = -1;
     int sizeS2 = (int)delimiter.size();
     int isize = (int)input.size();
-    
-    if( 
+
+    if(
        ( isize == 0 )
        ||
        ( sizeS2 == 0 )
@@ -127,8 +106,8 @@ namespace Antioch
     newPos = input.find (delimiter, 0);
 
     if( newPos < 0 )
-      { 
-	return 0; 
+      {
+	return 0;
       }
 
     int numFound = 0;
@@ -149,9 +128,9 @@ namespace Antioch
     for( int i=0; i <= static_cast<int>(positions.size()); ++i )
       {
 	string s("");
-	if( i == 0 ) 
-	  { 
-	    s = input.substr( i, positions[i] ); 
+	if( i == 0 )
+	  {
+	    s = input.substr( i, positions[i] );
 	  }
 	else
 	  {
@@ -164,7 +143,7 @@ namespace Antioch
 		  }
 		else if( i > 0 )
 		  {
-		    s = input.substr( positions[i-1] + sizeS2, 
+		    s = input.substr( positions[i-1] + sizeS2,
 				      positions[i] - positions[i-1] - sizeS2 );
 		  }
 	      }
@@ -211,7 +190,7 @@ namespace Antioch
   inline
   KineticsModel::Parameters string_to_kin_enum(const std::string & str)
   {
-// kinetics 
+// kinetics
       if(str == "A")
       {
         return KineticsModel::Parameters::A;
@@ -271,7 +250,7 @@ namespace Antioch
       {
         return ReactionType::Parameters::NOT_FOUND;
       }
-  } 
+  }
 
 } // end namespace Antioch
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -63,6 +63,7 @@ check_PROGRAMS += ideal_gas_micro_thermo_unit
 check_PROGRAMS += ascii_parser_unit
 check_PROGRAMS += lindemann_falloff_threebody_unit
 check_PROGRAMS += troe_falloff_threebody_unit
+check_PROGRAMS += kinetics_partial_order_unit
 
 #GSL Tests
 check_PROGRAMS += molecular_binary_diffusion_unit
@@ -175,6 +176,7 @@ rotational_relaxation_vec_unit_SOURCES = rotational_relaxation_vec_unit.C
 ascii_parser_unit_SOURCES = ascii_parser_unit.C
 lindemann_falloff_threebody_unit_SOURCES = lindemann_falloff_threebody_unit.C
 troe_falloff_threebody_unit_SOURCES = troe_falloff_threebody_unit.C
+kinetics_partial_order_unit_SOURCES = kinetics_partial_order_unit.C
 
 # GSL Tests
 molecular_binary_diffusion_unit_SOURCES = molecular_binary_diffusion_unit.C
@@ -242,6 +244,10 @@ TESTS += kinetics_reversibility_unit
 TESTS += parsing_xml.sh
 TESTS += fail_parsing_xml_1.sh
 TESTS += fail_parsing_xml_2.sh
+
+XFAIL_TESTS += fail_parsing_xml_1.sh
+XFAIL_TESTS += fail_parsing_xml_2.sh
+
 TESTS += parsing_chemkin.sh
 TESTS += units_unit
 TESTS += kinetics_reactive_scheme_unit.sh
@@ -256,8 +262,7 @@ TESTS += ideal_gas_micro_thermo_unit
 TESTS += ascii_parser_unit.sh
 TESTS += lindemann_falloff_threebody_unit
 TESTS += troe_falloff_threebody_unit
-XFAIL_TESTS += fail_parsing_xml_1.sh
-XFAIL_TESTS += fail_parsing_xml_2.sh
+TESTS += kinetics_partial_order_unit.sh
 
 # GSL Tests
 TESTS += molecular_binary_diffusion_unit

--- a/test/input_files/orders_chemkin.inp
+++ b/test/input_files/orders_chemkin.inp
@@ -1,0 +1,19 @@
+!
+! ONE-RXN TEST MODEL
+!
+ELEMENTS
+H O
+END
+SPECIES
+H2O2 H2 H HO2
+END
+REACTIONS
+! Tsang and Hampson, J. Phys. Chem. Ref. Data, 15:1087 (1986)
+! modified for the test:
+! all the orders in the forward direction
+! are changed, only HO2 is in the backward
+! direction
+H2O2+H=HO2+H2             0.482E+14  0.00  0.795E+04
+FORD/H2O2 1.5/H 0.5/
+RORD/HO2 2/
+END

--- a/test/input_files/orders_xml.inp
+++ b/test/input_files/orders_xml.inp
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<ctml>
+  <validate reactions="yes" species="yes"/>
+
+  <phase dim="3" id="test_orders">
+    <elementArray>H O</elementArray>
+    <speciesArray>H2 H H2O2 HO2</speciesArray>
+    <reactionArray datasrc="#test_orders_reaction">
+      <skip species="undeclared"/>
+    </reactionArray>
+    <state>
+      <temperature units="K">300.0</temperature>
+      <pressure units="Pa">101325.0</pressure>
+      <moleFractions>O2:0.22, N2:0.78</moleFractions>
+    </state>
+    <thermo model="IdealGas"/>
+    <kinetics model="GasKinetics"/>
+    <transport model="Pecos"/>
+  </phase>
+
+
+  <reactionData id="test_orders_reaction">
+    <!-- reaction 0001    -->
+    <reaction reversible="yes" type="Elementary" id="0001">
+      <equation>H2O2 + H [=] HO2 + H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A units="(cm3/mol)/s">4.82e13</A>
+           <E units="cal/mol">7.95e3</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H2O2:1 H:1</reactants>
+      <products>HO2:1 H2:1</products>
+      <ford>H2O2:1.5 H:0.5</ford>
+      <rord>HO2:2</rord>
+    </reaction>
+
+  </reactionData>
+</ctml>

--- a/test/kinetics_partial_order_unit.C
+++ b/test/kinetics_partial_order_unit.C
@@ -1,0 +1,413 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// Antioch - A Gas Dynamics Thermochemistry Library
+//
+// Copyright (C) 2014 Paul T. Bauman, Benjamin S. Kirk, Sylvain Plessis,
+//                    Roy H. Stonger
+// Copyright (C) 2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+//
+// $Id$
+//
+//--------------------------------------------------------------------------
+//--------------------------------------------------------------------------
+
+// C++
+#include <limits>
+#include <iomanip>
+#include <string>
+#include <vector>
+#include <sstream>
+
+// Antioch
+#include "antioch/vector_utils.h"
+
+#include "antioch/antioch_asserts.h"
+#include "antioch/chemical_species.h"
+#include "antioch/chemical_mixture.h"
+#include "antioch/reaction_set.h"
+#include "antioch/read_reaction_set_data.h"
+#include "antioch/nasa_mixture_parsing.h"
+#include "antioch/nasa_evaluator.h"
+#include "antioch/kinetics_evaluator.h"
+
+
+template <typename Scalar>
+std::vector<Scalar> temp_thermo()
+{
+  std::vector<Scalar> Ts(3,0);
+  Ts[0] = 200;
+  Ts[1] = 1000;
+  Ts[2] = 6000;
+  return Ts;
+}
+
+template <typename Scalar>
+std::vector<Scalar> H_thermo(const Scalar & T)
+{
+  std::vector<std::vector<Scalar> > out(3,std::vector<Scalar>(10,0));
+  out[0][0] =  0.00000000e+00;  
+  out[0][1] =  0.00000000e+00;
+  out[0][2] =  2.50000000e+00;
+  out[0][3] =  0.00000000e+00;
+  out[0][4] =  0.00000000e+00;
+  out[0][5] =  0.00000000e+00;
+  out[0][6] =  0.00000000e+00;
+  out[0][7] =  0.00000000e+00;
+  out[0][8] =  2.54737080e+04;
+  out[0][9] = -4.46682853e-01;
+
+  out[1][0] =  6.07877425e+01;
+  out[1][1] = -1.81935442e-01;
+  out[1][2] =  2.50021182e+00;
+  out[1][3] = -1.22651286e-07;
+  out[1][4] =  3.73287633e-11;
+  out[1][5] = -5.68774456e-15;
+  out[1][6] =  3.41021020e-19;
+  out[1][7] =  0.00000000e+00;
+  out[1][8] =  2.54748640e+04;
+  out[1][9] = -4.48191777e-01;
+
+  out[2][0] =  2.17375769e+08;
+  out[2][1] = -1.31203540e+05;
+  out[2][2] =  3.39917420e+01;
+  out[2][3] = -3.81399968e-03;
+  out[2][4] =  2.43285484e-07;
+  out[2][5] = -7.69427554e-12;
+  out[2][6] =  9.64410563e-17;
+  out[2][7] =  0.00000000e+00;
+  out[2][8] =  1.06763809e+06;
+  out[2][9] = -2.74230105e+02;
+
+  return (T <= temp_thermo<Scalar>()[1])?out[0]:(T <= temp_thermo<Scalar>()[2])?out[1]:out[2];
+}
+
+template <typename Scalar>
+std::vector<Scalar> H2_thermo(const Scalar & T)
+{
+  std::vector<std::vector<Scalar> > out(3,std::vector<Scalar>(10,0));
+
+  out[0][0] =  4.07832281e+04;
+  out[0][1] = -8.00918545e+02;
+  out[0][2] =  8.21470167e+00;
+  out[0][3] = -1.26971436e-02;
+  out[0][4] =  1.75360493e-05;
+  out[0][5] = -1.20286016e-08;
+  out[0][6] =  3.36809316e-12;
+  out[0][7] =  0.00000000e+00;
+  out[0][8] =  2.68248438e+03;
+  out[0][9] = -3.04378866e+01;
+
+  out[1][0] =  5.60812338e+05;
+  out[1][1] = -8.37149134e+02;
+  out[1][2] =  2.97536304e+00;
+  out[1][3] =  1.25224993e-03;
+  out[1][4] = -3.74071842e-07;
+  out[1][5] =  5.93662825e-11;
+  out[1][6] = -3.60699573e-15;
+  out[1][7] =  0.00000000e+00;
+  out[1][8] =  5.33981585e+03;
+  out[1][9] = -2.20276405e+00;
+
+  out[2][0] = 4.96671613e+08;
+  out[2][1] = -3.14744812e+05;
+  out[2][2] = 7.98388750e+01;
+  out[2][3] = -8.41450419e-03;
+  out[2][4] = 4.75306044e-07;
+  out[2][5] = -1.37180973e-11;
+  out[2][6] = 1.60537460e-16;
+  out[2][7] = 0.00000000e+00;
+  out[2][8] = 2.48835466e+06;
+  out[2][9] = -6.69552419e+02;
+
+  return (T <= temp_thermo<Scalar>()[1])?out[0]:(T <= temp_thermo<Scalar>()[2])?out[1]:out[2];
+}
+
+template <typename Scalar>
+std::vector<Scalar> H2O2_thermo(const Scalar & T)
+{
+  std::vector<std::vector<Scalar> > out(2,std::vector<Scalar>(10,0));
+
+  out[0][0] = -9.279533580E+04;
+  out[0][1] =  1.564748385E+03;
+  out[0][2] = -5.976460140E+00;
+  out[0][3] =  3.270744520E-02;
+  out[0][4] = -3.932193260E-05;
+  out[0][5] =  2.509255235E-08;
+  out[0][6] = -6.465045290E-12;
+  out[0][7] =  0.000000000E+00;
+  out[0][8] = -2.494004728E+04;
+  out[0][9] =  5.877174180E+01;
+
+  out[1][0] =  1.489428027E+06;
+  out[1][1] = -5.170821780E+03;
+  out[1][2] =  1.128204970E+01;
+  out[1][3] = -8.042397790E-05;
+  out[1][4] = -1.818383769E-08;
+  out[1][5] =  6.947265590E-12;
+  out[1][6] = -4.827831900E-16;
+  out[1][7] =  0.000000000E+00;
+  out[1][8] =  1.418251038E+04;
+  out[1][9] = -4.650855660E+01;
+
+  return (T <= temp_thermo<Scalar>()[1])?out[0]:out[1];
+}
+										 
+template <typename Scalar>
+std::vector<Scalar> HO2_thermo(const Scalar & T)
+{
+  std::vector<std::vector<Scalar> > out(2,std::vector<Scalar>(10,0));
+
+  out[0][0] = -7.598882540E+04;
+  out[0][1] =  1.329383918E+03;
+  out[0][2] = -4.677388240E+00;
+  out[0][3] =  2.508308202E-02;
+  out[0][4] = -3.006551588E-05;
+  out[0][5] =  1.895600056E-08;
+  out[0][6] = -4.828567390E-12;
+  out[0][7] =  0.000000000E+00;
+  out[0][8] = -5.873350960E+03;
+  out[0][9] =  5.193602140E+01;
+
+  out[1][0] = -1.810669724E+06;
+  out[1][1] =  4.963192030E+03;
+  out[1][2] = -1.039498992E+00;
+  out[1][3] =  4.560148530E-03;
+  out[1][4] = -1.061859447E-06;
+  out[1][5] =  1.144567878E-10;
+  out[1][6] = -4.763064160E-15;
+  out[1][7] =  0.000000000E+00;
+  out[1][8] = -3.200817190E+04;
+  out[1][9] =  4.066850920E+01;
+
+  return (T <= temp_thermo<Scalar>()[1])?out[0]:out[1];
+}
+
+template <typename Scalar>
+Scalar g(const std::vector<Scalar> & thermo, const Scalar & T)
+{
+  return - thermo[0] / ( 2 * T * T)  
+         + thermo[1] * ( 1 + Antioch::ant_log(T) ) / T  
+         + thermo[2] * ( 1 - Antioch::ant_log(T) )
+         - thermo[3] * T / 2
+         - thermo[4] * T * T / 6
+         - thermo[5] * T * T * T / 12 
+         - thermo[6] * T * T * T * T / 20
+         + thermo[8] / T
+         - thermo[9];
+}
+
+template <typename Scalar>
+Scalar G(const Scalar & T)
+{
+  return g(H2O2_thermo(T),T) + g(H_thermo(T),T) - g(HO2_thermo(T),T) - g(H2_thermo(T),T);
+}
+
+template <typename Scalar>
+int check_test(const Scalar &exact,const Scalar &cal,const std::string &words)
+{
+  const Scalar tol = std::numeric_limits<Scalar>::epsilon() * 250;
+
+  if(std::abs(exact - cal)/exact > tol)
+  {
+     std::cout << std::scientific << std::setprecision(20)
+               << "Erreur in tests of "  << words                       << "\n"
+               << "Calculated value is " << cal                         << "\n"
+               << "Exact value is "      << exact                       << "\n"
+               << "Relative error is "   << std::abs(exact - cal)/exact << "\n"
+               << "Tolerance is "        << tol << std::endl;
+    return 1;
+  }
+  return 0;
+}
+
+template <typename Scalar>
+int checker(const Scalar & net_rates_exact, 
+            const Scalar & kfwd_const_exact,  const Scalar & kfwd_exact, const Scalar & fwd_conc_exact, 
+            const Scalar & kbkwd_const_exact, const Scalar & kbkwd_exact, const Scalar & bkwd_conc_exact,
+            const Scalar & net_rates, 
+            const Scalar & kfwd_const,  const Scalar & kfwd,  const Scalar & fwd_conc, 
+            const Scalar & kbkwd_const, const Scalar & kbkwd, const Scalar & bkwd_conc,
+            const Scalar & Temp)
+{
+
+  int return_flag(0);
+
+  std::stringstream os;
+  os << Temp << "K";
+
+  return_flag = check_test(fwd_conc_exact,fwd_conc,"concentrations forward at " + os.str())       ||
+                return_flag;
+
+  return_flag = check_test(kfwd_const_exact,kfwd_const,"rate constant forward at " + os.str())    ||
+                return_flag;
+
+  return_flag = check_test(kfwd_exact,kfwd,"rate forward at " + os.str())                         ||
+                return_flag;
+
+  return_flag = check_test(bkwd_conc_exact,bkwd_conc,"concentrations backward at " + os.str())    ||
+                return_flag;
+
+  return_flag = check_test(kbkwd_const_exact,kbkwd_const,"rate constant backward at " + os.str()) ||
+                return_flag;
+
+  return_flag = check_test(kbkwd_exact,kbkwd,"rate backward at " + os.str())                      ||
+                return_flag;
+
+  return_flag = check_test(net_rates_exact,net_rates,"net rate at " + os.str())                   ||
+                return_flag;
+
+  return return_flag;
+}
+
+template <typename Scalar>
+int test_type(const std::string& input_name, const Antioch::ParsingType & inputType)
+{
+  using std::abs;
+
+  std::vector<std::string> species_str_list;
+  const unsigned int n_species = 4;
+  species_str_list.reserve(n_species);
+  species_str_list.push_back( "H" );
+  species_str_list.push_back( "H2" );
+  species_str_list.push_back( "H2O2" );
+  species_str_list.push_back( "HO2" );
+
+  // kinetics
+  Antioch::ChemicalMixture<Scalar> chem_mixture( species_str_list );
+  Antioch::ReactionSet<Scalar> reaction_set( chem_mixture );
+  Antioch::read_reaction_set_data<Scalar>( input_name, true, reaction_set, inputType );
+
+  // thermo
+  Antioch::NASAThermoMixture<Scalar,Antioch::NASA9CurveFit<Scalar> > thermo_mixture(chem_mixture); 
+  Antioch::read_nasa_mixture_data( thermo_mixture ); // default
+  Antioch::NASAEvaluator<Scalar,Antioch::NASA9CurveFit<Scalar> > thermo(thermo_mixture); 
+
+  const Scalar T = 1500.0; // K
+  const Scalar P = 1.0e5; // Pa
+
+  // Mass fractions
+  std::vector<Scalar> Y(n_species,0.25);
+
+  const Scalar R_mix = chem_mixture.R(Y); // get R_tot in J.kg-1.K-1
+
+  std::vector<Scalar> molar_densities(n_species,0);
+
+  std::vector<Scalar> h_RT_minus_s_R(n_species);
+
+  Scalar net_rates_exact(0),
+         kfwd_const_exact(0),
+         kbkwd_const_exact(0),
+         kfwd_exact(0),
+         kbkwd_exact(0),
+         fwd_conc_exact(0),
+         bkwd_conc_exact(0);
+
+  std::vector<Scalar> net_rates,kfwd_const,kbkwd_const,kfwd,kbkwd,fwd_conc,bkwd_conc;
+
+  // golden values from bc
+  kfwd_const_exact  = 3341803.012517167957974472239343341385324934527797794;
+  fwd_conc_exact    = 0.13473900180907885567483372493084259843941997896096;
+  kfwd_exact        = 450271.20214913586326479266723410049955538508784467327734;
+  bkwd_conc_exact   = 0.06329787652743180276417606259788367794531198101580;
+  kbkwd_const_exact = 4327.11114439947889901291861278625576793065735934819023;
+  kbkwd_exact       = 273.89694693867234146591036506821238311545088830214564;
+  net_rates_exact   = 449997.30520219719092332675686903228717226963695635680885;
+
+
+  Scalar rho = P/(R_mix*T); // kg.m-3
+  chem_mixture.molar_densities(rho,Y,molar_densities);
+  const Antioch::KineticsConditions<Scalar> conditions(T);
+  const Antioch::TempCache<Scalar> Cache(T);
+  thermo.h_RT_minus_s_R(Cache,h_RT_minus_s_R);
+  reaction_set.get_reactive_scheme(conditions,molar_densities,h_RT_minus_s_R,net_rates,
+                                   kfwd_const,kbkwd_const,kfwd,kbkwd,fwd_conc,bkwd_conc);
+
+  int return_flag = checker(net_rates_exact, kfwd_const_exact, kfwd_exact, fwd_conc_exact, kbkwd_const_exact, kbkwd_exact, bkwd_conc_exact,
+                            net_rates[0],    kfwd_const[0],    kfwd[0],    fwd_conc[0],    kbkwd_const[0],    kbkwd[0],    bkwd_conc[0], T);
+
+  const Scalar Rcal = Antioch::Constants::R_universal<Scalar>() * Antioch::Constants::R_universal_unit<Scalar>().factor_to_some_unit("cal/mol/K");
+  const Scalar fac(1e-6);
+
+  for(Scalar Temp = 210; Temp < 5990; Temp += 10){
+
+    rho = P/(R_mix*Temp); // kg.m-3
+
+    molar_densities.resize(4,0);
+    chem_mixture.molar_densities(rho,Y,molar_densities);
+
+    const Antioch::KineticsConditions<Scalar> conditionsTemp(Temp);
+    const Antioch::TempCache<Scalar> CacheTemp(Temp);
+    h_RT_minus_s_R.resize(4,0);
+    thermo.h_RT_minus_s_R(CacheTemp,h_RT_minus_s_R);
+
+    net_rates.clear();
+    kfwd_const.clear();
+    kbkwd_const.clear();
+    kfwd.clear();
+    kbkwd.clear();
+    fwd_conc.clear();
+    bkwd_conc.clear();
+    reaction_set.get_reactive_scheme(conditionsTemp,molar_densities,h_RT_minus_s_R,net_rates,
+                                     kfwd_const,kbkwd_const,kfwd,kbkwd,fwd_conc,bkwd_conc);
+
+// H2O2 + H <=> HO2 + H2
+// k = Arrhenius(4.82e13 (cm3/mol/s), 7.95e3 (cal/mol) )
+// m_H2O2 = 1.5
+// m_H = 0.5
+// m_HO2 = 2
+// m_H2 = 1
+    fwd_conc_exact    = Antioch::ant_pow(molar_densities[2],1.5) * Antioch::ant_pow(molar_densities[0],0.5);
+    bkwd_conc_exact   = Antioch::ant_pow(molar_densities[3],2) * molar_densities[1];
+    kfwd_const_exact  = 4.82e13 * fac * std::exp(-7.95e3/(Rcal * Temp)); // Arrhenius
+    kfwd_exact        = kfwd_const_exact * fwd_conc_exact;
+    kbkwd_const_exact = kfwd_const_exact / Antioch::ant_exp(G(Temp));
+    kbkwd_exact       = kbkwd_const_exact * bkwd_conc_exact;
+    net_rates_exact   = kfwd_exact - kbkwd_exact;
+
+    return_flag = checker(net_rates_exact, kfwd_const_exact, kfwd_exact, fwd_conc_exact, kbkwd_const_exact, kbkwd_exact, bkwd_conc_exact,
+                          net_rates[0],    kfwd_const[0],    kfwd[0],    fwd_conc[0],    kbkwd_const[0],    kbkwd[0],    bkwd_conc[0], Temp) ||
+                  return_flag;
+  }
+
+  return return_flag;
+}
+
+template <typename Scalar>
+int tester(const std::string& input_name_xml, const std::string& input_name_ck)
+{
+  return test_type<Scalar>(input_name_xml, Antioch::ParsingType::XML) ||
+    test_type<Scalar>(input_name_ck, Antioch::ParsingType::CHEMKIN);
+}
+
+int main(int argc, char* argv[])
+{
+  // Check command line count.
+  if( argc < 3 )
+    {
+      // TODO: Need more consistent error handling.
+      std::cerr << "Error: Must specify reaction set XML input file and reaction set ChemKin input file." << std::endl;
+      antioch_error();
+    }
+
+  return (tester<float>(std::string(argv[1]), std::string(argv[2]) ) ||
+          tester<double>(std::string(argv[1]), std::string(argv[2]) )  /*||
+          tester<long double>(std::string(argv[1]), std::string(argv[2]) )*/
+         ); 
+}

--- a/test/kinetics_partial_order_unit.sh.in
+++ b/test/kinetics_partial_order_unit.sh.in
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+PROG="@top_builddir@/test/kinetics_partial_order_unit"
+
+INPUT="@top_srcdir@/test/input_files/orders_xml.inp @top_srcdir@/test/input_files/orders_chemkin.inp"
+
+$PROG $INPUT
+


### PR DESCRIPTION
This is PR #172 rebased on master. The only thing really changed was I trimmed some of the string utilities to use new functions I introduced in PR #179. `make check` passed all along the way. Going to go ahead and merge since I'll be cleaning up the XML parser anyway. Will open new issues for for the XML cross-compatibility bits. @beanSnippet, would still be glad if you tried out your input on master after this is merged and let us know if you have any problems.

Also, @SylvainPlessis, start using CppUnit for new tests. :) Hopefully @tradowsk will be migrating some of the old one to CppUnit soon.