### PR TITLE
Add antioch_error_msg

### DIFF
--- a/src/transport/include/antioch/mixture_averaged_transport_evaluator.h
+++ b/src/transport/include/antioch/mixture_averaged_transport_evaluator.h
@@ -609,8 +609,7 @@ namespace Antioch
         }
       default:
         {
-          antioch_msg_error("ERROR: Invalid DiffusivityType in MixtureAveragedTransportEvaluator::diffusion_mixing_rule");
-          antioch_error();
+          antioch_error_msg("ERROR: Invalid DiffusivityType in MixtureAveragedTransportEvaluator::diffusion_mixing_rule");
         }
       } // switch(diff_type)
   }

--- a/src/transport/include/antioch/mixture_diffusion.h
+++ b/src/transport/include/antioch/mixture_diffusion.h
@@ -221,7 +221,7 @@ namespace Antioch
         std::string error = "ERROR: You're trying to construct an object\n";
         error += "       with an unknown diffusion model!\n";
         error += "       Does your compiler not support static_assert?";
-        antioch_msg_error(error);
+        antioch_error_msg(error);
       }
 
     // Build tag so we defer to the right initialization function

--- a/src/utilities/include/antioch/antioch_asserts.h
+++ b/src/utilities/include/antioch/antioch_asserts.h
@@ -123,8 +123,9 @@
 
 
 // Just outputing to std::cerr
-#define antioch_msg_error(errmsg)           do { std::cerr << errmsg << std::endl; }                   while(0)
-#define antioch_not_implemented_msg(errmsg) do {antioch_msg_error(errmsg); antioch_not_implemented();} while(0)
+#define antioch_msg(errmsg)                 do {std::cerr << errmsg << std::endl;} while(0)
+#define antioch_error_msg(errmsg)           do {antioch_msg(errmsg); antioch_error();} while(0)
+#define antioch_not_implemented_msg(errmsg) do {antioch_msg(errmsg); antioch_not_implemented();} while(0)
 
 // Encapsulate guarding static_assert until we require C++11
 #ifdef ANTIOCH_HAVE_CXX_STATIC_ASSERT

--- a/src/viscosity/include/antioch/blottner_viscosity.h
+++ b/src/viscosity/include/antioch/blottner_viscosity.h
@@ -154,8 +154,7 @@ namespace Antioch
   inline
   void BlottnerViscosity<CoeffType>::extrapolate_max_temp_impl(const StateType & /*Tmax*/)
   {
-    antioch_msg_error("Extrapolation not well defined for BlottnerViscosity!");
-    antioch_error();
+    antioch_error_msg("Extrapolation not well defined for BlottnerViscosity!");
   }
 
 } // end namespace Antioch

--- a/src/viscosity/include/antioch/sutherland_viscosity.h
+++ b/src/viscosity/include/antioch/sutherland_viscosity.h
@@ -140,8 +140,7 @@ namespace Antioch
   inline
   void SutherlandViscosity<CoeffType>::extrapolate_max_temp_impl(const StateType & /*Tmax*/)
   {
-    antioch_msg_error("Extrapolation not well defined for SutherlandViscosity!");
-    antioch_error();
+    antioch_error_msg("Extrapolation not well defined for SutherlandViscosity!");
   }
 
 } // end namespace Antioch


### PR DESCRIPTION
I found antioch_msg_error misleading (it didn't actually call
antioch_error() ) and not consistent with libmesh_error_msg. :)
This adds the macro and patches up a couple of places where it was
used.