### PR TITLE
NASA Curve Fit Refactor, Part 2

### DIFF
--- a/src/parsing/include/antioch/ascii_parser.h
+++ b/src/parsing/include/antioch/ascii_parser.h
@@ -122,20 +122,20 @@ namespace Antioch
 ///////////////
 
 //global overload
-        //! reads the thermo, NASA generalist, no templates for virtual
-        void read_thermodynamic_data(NASAThermoMixture<NumericType, NASA7CurveFit<NumericType> >& thermo)
-                {this->read_thermodynamic_data_root(thermo);}
+    //! reads the thermo, NASA generalist, no templates for virtual
+    void read_thermodynamic_data(NASAThermoMixture<NumericType, NASA7CurveFit<NumericType> >& /*thermo*/)
+    {antioch_error_msg("ERROR: ASCIIParsing only supports parsing for CEACurveFit!");}
+
+    //! reads the thermo, NASA generalist, no templates for virtual
+    void read_thermodynamic_data(NASAThermoMixture<NumericType, NASA9CurveFit<NumericType> >& /*thermo*/)
+    {antioch_error_msg("ERROR: ASCIIParsing only supports parsing for CEACurveFit!");}
 
         //! reads the thermo, NASA generalist, no templates for virtual
-        void read_thermodynamic_data(NASAThermoMixture<NumericType, NASA9CurveFit<NumericType> >& thermo)
-                {this->read_thermodynamic_data_root(thermo);}
+    void read_thermodynamic_data(NASAThermoMixture<NumericType, CEACurveFit<NumericType> >& thermo)
+    {this->read_thermodynamic_data_root(thermo);}
 
-        //! reads the thermo, NASA generalist, no templates for virtual
-        void read_thermodynamic_data(NASAThermoMixture<NumericType, CEACurveFit<NumericType> >& thermo)
-                {this->read_thermodynamic_data_root(thermo);}
-
-        //! read the thermodynamic data, deprecated object
-        void read_thermodynamic_data(CEAThermodynamics<NumericType>& thermo);
+    //! read the thermodynamic data, deprecated object
+    void read_thermodynamic_data(CEAThermodynamics<NumericType>& /*thermo*/);
 
      private:
 

--- a/src/parsing/include/antioch/chemkin_parser.h
+++ b/src/parsing/include/antioch/chemkin_parser.h
@@ -105,21 +105,21 @@ namespace Antioch{
 // a way so they shadow themselves
 // => we need to implement all or nothing
 
-        //! reads the thermo, NASA generalist, no templates for virtual
-        void read_thermodynamic_data(NASAThermoMixture<NumericType, NASA7CurveFit<NumericType> >& thermo)
-                {this->read_thermodynamic_data_root(thermo);}
+    //! reads the thermo, NASA generalist, no templates for virtual
+    void read_thermodynamic_data(NASAThermoMixture<NumericType, NASA7CurveFit<NumericType> >& thermo)
+    {this->read_thermodynamic_data_root(thermo);}
 
-        //! reads the thermo, NASA generalist, no templates for virtual
-        void read_thermodynamic_data(NASAThermoMixture<NumericType, NASA9CurveFit<NumericType> >& /*thermo*/)
-                {antioch_not_implemented_msg(ParserBase<NumericType>::_not_implemented);}
+    //! reads the thermo, NASA generalist, no templates for virtual
+    void read_thermodynamic_data(NASAThermoMixture<NumericType, NASA9CurveFit<NumericType> >& /*thermo*/)
+    {antioch_error_msg("ERROR: ChemKin Parsing only supports parsing for NASA7CurveFit!");}
 
-        //! reads the thermo, NASA generalist, no templates for virtual
-        void read_thermodynamic_data(NASAThermoMixture<NumericType, CEACurveFit<NumericType> >& /*thermo*/)
-                {antioch_not_implemented_msg(ParserBase<NumericType>::_not_implemented);}
+    //! reads the thermo, NASA generalist, no templates for virtual
+    void read_thermodynamic_data(NASAThermoMixture<NumericType, CEACurveFit<NumericType> >& /*thermo*/)
+    {antioch_error_msg("ERROR: ChemKin Parsing only supports parsing for NASA7CurveFit!");}
 
-        //! reads the thermo, CEA deprecated
-        void read_thermodynamic_data(CEAThermodynamics<NumericType >& /*thermo*/)
-                {antioch_not_implemented_msg(ParserBase<NumericType>::_not_implemented);}
+    //! reads the thermo, CEA deprecated
+    void read_thermodynamic_data(CEAThermodynamics<NumericType >& /*thermo*/)
+    {antioch_error_msg("ERROR: ChemKin Parsing only supports parsing for NASA7CurveFit!");}
 
 ///////////////// kinetics
 

--- a/src/parsing/include/antioch/xml_parser.h
+++ b/src/parsing/include/antioch/xml_parser.h
@@ -100,13 +100,13 @@ namespace Antioch{
         void read_thermodynamic_data(NASAThermoMixture<NumericType, NASA9CurveFit<NumericType> >& thermo)
                 {this->read_thermodynamic_data_root(thermo);}
 
-        //! reads the thermo, NASA generalist, no templates for virtual
-        void read_thermodynamic_data(NASAThermoMixture<NumericType, CEACurveFit<NumericType> >& thermo)
-                {this->read_thermodynamic_data_root(thermo);}
+    //! reads the thermo, NASA generalist, no templates for virtual
+    void read_thermodynamic_data(NASAThermoMixture<NumericType, CEACurveFit<NumericType> >& /*thermo*/)
+    {antioch_error_msg("ERROR: XML Parsing only supports parsing for NASA7CurveFit and NASA9CurveFit!");}
 
-        //! reads the thermo, CEA deprecated
-        void read_thermodynamic_data(CEAThermodynamics<NumericType >& thermo)
-                {this->read_thermodynamic_data_root(thermo);}
+    //! reads the thermo, CEA deprecated
+    void read_thermodynamic_data(CEAThermodynamics<NumericType >& /*thermo*/)
+    {antioch_error_msg("ERROR: XML Parsing only supports parsing for NASA7CurveFit and NASA9CurveFit!");}
 
 /// reaction
 

--- a/src/thermo/include/antioch/cea_curve_fit.h
+++ b/src/thermo/include/antioch/cea_curve_fit.h
@@ -61,14 +61,41 @@ namespace Antioch
   template<typename CoeffType>
   inline
   CEACurveFit<CoeffType>::CEACurveFit( const std::vector<CoeffType>& coeffs )
-    :NASA9CurveFit<CoeffType>(coeffs)
-  {}
+    :NASA9CurveFit<CoeffType>()
+  {
+
+    if( this->_coefficients.size()%10 != 0 )
+      antioch_error_msg("ERROR: Expected CEA style of input for coefficients! Must be a multiple of 10!");
+
+    this->_n_coeffs = 9;
+
+    // If no temp is provided, we assume the standard CEA form.
+    this->init_nasa9_temps( coeffs, 10 );
+
+    this->remap_coeffs(coeffs);
+
+    this->check_coeff_size();
+    this->check_temp_coeff_size_consistency();
+  }
 
   template<typename CoeffType>
   inline
-  CEACurveFit<CoeffType>::CEACurveFit( const std::vector<CoeffType>& coeffs, const std::vector<CoeffType> & temps )
-    :NASA9CurveFit<CoeffType>(coeffs,temps)
-  {}
+  CEACurveFit<CoeffType>::CEACurveFit( const std::vector<CoeffType>& coeffs,
+                                       const std::vector<CoeffType> & temp )
+    :NASA9CurveFit<CoeffType>()
+  {
+    if( this->_coefficients.size()%10 != 0 )
+      antioch_error_msg("ERROR: Expected CEA style of input for coefficients! Must be a multiple of 10!");
+
+    this->_n_coeffs = 9;
+
+    this->_temp = temp;
+
+    this->remap_coeffs(coeffs);
+
+    this->check_coeff_size();
+    this->check_temp_coeff_size_consistency();
+  }
 
   template<typename CoeffType>
   inline

--- a/src/thermo/include/antioch/cea_curve_fit.h
+++ b/src/thermo/include/antioch/cea_curve_fit.h
@@ -33,13 +33,11 @@ namespace Antioch
 {
   /*!\class CEACurveFit
 
-    This is a synomym for NASA9CurveFit, the NASA9
-    name ensures consistency with the NASA7 objects
-    while the CEA name provides backward compatiblity
-    and a more `physics-based' name.
-
-    Note that as nothing happens in the destructor (and
-    nothing should ever), no need to get virtual in NASA9.
+    This class only differs from NASA9CurveFit in the construction. Here,
+    we assume that there are 10 coefficients, with the 7th being zero. This is
+    exactly the format output from NASA's CEA program and, hence, this class
+    was build to enable this compatiblity. Internally, the coefficients are
+    remapped to 9 coefficients and is then functionally identical to NASA9CurveFit.
   */
   template<typename CoeffType=double>
   class CEACurveFit: public NASA9CurveFit<CoeffType>

--- a/src/thermo/include/antioch/cea_curve_fit.h
+++ b/src/thermo/include/antioch/cea_curve_fit.h
@@ -51,6 +51,11 @@ namespace Antioch
     CEACurveFit( const std::vector<CoeffType>& coeffs, const std::vector<CoeffType> & temps );
 
     ~CEACurveFit(){}
+
+  private:
+
+    void remap_coeffs( const std::vector<CoeffType>& coeffs );
+
   };
 
   template<typename CoeffType>
@@ -64,6 +69,30 @@ namespace Antioch
   CEACurveFit<CoeffType>::CEACurveFit( const std::vector<CoeffType>& coeffs, const std::vector<CoeffType> & temps )
     :NASA9CurveFit<CoeffType>(coeffs,temps)
   {}
+
+  template<typename CoeffType>
+  inline
+  void CEACurveFit<CoeffType>::remap_coeffs( const std::vector<CoeffType>& coeffs )
+  {
+    this->_coefficients.resize(this->_n_coeffs*(this->_temp.size()-1),0.0);
+
+    for( unsigned int t = 0; t < this->_temp.size()-1; t++ )
+      {
+        for( unsigned int c = 0; c < 7; c++ )
+          {
+            unsigned int i = 10*t + c;
+            unsigned int j = 9*t + c;
+            this->_coefficients[j] = coeffs[i];
+          }
+
+        for( unsigned int c = 7; c < 9; c++ )
+          {
+            unsigned int i = 10*t + c;
+            unsigned int j = 9*t + c;
+            this->_coefficients[j] = coeffs[i+1];
+          }
+      }
+  }
 
 } // end namespace Antioch
 

--- a/src/thermo/include/antioch/cea_thermo.h
+++ b/src/thermo/include/antioch/cea_thermo.h
@@ -167,7 +167,7 @@ namespace Antioch
 
     const ChemicalMixture<CoeffType>& _chem_mixture;
 
-    std::vector<NASA9CurveFit<CoeffType>* > _species_curve_fits;
+    std::vector<CEACurveFit<CoeffType>* > _species_curve_fits;
 
     std::vector<CoeffType> _cp_at_200p1;
 
@@ -211,8 +211,8 @@ namespace Antioch
   inline
   CEAThermodynamics<CoeffType>::~CEAThermodynamics()
   {
-    // Clean up all the NASA9CurveFits we created
-    for( typename std::vector<NASA9CurveFit<CoeffType>* >::iterator it = _species_curve_fits.begin();
+    // Clean up all the CEACurveFits we created
+    for( typename std::vector<CEACurveFit<CoeffType>* >::iterator it = _species_curve_fits.begin();
 	 it < _species_curve_fits.end(); ++it )
       {
 	delete (*it);
@@ -235,7 +235,7 @@ namespace Antioch
     antioch_assert_less_equal( s, _species_curve_fits.size() );
     antioch_assert( !_species_curve_fits[s] );
 
-    _species_curve_fits[s] = new NASA9CurveFit<CoeffType>(coeffs);
+    _species_curve_fits[s] = new CEACurveFit<CoeffType>(coeffs);
     return;
   }
 
@@ -246,7 +246,7 @@ namespace Antioch
   {
     bool valid = true;
 
-    for( typename std::vector<NASA9CurveFit<CoeffType>* >::const_iterator it = _species_curve_fits.begin();
+    for( typename std::vector<CEACurveFit<CoeffType>* >::const_iterator it = _species_curve_fits.begin();
 	 it != _species_curve_fits.end(); ++ it )
       {
 	if( !(*it) )

--- a/src/thermo/include/antioch/cea_thermo.h
+++ b/src/thermo/include/antioch/cea_thermo.h
@@ -382,11 +382,11 @@ namespace Antioch
     typedef typename
       Antioch::raw_value_type<StateType>::type raw_type;
 
-    /* h/RT = -a0*T^-2   + a1*T^-1*lnT + a2     + a3*T/2 + a4*T^2/3 + a5*T^3/4 + a6*T^4/5 + a8/T */
+    /* h/RT = -a0*T^-2   + a1*T^-1*lnT + a2     + a3*T/2 + a4*T^2/3 + a5*T^3/4 + a6*T^4/5 + a7/T */
     return -a[0]/cache.T2 + a[1]*cache.lnT/cache.T + a[2] +
 	   a[3]*cache.T/raw_type(2) + a[4]*cache.T2/raw_type(3) +
 	   a[5]*cache.T3/raw_type(4) + a[6]*cache.T4/raw_type(5) +
-           a[8]/cache.T;
+           a[7]/cache.T;
   }
 
 
@@ -406,10 +406,10 @@ namespace Antioch
     typedef typename
       Antioch::raw_value_type<StateType>::type raw_type;
 
-    /* s/R = -a0*T^-2/2 - a1*T^-1     + a2*lnT + a3*T   + a4*T^2/2 + a5*T^3/3 + a6*T^4/4 + a9 */
+    /* s/R = -a0*T^-2/2 - a1*T^-1     + a2*lnT + a3*T   + a4*T^2/2 + a5*T^3/3 + a6*T^4/4 + a8 */
     return -a[0]/cache.T2/raw_type(2) - a[1]/cache.T +
 	   a[2]*cache.lnT + a[3]*cache.T + a[4]*cache.T2/raw_type(2) +
-           a[5]*cache.T3/raw_type(3) + a[6]*cache.T4/raw_type(4) + a[9];
+           a[5]*cache.T3/raw_type(3) + a[6]*cache.T4/raw_type(4) + a[8];
   }
 
 
@@ -437,8 +437,8 @@ namespace Antioch
     typedef typename
       Antioch::raw_value_type<StateType>::type raw_type;
 
-    /* h/RT = -a[0]/T2    + a[1]*lnT/T + a[2]     + a[3]*T/2. + a[4]*T2/3. + a[5]*T3/4. + a[6]*T4/5. + a[8]/T,
-       s/R  = -a[0]/T2/2. - a[1]/T     + a[2]*lnT + a[3]*T    + a[4]*T2/2. + a[5]*T3/3. + a[6]*T4/4. + a[9]   */
+    /* h/RT = -a[0]/T2    + a[1]*lnT/T + a[2]     + a[3]*T/2. + a[4]*T2/3. + a[5]*T3/4. + a[6]*T4/5. + a[7]/T,
+       s/R  = -a[0]/T2/2. - a[1]/T     + a[2]*lnT + a[3]*T    + a[4]*T2/2. + a[5]*T3/3. + a[6]*T4/4. + a[8]   */
     for (unsigned int i=begin_interval; i != end_interval; ++i)
       {
         const CoeffType * const a =
@@ -446,9 +446,9 @@ namespace Antioch
 	returnval = Antioch::if_else
 	  (interval == i,
 	   StateType(-a[0]/cache.T2/raw_type(2) +
-                     (a[1] + a[8])/cache.T +
+                     (a[1] + a[7])/cache.T +
 		     a[1]*cache.lnT/cache.T - a[2]*cache.lnT +
-		     (a[2] - a[9]) - a[3]*cache.T/raw_type(2) -
+		     (a[2] - a[8]) - a[3]*cache.T/raw_type(2) -
 		     a[4]*cache.T2/raw_type(6) -
                      a[5]*cache.T3/raw_type(12) -
 		     a[6]*cache.T4/raw_type(20)),
@@ -505,15 +505,15 @@ namespace Antioch
     typedef typename
       Antioch::raw_value_type<StateType>::type raw_type;
 
-    /* h/RT = -a[0]/T2    + a[1]*lnT/T + a[2]     + a[3]*T/2. + a[4]*T2/3. + a[5]*T3/4. + a[6]*T4/5. + a[8]/T,
-       s/R  = -a[0]/T2/2. - a[1]/T     + a[2]*lnT + a[3]*T    + a[4]*T2/2. + a[5]*T3/3. + a[6]*T4/4. + a[9]   */
+    /* h/RT = -a[0]/T2    + a[1]*lnT/T + a[2]     + a[3]*T/2. + a[4]*T2/3. + a[5]*T3/4. + a[6]*T4/5. + a[7]/T,
+       s/R  = -a[0]/T2/2. - a[1]/T     + a[2]*lnT + a[3]*T    + a[4]*T2/2. + a[5]*T3/3. + a[6]*T4/4. + a[8]   */
     for (unsigned int i=begin_interval; i != end_interval; ++i)
       {
         const CoeffType * const a =
           this->_species_curve_fits[species]->coefficients(i);
 	returnval = Antioch::if_else
 	  (interval == i,
-	   StateType(a[0]/cache.T3 - a[8]/cache.T2 -
+	   StateType(a[0]/cache.T3 - a[7]/cache.T2 -
 		     a[1]*cache.lnT/cache.T2 - a[2]/cache.T -
 		     a[3]/raw_type(2) - a[4]*cache.T/raw_type(3) -
                      a[5]*cache.T2/raw_type(4) -

--- a/src/thermo/include/antioch/nasa9_curve_fit.h
+++ b/src/thermo/include/antioch/nasa9_curve_fit.h
@@ -138,6 +138,10 @@ namespace Antioch
     template <typename StateType>
     StateType dh_RT_minus_s_R_dT( const TempCache<StateType>& cache) const;
 
+  protected:
+
+    NASA9CurveFit(){};
+
   };
 
 

--- a/src/thermo/include/antioch/nasa9_curve_fit.h
+++ b/src/thermo/include/antioch/nasa9_curve_fit.h
@@ -35,13 +35,13 @@ namespace Antioch
 {
   /*! \class NASA9CurveFit
    *
-   *  This class stores the CEA polynomial fit to
+   *  This class stores the NASA polynomial fit to
    *  the thermodynamics quantities \f$\frac{C_p}{\mathrm{R}}\f$
    *  \f$\frac{h}{\mathrm{R}T}\f$ and \f$\frac{s}{\mathrm{R}T}\f$.
    *  This formulation requires nine coefficients, from \f$a_0\f$
-   *  to \f$a_9\f$, \f$a_7\f$ is always equals to zero.
+   *  to \f$a_8\f$.
    *
-   *  The temperature intervals are imposed as:
+   *  The default temperature intervals are
    *   [200--1,000], [1,000--6,000], [6,000--20,000] K.
    *
    *  The equations are:
@@ -54,14 +54,14 @@ namespace Antioch
    *        \frac{h}{\mathrm{R}T} = -\frac{a_0}{T^2} + \frac{a_1}{T} \ln(T)
    *                                + a2  + \frac{a_3}{2} T + \frac{a_4}{3} T^2
    *                                + \frac{a_5}{4} T^3 + \frac{a_6}{5} T^4
-   *                                + \frac{a_8}{T}
+   *                                + \frac{a_7}{T}
    *    \f]
    *
    *    \f[
    *        \frac{s}{\mathrm{R}} = -\frac{a_0}{2T^2} - \frac{a_1}{T}
    *                                + a_2 \ln(T) + a_3 T + \frac{a_4}{2} T^2
    *                                + \frac{a_5}{3} T^3 + \frac{a_6}{4} T^4
-   *                                + a_9
+   *                                + a_8
    *    \f]
    *
    */
@@ -71,9 +71,12 @@ namespace Antioch
   {
   public:
 
-    // for compatibility with NASA, not used
+    //! Accepts a vector temperatures to specify the temp. intervals
     NASA9CurveFit( const std::vector<CoeffType>& coeffs, const std::vector<CoeffType>& temps );
 
+    //! Assumes the coefficients correspond to the default temperature intervals
+    /*! If there are not enough coefficients for the third interval,
+        then this only builds up through the second interval. */
     NASA9CurveFit( const std::vector<CoeffType>& coeffs );
 
     ~NASA9CurveFit(){};

--- a/src/thermo/include/antioch/nasa_curve_fit_base.h
+++ b/src/thermo/include/antioch/nasa_curve_fit_base.h
@@ -67,6 +67,8 @@ namespace Antioch
 
   protected:
 
+    NASACurveFitBase(){};
+
     void check_coeff_size() const;
 
     void check_temp_coeff_size_consistency() const;
@@ -87,10 +89,6 @@ namespace Antioch
       The temperature defining the intervals
      */
     std::vector<CoeffType> _temp;
-
-  private:
-
-    NASACurveFitBase();
 
   };
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -101,6 +101,7 @@ pkginclude_HEADERS =
 standard_unit_tests_SOURCES = standard_unit/arrhenius_rate_test.C        \
                               standard_unit/arrhenius_rate_valarray_test.C \
                               standard_unit/string_utils_test.C \
+                              standard_unit/nasa9_curve_fit_test.C \
                               standard_unit/standard_unit_tests.C
 
 eigen_unit_tests_SOURCES = eigen_unit/arrhenius_rate_eigen_test.C \

--- a/test/Stockmayer_unit.C
+++ b/test/Stockmayer_unit.C
@@ -94,12 +94,12 @@ int tester()
   Antioch::ChemicalMixture<Scalar> chem_mixture( molecules );
 
   // macro thermo
-  Antioch::NASAThermoMixture<Scalar, Antioch::NASA9CurveFit<Scalar> > nasa_mixture( chem_mixture );
+  Antioch::NASAThermoMixture<Scalar, Antioch::CEACurveFit<Scalar> > nasa_mixture( chem_mixture );
 
   // ASCII and true are default, but let's be verbose
   Antioch::read_nasa_mixture_data( nasa_mixture, Antioch::DefaultFilename::thermo_data(), Antioch::ASCII, true);
 
-  typedef Antioch::NASAEvaluator<Scalar, Antioch::NASA9CurveFit<Scalar> > MacroThermo;
+  typedef Antioch::NASAEvaluator<Scalar, Antioch::CEACurveFit<Scalar> > MacroThermo;
   MacroThermo nasa_thermo( nasa_mixture );
 
   // micro thermo

--- a/test/kinetics_partial_order_unit.C
+++ b/test/kinetics_partial_order_unit.C
@@ -296,9 +296,9 @@ int test_type(const std::string& input_name, const Antioch::ParsingType & inputT
   Antioch::read_reaction_set_data<Scalar>( input_name, true, reaction_set, inputType );
 
   // thermo
-  Antioch::NASAThermoMixture<Scalar,Antioch::NASA9CurveFit<Scalar> > thermo_mixture(chem_mixture); 
+  Antioch::NASAThermoMixture<Scalar,Antioch::CEACurveFit<Scalar> > thermo_mixture(chem_mixture); 
   Antioch::read_nasa_mixture_data( thermo_mixture ); // default
-  Antioch::NASAEvaluator<Scalar,Antioch::NASA9CurveFit<Scalar> > thermo(thermo_mixture); 
+  Antioch::NASAEvaluator<Scalar,Antioch::CEACurveFit<Scalar> > thermo(thermo_mixture); 
 
   const Scalar T = 1500.0; // K
   const Scalar P = 1.0e5; // Pa

--- a/test/standard_unit/nasa9_curve_fit_test.C
+++ b/test/standard_unit/nasa9_curve_fit_test.C
@@ -1,0 +1,362 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// Antioch - A Gas Dynamics Thermochemistry Library
+//
+// Copyright (C) 2014-2016 Paul T. Bauman, Benjamin S. Kirk,
+//                         Sylvain Plessis, Roy H. Stonger
+//
+// Copyright (C) 2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include "antioch_config.h"
+
+#ifdef ANTIOCH_HAVE_CPPUNIT
+
+// C++
+#include <limits>
+
+// CppUnit
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/TestCase.h>
+
+// Antioch
+#include "antioch/nasa9_curve_fit.h"
+#include "antioch/temp_cache.h"
+
+namespace AntiochTesting
+{
+  template<typename Scalar>
+  class NASA9CurveFitTest : public CppUnit::TestCase
+  {
+  public:
+
+    void setUp()
+    {
+      this->init_N2_coeffs_200_1000();
+      this->init_N2_coeffs_1000_6000();
+      this->init_N2_coeffs_6000_20000();
+      this->init_all_N2_coeffs();
+
+      this->init_NO2_coeffs_200_1000();
+      this->init_NO2_coeffs_1000_6000();
+      this->init_all_NO2_coeffs();
+    }
+
+    void tearDown(){}
+
+    void test_nasa9_default_temp_intervals()
+    {
+      {
+        Antioch::NASA9CurveFit<Scalar> curve_fit( _all_N2_coeffs );
+        this->three_interval_test(curve_fit);
+      }
+
+      {
+        Antioch::NASA9CurveFit<Scalar> curve_fit( _all_NO2_coeffs );
+        this->two_interval_test(curve_fit);
+      }
+
+    }
+
+    void test_nasa9_user_specified_temp_intervals()
+    {
+      {
+        std::vector<Scalar> temp(4);
+        temp[0] = 200;
+        temp[1] = 1000;
+        temp[2] = 6000;
+        temp[3] = 20000;
+
+        Antioch::NASA9CurveFit<Scalar> curve_fit( _all_N2_coeffs, temp );
+        this->three_interval_test(curve_fit);
+      }
+
+      {
+        std::vector<Scalar> temp(3);
+        temp[0] = 200;
+        temp[1] = 1000;
+        temp[2] = 6000;
+
+        Antioch::NASA9CurveFit<Scalar> curve_fit( _all_NO2_coeffs, temp );
+        this->two_interval_test(curve_fit);
+      }
+
+    }
+
+    void three_interval_test( const Antioch::NASA9CurveFit<Scalar>& curve_fit )
+    {
+      Scalar T = 302.0;
+      this->test_cp( T, _N2_coeffs_200_1000, curve_fit );
+      this->test_h( T, _N2_coeffs_200_1000, curve_fit );
+      this->test_s( T, _N2_coeffs_200_1000, curve_fit );
+
+      T = 3002.0;
+      this->test_cp( T, _N2_coeffs_1000_6000, curve_fit );
+      this->test_h( T, _N2_coeffs_1000_6000, curve_fit );
+      this->test_s( T, _N2_coeffs_1000_6000, curve_fit );
+
+      T = 7002.0;
+      this->test_cp( T, _N2_coeffs_6000_20000, curve_fit );
+      this->test_h( T, _N2_coeffs_6000_20000, curve_fit );
+      this->test_s( T, _N2_coeffs_6000_20000, curve_fit );
+    }
+
+    void two_interval_test( const Antioch::NASA9CurveFit<Scalar>& curve_fit )
+    {
+      Scalar T = 302.0;
+      this->test_cp( T, _NO2_coeffs_200_1000, curve_fit );
+      this->test_h( T, _NO2_coeffs_200_1000, curve_fit );
+      this->test_s( T, _NO2_coeffs_200_1000, curve_fit );
+
+      T = 3002.0;
+      this->test_cp( T, _NO2_coeffs_1000_6000, curve_fit );
+      this->test_h( T, _NO2_coeffs_1000_6000, curve_fit );
+      this->test_s( T, _NO2_coeffs_1000_6000, curve_fit );
+    }
+
+    void test_cp( Scalar T,
+                  const std::vector<Scalar>& exact_coeffs,
+                 const Antioch::NASA9CurveFit<Scalar>& curve_fit )
+    {
+      Antioch::TempCache<Scalar> cache(T);
+      Scalar cp = this->cp_exact( T,
+                                  exact_coeffs[0],
+                                  exact_coeffs[1],
+                                  exact_coeffs[2],
+                                  exact_coeffs[3],
+                                  exact_coeffs[4],
+                                  exact_coeffs[5],
+                                  exact_coeffs[6] );
+
+      CPPUNIT_ASSERT_DOUBLES_EQUAL( cp, curve_fit.cp_over_R(cache), this->tol() );
+    }
+
+    void test_h( Scalar T,
+                 const std::vector<Scalar>& exact_coeffs,
+                 const Antioch::NASA9CurveFit<Scalar>& curve_fit )
+    {
+      Antioch::TempCache<Scalar> cache(T);
+      Scalar h = this->h_exact( T,
+                                exact_coeffs[0],
+                                exact_coeffs[1],
+                                exact_coeffs[2],
+                                exact_coeffs[3],
+                                exact_coeffs[4],
+                                exact_coeffs[5],
+                                exact_coeffs[6],
+                                exact_coeffs[7] );
+
+      CPPUNIT_ASSERT_DOUBLES_EQUAL( h, curve_fit.h_over_RT(cache), this->tol() );
+    }
+
+    void test_s( Scalar T,
+                 const std::vector<Scalar>& exact_coeffs,
+                 const Antioch::NASA9CurveFit<Scalar>& curve_fit )
+    {
+      Antioch::TempCache<Scalar> cache(T);
+      Scalar s = this->s_exact( T,
+                                exact_coeffs[0],
+                                exact_coeffs[1],
+                                exact_coeffs[2],
+                                exact_coeffs[3],
+                                exact_coeffs[4],
+                                exact_coeffs[5],
+                                exact_coeffs[6],
+                                exact_coeffs[8] );
+
+      CPPUNIT_ASSERT_DOUBLES_EQUAL( s, curve_fit.s_over_R(cache), this->tol() );
+    }
+
+    Scalar tol()
+    { return std::numeric_limits<Scalar>::epsilon() * 500; }
+
+    Scalar cp_exact( Scalar T, Scalar a0, Scalar a1, Scalar a2,
+                     Scalar a3, Scalar a4, Scalar a5, Scalar a6 )
+    {
+      return a0/(T*T) + a1/T + a2 + a3*T + a4*(T*T) + a5*(T*T*T) + a6*(T*T*T*T);
+    }
+
+    Scalar h_exact( Scalar T, Scalar a0, Scalar a1, Scalar a2,
+                    Scalar a3, Scalar a4, Scalar a5, Scalar a6,
+                    Scalar a7 )
+    {
+      return -a0/(T*T) + a1*std::log(T)/T + a2 + a3*T/2.0L + a4*(T*T)/3.0L
+        + a5*(T*T*T)/4.0L + a6*(T*T*T*T)/5.0L + a7/T;
+    }
+
+    Scalar s_exact( Scalar T, Scalar a0, Scalar a1, Scalar a2,
+                    Scalar a3, Scalar a4, Scalar a5, Scalar a6,
+                    Scalar a8 )
+    {
+      return -a0/(2.L*T*T) - a1/T + a2*std::log(T) + a3*T + a4*(T*T)/2.0L
+        + a5*(T*T*T)/3.0L + a6*(T*T*T*T)/4.0L + a8;
+    }
+
+    void init_N2_coeffs_200_1000()
+    {
+      _N2_coeffs_200_1000.resize(9);
+      _N2_coeffs_200_1000[0] =  2.21037122e+04L;
+      _N2_coeffs_200_1000[1] = -3.81846145e+02L;
+      _N2_coeffs_200_1000[2] =  6.08273815e+00L;
+      _N2_coeffs_200_1000[3] = -8.53091381e-03L;
+      _N2_coeffs_200_1000[4] =  1.38464610e-05L;
+      _N2_coeffs_200_1000[5] = -9.62579293e-09L;
+      _N2_coeffs_200_1000[6] =  2.51970560e-12L;
+      _N2_coeffs_200_1000[7] =  7.10845911e+02L;
+      _N2_coeffs_200_1000[8] = -1.07600320e+01L;
+    }
+
+    void init_N2_coeffs_1000_6000()
+    {
+      _N2_coeffs_1000_6000.resize(9);
+      _N2_coeffs_1000_6000[0] =  5.87709908e+05L;
+      _N2_coeffs_1000_6000[1] = -2.23924255e+03L;
+      _N2_coeffs_1000_6000[2] =  6.06694267e+00L;
+      _N2_coeffs_1000_6000[3] = -6.13965296e-04L;
+      _N2_coeffs_1000_6000[4] =  1.49179819e-07L;
+      _N2_coeffs_1000_6000[5] = -1.92309442e-11L;
+      _N2_coeffs_1000_6000[6] =  1.06194871e-15L;
+      _N2_coeffs_1000_6000[7] =  1.28320618e+04L;
+      _N2_coeffs_1000_6000[8] = -1.58663484e+01L;
+    }
+
+    void init_N2_coeffs_6000_20000()
+    {
+      _N2_coeffs_6000_20000.resize(9);
+      _N2_coeffs_6000_20000[0] =  8.30971200e+08L;
+      _N2_coeffs_6000_20000[1] = -6.42048187e+05L;
+      _N2_coeffs_6000_20000[2] =  2.02020507e+02L;
+      _N2_coeffs_6000_20000[3] = -3.06501961e-02L;
+      _N2_coeffs_6000_20000[4] =  2.48685558e-06L;
+      _N2_coeffs_6000_20000[5] = -9.70579208e-11L;
+      _N2_coeffs_6000_20000[6] =  1.43751673e-15L;
+      _N2_coeffs_6000_20000[7] =  4.93850663e+06L;
+      _N2_coeffs_6000_20000[8] = -1.67204791e+03L;
+    }
+
+    void init_all_N2_coeffs()
+    {
+      _all_N2_coeffs.insert(  _all_N2_coeffs.end(),
+                              _N2_coeffs_200_1000.begin(),
+                              _N2_coeffs_200_1000.end() );
+
+      _all_N2_coeffs.insert(  _all_N2_coeffs.end(),
+                              _N2_coeffs_1000_6000.begin(),
+                              _N2_coeffs_1000_6000.end() );
+
+      _all_N2_coeffs.insert(  _all_N2_coeffs.end(),
+                              _N2_coeffs_6000_20000.begin(),
+                              _N2_coeffs_6000_20000.end() );
+    }
+
+    void init_NO2_coeffs_200_1000()
+    {
+      _NO2_coeffs_200_1000.resize(9);
+      _NO2_coeffs_200_1000[0] = -5.64204584e+04L;
+      _NO2_coeffs_200_1000[1] =  9.63309734e+02L;
+      _NO2_coeffs_200_1000[2] = -2.43451851e+00L;
+      _NO2_coeffs_200_1000[3] =  1.92776414e-02L;
+      _NO2_coeffs_200_1000[4] = -1.87456362e-05L;
+      _NO2_coeffs_200_1000[5] =  9.14553637e-09L;
+      _NO2_coeffs_200_1000[6] = -1.77766146e-12L;
+      _NO2_coeffs_200_1000[7] = -1.54793043e+03L;
+      _NO2_coeffs_200_1000[8] =  4.06785541e+01L;
+    }
+
+    void init_NO2_coeffs_1000_6000()
+    {
+      _NO2_coeffs_1000_6000.resize(9);
+      _NO2_coeffs_1000_6000[0] =  7.21271176e+05L;
+      _NO2_coeffs_1000_6000[1] = -3.83253763e+03L;
+      _NO2_coeffs_1000_6000[2] =  1.11395534e+01L;
+      _NO2_coeffs_1000_6000[3] = -2.23801440e-03L;
+      _NO2_coeffs_1000_6000[4] =  6.54762164e-07L;
+      _NO2_coeffs_1000_6000[5] = -7.61120803e-11L;
+      _NO2_coeffs_1000_6000[6] =  3.32829926e-15L;
+      _NO2_coeffs_1000_6000[7] =  2.50244718e+04L;
+      _NO2_coeffs_1000_6000[8] = -4.30507224e+01L;
+    }
+
+    void init_all_NO2_coeffs()
+    {
+      _all_NO2_coeffs.insert(  _all_NO2_coeffs.end(),
+                              _NO2_coeffs_200_1000.begin(),
+                              _NO2_coeffs_200_1000.end() );
+
+      _all_NO2_coeffs.insert(  _all_NO2_coeffs.end(),
+                              _NO2_coeffs_1000_6000.begin(),
+                              _NO2_coeffs_1000_6000.end() );
+    }
+
+  protected:
+
+    std::vector<Scalar> _N2_coeffs_200_1000;
+    std::vector<Scalar> _N2_coeffs_1000_6000;
+    std::vector<Scalar> _N2_coeffs_6000_20000;
+
+    std::vector<Scalar> _NO2_coeffs_200_1000;
+    std::vector<Scalar> _NO2_coeffs_1000_6000;
+
+    std::vector<Scalar> _all_N2_coeffs;
+    std::vector<Scalar> _all_NO2_coeffs;
+  };
+
+  class NASA9CurveFitTestFloat : public NASA9CurveFitTest<float>
+  {
+  public:
+    CPPUNIT_TEST_SUITE( NASA9CurveFitTestFloat );
+
+    CPPUNIT_TEST(test_nasa9_default_temp_intervals);
+    CPPUNIT_TEST(test_nasa9_user_specified_temp_intervals);
+
+    CPPUNIT_TEST_SUITE_END();
+
+  };
+
+  class NASA9CurveFitTestDouble : public NASA9CurveFitTest<double>
+  {
+  public:
+    CPPUNIT_TEST_SUITE( NASA9CurveFitTestDouble );
+
+    CPPUNIT_TEST(test_nasa9_default_temp_intervals);
+    CPPUNIT_TEST(test_nasa9_user_specified_temp_intervals);
+
+    CPPUNIT_TEST_SUITE_END();
+
+  };
+
+  class NASA9CurveFitTestLongDouble : public NASA9CurveFitTest<long double>
+  {
+  public:
+    CPPUNIT_TEST_SUITE( NASA9CurveFitTestLongDouble );
+
+    CPPUNIT_TEST(test_nasa9_default_temp_intervals);
+    CPPUNIT_TEST(test_nasa9_user_specified_temp_intervals);
+
+    CPPUNIT_TEST_SUITE_END();
+
+  };
+
+  CPPUNIT_TEST_SUITE_REGISTRATION( NASA9CurveFitTestFloat );
+  CPPUNIT_TEST_SUITE_REGISTRATION( NASA9CurveFitTestDouble );
+  CPPUNIT_TEST_SUITE_REGISTRATION( NASA9CurveFitTestLongDouble );
+
+} // end namespace AntiochTesting
+
+#endif // ANTIOCH_HAVE_CPPUNIT

--- a/test/wilke_transport_unit.C
+++ b/test/wilke_transport_unit.C
@@ -119,9 +119,9 @@ int tester()
   typedef Antioch::StatMechThermodynamics<Scalar> MicroThermo;
 
 // macro thermo for cp (diffusion)
-  Antioch::NASAThermoMixture<Scalar,Antioch::NASA9CurveFit<Scalar> > cea_mixture( chem_mixture );
+  Antioch::NASAThermoMixture<Scalar,Antioch::CEACurveFit<Scalar> > cea_mixture( chem_mixture );
   Antioch::read_nasa_mixture_data( cea_mixture, Antioch::DefaultFilename::thermo_data(),Antioch::ASCII, true );
-  Antioch::NASAEvaluator<Scalar,Antioch::NASA9CurveFit<Scalar> > thermo_mix( cea_mixture );
+  Antioch::NASAEvaluator<Scalar,Antioch::CEACurveFit<Scalar> > thermo_mix( cea_mixture );
 
   Antioch::TransportMixture<Scalar> tran_mixture( chem_mixture );
 

--- a/test/wilke_transport_vec_unit.C
+++ b/test/wilke_transport_vec_unit.C
@@ -138,9 +138,9 @@ int tester(const PairScalars& example, const std::string& testname)
   typedef Antioch::StatMechThermodynamics< Scalar >   MicroThermo;
 
 // thermo for cp (diffusion)
-  Antioch::NASAThermoMixture<Scalar,Antioch::NASA9CurveFit<Scalar> > cea_mixture( chem_mixture );
+  Antioch::NASAThermoMixture<Scalar,Antioch::CEACurveFit<Scalar> > cea_mixture( chem_mixture );
   Antioch::read_nasa_mixture_data( cea_mixture, Antioch::DefaultFilename::thermo_data(), Antioch::ASCII, true );
-  Antioch::NASAEvaluator<Scalar,Antioch::NASA9CurveFit<Scalar> > thermo_mix( cea_mixture );
+  Antioch::NASAEvaluator<Scalar,Antioch::CEACurveFit<Scalar> > thermo_mix( cea_mixture );
 
   Antioch::TransportMixture<Scalar> tran_mixture( chem_mixture );
 


### PR DESCRIPTION
This is the second part of the NASA curve fit refactoring to facilitate updates/fixes to the parsing. This PR updates the internals of `NASA9CurveFit` to only store 9 coefficients. `NASA9CurveFit` now will only accept coefficients in the "nine form".  `CEACurveFit` only accepts coefficients in the "10 form" and will remap the 10 coefficients to the underlying 9. 

Note this preserves backward compatibility with `CEACurveFit` which has been around awhile. `NASA9CurveFit` is new so we don't need to worry about backward compatibility.

With this form for construction, we can easily apply ASCII (`CEACurveFit`) vs. XML parsing (`NASA9CurveFit`).