### PR TITLE
Support XML Parsing of NASA7 Thermodynamics

### DIFF
--- a/src/parsing/include/antioch/xml_parser.h
+++ b/src/parsing/include/antioch/xml_parser.h
@@ -226,6 +226,24 @@ namespace Antioch{
                                                         const std::string& attribute,
                                                         const std::string& attr_value ) const;
 
+    //! For the given thermo type, return the string for the corresponding XML section
+    std::string nasa_xml_section( NASAThermoMixture<NumericType, NASA7CurveFit<NumericType> >& /*thermo*/ )
+    { return _map.at(ParsingKey::NASA7); }
+
+    //! For the given thermo type, return the string for the corresponding XML section
+    std::string nasa_xml_section( NASAThermoMixture<NumericType, NASA9CurveFit<NumericType> >& /*thermo*/ )
+    { return _map.at(ParsingKey::NASA9); }
+
+    //! For the given thermo type, return the string for the corresponding XML section
+    std::string nasa_xml_section( NASAThermoMixture<NumericType, CEACurveFit<NumericType> >& /*thermo*/ )
+    { antioch_error_msg("ERROR: Only supported for NASA7CurveFit and NASA9CurveFit!"); return "";}
+
+    //! For the given thermo type, return the string for the corresponding XML section
+    std::string nasa_xml_section( CEAThermodynamics<NumericType >& /*thermo*/ )
+    { antioch_error_msg("ERROR: Only supported for NASA7CurveFit and NASA9CurveFit!"); return "";}
+
+
+
           /*! Never use default constructor*/
           XMLParser();
           tinyxml2::XMLDocument * _doc;

--- a/src/parsing/src/xml_parser.C
+++ b/src/parsing/src/xml_parser.C
@@ -202,12 +202,12 @@ namespace Antioch
   template <typename NumericType>
   const std::vector<std::string> XMLParser<NumericType>::species_list()
   {
+    if(!_species_block)
+      antioch_error_msg("ERROR: Could not find "+_map.at(ParsingKey::SPECIES_SET)+" section in input file!");
+
     std::vector<std::string> molecules;
 
-    if(_species_block)
-      {
-        split_string(std::string(_species_block->GetText())," ",molecules);
-      }
+    split_string(std::string(_species_block->GetText())," ",molecules);
 
     return molecules;
   }

--- a/src/parsing/src/xml_parser.C
+++ b/src/parsing/src/xml_parser.C
@@ -208,6 +208,7 @@ namespace Antioch
     std::vector<std::string> molecules;
 
     split_string(std::string(_species_block->GetText())," ",molecules);
+    remove_newline_from_strings(molecules);
 
     return molecules;
   }

--- a/src/parsing/src/xml_parser.C
+++ b/src/parsing/src/xml_parser.C
@@ -680,6 +680,9 @@ namespace Antioch
     const ChemicalMixture<NumericType> & chem_mixture = thermo.chemical_mixture();
     const std::vector<ChemicalSpecies<NumericType>*>& chem_species = chem_mixture.chemical_species();
 
+    // Based on the ThermoType, namely the CurveFit, we deduce what the section name is.
+    std::string nasa_xml_section = this->nasa_xml_section(thermo);
+
     for(unsigned int s = 0; s < chem_mixture.n_species(); s++)
       {
         // Step to first species block
@@ -714,9 +717,9 @@ namespace Antioch
             std::vector<std::string> coeffs_str;
 
             // looping for each of the temperature intervals for this species
-            tinyxml2::XMLElement * nasa = spec->FirstChildElement(_map.at(ParsingKey::NASA9).c_str());
+            tinyxml2::XMLElement * nasa = spec->FirstChildElement(nasa_xml_section.c_str());
             if(!nasa)
-              antioch_error_msg("ERROR: Could not find "+_map.at(ParsingKey::NASA9)+" thermo section!");
+              antioch_error_msg("ERROR: Could not find "+nasa_xml_section+" thermo section!");
 
             while(nasa)
               {
@@ -761,7 +764,7 @@ namespace Antioch
                 coeffs_str.clear();
 
                 // Move onto next interval of data
-                nasa = nasa->NextSiblingElement(_map.at(ParsingKey::NASA9).c_str());
+                nasa = nasa->NextSiblingElement(nasa_xml_section.c_str());
 
               } // end while loop
 

--- a/src/thermo/include/antioch/nasa7_curve_fit.h
+++ b/src/thermo/include/antioch/nasa7_curve_fit.h
@@ -30,6 +30,7 @@
 
 // Antioch
 #include "antioch/nasa_curve_fit_base.h"
+#include "antioch/temp_cache.h"
 
 namespace Antioch
 {

--- a/src/thermo/include/antioch/nasa9_curve_fit.h
+++ b/src/thermo/include/antioch/nasa9_curve_fit.h
@@ -29,7 +29,7 @@
 
 // Antioch
 #include "antioch/nasa_curve_fit_base.h"
-#include "antioch/metaprogramming.h"
+#include "antioch/temp_cache.h"
 
 namespace Antioch
 {

--- a/src/thermo/include/antioch/nasa_curve_fit_base.h
+++ b/src/thermo/include/antioch/nasa_curve_fit_base.h
@@ -30,7 +30,7 @@
 // Antioch
 #include "antioch/antioch_asserts.h"
 #include "antioch/metaprogramming_decl.h" // Antioch::rebind
-#include "antioch/temp_cache.h"
+#include "antioch/metaprogramming.h"
 
 // C++
 #include <vector>

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -122,6 +122,7 @@ pkginclude_HEADERS += standard_unit/reaction_rate_test_base.h
 pkginclude_HEADERS += standard_unit/reaction_rate_vector_test_base.h
 pkginclude_HEADERS += standard_unit/arrhenius_rate_test_helper.h
 pkginclude_HEADERS += standard_unit/arrhenius_rate_vector_test_base.h
+pkginclude_HEADERS += standard_unit/nasa7_thermo_test_base.h
 pkginclude_HEADERS += standard_unit/nasa9_thermo_test_base.h
 pkginclude_HEADERS += gsl_unit/gsl_spliner_test_base.h
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -101,6 +101,7 @@ pkginclude_HEADERS =
 standard_unit_tests_SOURCES = standard_unit/arrhenius_rate_test.C        \
                               standard_unit/arrhenius_rate_valarray_test.C \
                               standard_unit/string_utils_test.C \
+                              standard_unit/nasa7_curve_fit_test.C \
                               standard_unit/nasa9_curve_fit_test.C \
                               standard_unit/nasa_mixture_xml_parsing_test.C \
                               standard_unit/standard_unit_tests.C

--- a/test/input_files/nasa7_thermo_test.xml
+++ b/test/input_files/nasa7_thermo_test.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0"?>
+<ctml>
+
+  <!-- phase gri30     -->
+  <phase id="gri30">
+    <speciesArray datasrc="#species_data">
+      H2 N2
+    </speciesArray>
+  </phase>
+
+  <!-- species definitions     -->
+  <speciesData id="species_data">
+
+    <!-- species H2    -->
+    <species name="H2">
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.344331120E+00,   7.980520750E-03,  -1.947815100E-05,   2.015720940E-08,
+             -7.376117610E-12,  -9.179351730E+02,   6.830102380E-01
+           </floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.337279200E+00,  -4.940247310E-05,   4.994567780E-07,  -1.795663940E-10,
+             2.002553760E-14,  -9.501589220E+02,  -3.205023310E+00
+           </floatArray>
+        </NASA>
+      </thermo>
+    </species>
+
+    <!-- species N2    -->
+    <species name="N2">
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="300.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.298677000E+00,   1.408240400E-03,  -3.963222000E-06,   5.641515000E-09,
+             -2.444854000E-12,  -1.020899900E+03,   3.950372000E+00
+           </floatArray>
+        </NASA>
+        <NASA Tmax="5000.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.926640000E+00,   1.487976800E-03,  -5.684760000E-07,   1.009703800E-10,
+             -6.753351000E-15,  -9.227977000E+02,   5.980528000E+00
+           </floatArray>
+        </NASA>
+      </thermo>
+    </species>
+  </speciesData>
+
+</ctml>

--- a/test/standard_unit/nasa7_curve_fit_test.C
+++ b/test/standard_unit/nasa7_curve_fit_test.C
@@ -1,0 +1,198 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// Antioch - A Gas Dynamics Thermochemistry Library
+//
+// Copyright (C) 2014-2016 Paul T. Bauman, Benjamin S. Kirk,
+//                         Sylvain Plessis, Roy H. Stonger
+//
+// Copyright (C) 2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include "antioch_config.h"
+
+#ifdef ANTIOCH_HAVE_CPPUNIT
+
+// C++
+#include <limits>
+
+// Antioch
+#include "antioch/nasa7_curve_fit.h"
+#include "antioch/temp_cache.h"
+#include "nasa7_thermo_test_base.h"
+
+namespace AntiochTesting
+{
+  template<typename Scalar>
+  class NASA7CurveFitTest : public NASA7ThermoTestBase<Scalar>
+  {
+  public:
+
+    void test_nasa7_default_temp_intervals()
+    {
+      Antioch::NASA7CurveFit<Scalar> curve_fit( this->_all_standard_N2_coeffs );
+      this->N2_test(curve_fit);
+    }
+
+    void test_nasa7_user_specified_temp_intervals()
+    {
+      std::vector<Scalar> temp(3);
+      temp[0] = 200;
+      temp[1] = 1000;
+      temp[2] = 3500;
+
+      Antioch::NASA7CurveFit<Scalar> curve_fit( this->_all_standard_H2_coeffs, temp );
+      this->H2_test(curve_fit);
+    }
+
+    void N2_test( const Antioch::NASA7CurveFit<Scalar>& curve_fit )
+    {
+      Scalar T = 352.0;
+      this->test_cp( T, this->_N2_coeffs_300_1000, curve_fit );
+      this->test_h( T, this->_N2_coeffs_300_1000, curve_fit );
+      this->test_s( T, this->_N2_coeffs_300_1000, curve_fit );
+
+      T = 3002.0;
+      this->test_cp( T, this->_N2_coeffs_1000_5000, curve_fit );
+      this->test_h( T, this->_N2_coeffs_1000_5000, curve_fit );
+      this->test_s( T, this->_N2_coeffs_1000_5000, curve_fit );
+    }
+
+    void H2_test( const Antioch::NASA7CurveFit<Scalar>& curve_fit )
+    {
+      Scalar T = 352.0;
+      this->test_cp( T, this->_H2_coeffs_200_1000, curve_fit );
+      this->test_h( T, this->_H2_coeffs_200_1000, curve_fit );
+      this->test_s( T, this->_H2_coeffs_200_1000, curve_fit );
+
+      T = 2002.0;
+      this->test_cp( T, this->_H2_coeffs_1000_3500, curve_fit );
+      this->test_h( T, this->_H2_coeffs_1000_3500, curve_fit );
+      this->test_s( T, this->_H2_coeffs_1000_3500, curve_fit );
+    }
+
+    void test_cp( Scalar T,
+                  const std::vector<Scalar>& exact_coeffs,
+                 const Antioch::NASA7CurveFit<Scalar>& curve_fit )
+    {
+      Antioch::TempCache<Scalar> cache(T);
+      Scalar cp = this->cp_exact( T,
+                                  exact_coeffs[0],
+                                  exact_coeffs[1],
+                                  exact_coeffs[2],
+                                  exact_coeffs[3],
+                                  exact_coeffs[4] );
+
+      CPPUNIT_ASSERT_DOUBLES_EQUAL( cp, curve_fit.cp_over_R(cache), this->tol() );
+    }
+
+    void test_h( Scalar T,
+                 const std::vector<Scalar>& exact_coeffs,
+                 const Antioch::NASA7CurveFit<Scalar>& curve_fit )
+    {
+      Antioch::TempCache<Scalar> cache(T);
+      Scalar h = this->h_exact( T,
+                                exact_coeffs[0],
+                                exact_coeffs[1],
+                                exact_coeffs[2],
+                                exact_coeffs[3],
+                                exact_coeffs[4],
+                                exact_coeffs[5] );
+
+      CPPUNIT_ASSERT_DOUBLES_EQUAL( h, curve_fit.h_over_RT(cache), this->tol() );
+    }
+
+    void test_s( Scalar T,
+                 const std::vector<Scalar>& exact_coeffs,
+                 const Antioch::NASA7CurveFit<Scalar>& curve_fit )
+    {
+      Antioch::TempCache<Scalar> cache(T);
+      Scalar s = this->s_exact( T,
+                                exact_coeffs[0],
+                                exact_coeffs[1],
+                                exact_coeffs[2],
+                                exact_coeffs[3],
+                                exact_coeffs[4],
+                                exact_coeffs[6] );
+
+      CPPUNIT_ASSERT_DOUBLES_EQUAL( s, curve_fit.s_over_R(cache), this->tol() );
+    }
+
+    Scalar tol()
+    { return std::numeric_limits<Scalar>::epsilon() * 500; }
+
+    Scalar cp_exact( Scalar T, Scalar a0, Scalar a1, Scalar a2, Scalar a3, Scalar a4 )
+    {
+      return a0 + a1*T + a2*T*T + a3*T*T*T + a4*(T*T*T*T);
+    }
+
+    Scalar h_exact( Scalar T, Scalar a0, Scalar a1, Scalar a2, Scalar a3, Scalar a4, Scalar a5 )
+    {
+      return a0 + a1/2.0L*T + a2/3.0L*T*T + a3/4.0L*T*T*T + a4/5.0L*(T*T*T*T) + a5/T;
+    }
+
+    Scalar s_exact( Scalar T, Scalar a0, Scalar a1, Scalar a2, Scalar a3, Scalar a4, Scalar a6 )
+    {
+      return a0*std::log(T) + a1*T + a2/2.0L*T*T + a3/3.0L*T*T*T + a4/4.0L*(T*T*T*T) + a6;
+    }
+
+  };
+
+  class NASA7CurveFitTestFloat : public NASA7CurveFitTest<float>
+  {
+  public:
+    CPPUNIT_TEST_SUITE( NASA7CurveFitTestFloat );
+
+    CPPUNIT_TEST(test_nasa7_default_temp_intervals);
+    CPPUNIT_TEST(test_nasa7_user_specified_temp_intervals);
+
+    CPPUNIT_TEST_SUITE_END();
+
+  };
+
+  class NASA7CurveFitTestDouble : public NASA7CurveFitTest<double>
+  {
+  public:
+    CPPUNIT_TEST_SUITE( NASA7CurveFitTestDouble );
+
+    CPPUNIT_TEST(test_nasa7_default_temp_intervals);
+    CPPUNIT_TEST(test_nasa7_user_specified_temp_intervals);
+
+    CPPUNIT_TEST_SUITE_END();
+
+  };
+
+  class NASA7CurveFitTestLongDouble : public NASA7CurveFitTest<long double>
+  {
+  public:
+    CPPUNIT_TEST_SUITE( NASA7CurveFitTestLongDouble );
+
+    CPPUNIT_TEST(test_nasa7_default_temp_intervals);
+    CPPUNIT_TEST(test_nasa7_user_specified_temp_intervals);
+
+    CPPUNIT_TEST_SUITE_END();
+
+  };
+
+  CPPUNIT_TEST_SUITE_REGISTRATION( NASA7CurveFitTestFloat );
+  CPPUNIT_TEST_SUITE_REGISTRATION( NASA7CurveFitTestDouble );
+  CPPUNIT_TEST_SUITE_REGISTRATION( NASA7CurveFitTestLongDouble );
+
+} // end namespace AntiochTesting
+
+#endif // ANTIOCH_HAVE_CPPUNIT

--- a/test/standard_unit/nasa7_thermo_test_base.h
+++ b/test/standard_unit/nasa7_thermo_test_base.h
@@ -1,0 +1,146 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// Antioch - A Gas Dynamics Thermochemistry Library
+//
+// Copyright (C) 2014-2016 Paul T. Bauman, Benjamin S. Kirk,
+//                         Sylvain Plessis, Roy H. Stonger
+//
+// Copyright (C) 2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef ANTIOCH_NASA7_THERMO_TEST_BASE_H
+#define ANTIOCH_NASA7_THERMO_TEST_BASE_H
+
+#include "antioch_config.h"
+
+#ifdef ANTIOCH_HAVE_CPPUNIT
+
+// CppUnit
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/TestCase.h>
+
+namespace AntiochTesting
+{
+  template<typename Scalar>
+  class NASA7ThermoTestBase : public CppUnit::TestCase
+  {
+  public:
+
+    void setUp()
+    {
+      this->init_H2_coeffs_200_1000();
+      this->init_H2_coeffs_1000_3500();
+      this->init_all_H2_coeffs();
+
+      this->init_N2_coeffs_300_1000();
+      this->init_N2_coeffs_1000_5000();
+      this->init_all_N2_coeffs();
+    }
+
+    void tearDown(){}
+
+    void init_H2_coeffs_200_1000()
+    {
+      _H2_coeffs_200_1000.resize(7);
+      _H2_coeffs_200_1000[0] =  2.344331120E+00L;
+      _H2_coeffs_200_1000[1] =  7.980520750E-03L;
+      _H2_coeffs_200_1000[2] = -1.947815100E-05L;
+      _H2_coeffs_200_1000[3] =  2.015720940E-08L;
+      _H2_coeffs_200_1000[4] = -7.376117610E-12L;
+      _H2_coeffs_200_1000[5] = -9.179351730E+02L;
+      _H2_coeffs_200_1000[6] =  6.830102380E-01L;
+    }
+
+    void init_H2_coeffs_1000_3500()
+    {
+      _H2_coeffs_1000_3500.resize(7);
+      _H2_coeffs_1000_3500[0] =  3.337279200E+00L;
+      _H2_coeffs_1000_3500[1] = -4.940247310E-05L;
+      _H2_coeffs_1000_3500[2] =  4.994567780E-07L;
+      _H2_coeffs_1000_3500[3] = -1.795663940E-10L;
+      _H2_coeffs_1000_3500[4] =  2.002553760E-14L;
+      _H2_coeffs_1000_3500[5] = -9.501589220E+02L;
+      _H2_coeffs_1000_3500[6] = -3.205023310E+00L;
+    }
+
+    void init_all_H2_coeffs()
+    {
+      _all_standard_H2_coeffs.insert(  _all_standard_H2_coeffs.end(),
+                                       _H2_coeffs_200_1000.begin(),
+                                       _H2_coeffs_200_1000.end() );
+
+      _all_standard_H2_coeffs.insert(  _all_standard_H2_coeffs.end(),
+                                       _H2_coeffs_1000_3500.begin(),
+                                       _H2_coeffs_1000_3500.end() );
+    }
+
+    void init_N2_coeffs_300_1000()
+    {
+      _N2_coeffs_300_1000.resize(7);
+      _N2_coeffs_300_1000[0] =  3.298677000E+00L;
+      _N2_coeffs_300_1000[1] =  1.408240400E-03L;
+      _N2_coeffs_300_1000[2] = -3.963222000E-06L;
+      _N2_coeffs_300_1000[3] =  5.641515000E-09L;
+      _N2_coeffs_300_1000[4] = -2.444854000E-12L;
+      _N2_coeffs_300_1000[5] = -1.020899900E+03L;
+      _N2_coeffs_300_1000[6] =  3.950372000E+00L;
+    }
+
+    void init_N2_coeffs_1000_5000()
+    {
+      _N2_coeffs_1000_5000.resize(7);
+      _N2_coeffs_1000_5000[0] =  2.926640000E+00L;
+      _N2_coeffs_1000_5000[1] =  1.487976800E-03L;
+      _N2_coeffs_1000_5000[2] = -5.684760000E-07L;
+      _N2_coeffs_1000_5000[3] =  1.009703800E-10L;
+      _N2_coeffs_1000_5000[4] = -6.753351000E-15L;
+      _N2_coeffs_1000_5000[5] = -9.227977000E+02L;
+      _N2_coeffs_1000_5000[6] =  5.980528000E+00L;
+    }
+
+    void init_all_N2_coeffs()
+    {
+      _all_standard_N2_coeffs.insert(  _all_standard_N2_coeffs.end(),
+                                       _N2_coeffs_300_1000.begin(),
+                                       _N2_coeffs_300_1000.end() );
+
+      _all_standard_N2_coeffs.insert(  _all_standard_N2_coeffs.end(),
+                                       _N2_coeffs_1000_5000.begin(),
+                                       _N2_coeffs_1000_5000.end() );
+    }
+
+  protected:
+
+    std::vector<Scalar> _H2_coeffs_200_1000;
+    std::vector<Scalar> _H2_coeffs_1000_3500;
+
+    std::vector<Scalar> _N2_coeffs_300_1000;
+    std::vector<Scalar> _N2_coeffs_1000_5000;
+
+
+    std::vector<Scalar> _all_standard_H2_coeffs;
+    std::vector<Scalar> _all_standard_N2_coeffs;
+
+  };
+
+} // end namespace AntiochTesting
+
+#endif // ANTIOCH_HAVE_CPPUNIT
+
+#endif // ANTIOCH_NASA7_THERMO_TEST_BASE_H

--- a/test/standard_unit/nasa9_thermo_test_base.h
+++ b/test/standard_unit/nasa9_thermo_test_base.h
@@ -24,6 +24,9 @@
 //
 //-----------------------------------------------------------------------el-
 
+#ifndef ANTIOCH_NASA9_THERMO_TEST_BASE_H
+#define ANTIOCH_NASA9_THERMO_TEST_BASE_H
+
 #include "antioch_config.h"
 
 #ifdef ANTIOCH_HAVE_CPPUNIT
@@ -207,3 +210,5 @@ namespace AntiochTesting
 } // end namespace AntiochTesting
 
 #endif // ANTIOCH_HAVE_CPPUNIT
+
+#endif // ANTIOCH_NASA9_THERMO_TEST_BASE_H

--- a/test/standard_unit/nasa_mixture_xml_parsing_test.C
+++ b/test/standard_unit/nasa_mixture_xml_parsing_test.C
@@ -39,6 +39,7 @@
 #include "antioch/nasa9_curve_fit.h"
 #include "antioch/nasa_mixture.h"
 #include "antioch/nasa_mixture_parsing.h"
+#include "antioch/xml_parser.h"
 
 namespace AntiochTesting
 {
@@ -113,6 +114,22 @@ namespace AntiochTesting
       this->check_curve_fits(nasa_mixture);
      }
 
+    void test_parsed_species_list()
+    {
+      std::string thermo_filename = std::string(ANTIOCH_TESTING_INPUT_FILES_PATH)+"nasa7_thermo_test.xml";
+
+      Antioch::XMLParser<Scalar> xml_parser(thermo_filename,false);
+
+      std::vector<std::string> species_str_list = xml_parser.species_list();
+
+      Antioch::ChemicalMixture<Scalar> chem_mixture( species_str_list );
+
+      Antioch::NASAThermoMixture<Scalar, Antioch::NASA7CurveFit<Scalar> > nasa_mixture( chem_mixture );
+
+      xml_parser.read_thermodynamic_data(nasa_mixture);
+
+      this->check_curve_fits(nasa_mixture);
+    }
 
     void check_curve_fits( const Antioch::NASAThermoMixture<Scalar, Antioch::NASA7CurveFit<Scalar> >& nasa_mixture)
     {
@@ -181,6 +198,7 @@ namespace AntiochTesting
     CPPUNIT_TEST_SUITE( NASA7XMLParsingTestFloat );
 
     CPPUNIT_TEST(test_supplied_species);
+    CPPUNIT_TEST(test_parsed_species_list);
 
     CPPUNIT_TEST_SUITE_END();
 
@@ -192,6 +210,7 @@ namespace AntiochTesting
     CPPUNIT_TEST_SUITE( NASA7XMLParsingTestDouble );
 
     CPPUNIT_TEST(test_supplied_species);
+    CPPUNIT_TEST(test_parsed_species_list);
 
     CPPUNIT_TEST_SUITE_END();
 
@@ -203,6 +222,7 @@ namespace AntiochTesting
     CPPUNIT_TEST_SUITE( NASA7XMLParsingTestLongDouble );
 
     CPPUNIT_TEST(test_supplied_species);
+    CPPUNIT_TEST(test_parsed_species_list);
 
     CPPUNIT_TEST_SUITE_END();
 

--- a/test/standard_unit/nasa_mixture_xml_parsing_test.C
+++ b/test/standard_unit/nasa_mixture_xml_parsing_test.C
@@ -32,8 +32,10 @@
 #include <limits>
 
 // Antioch
+#include "nasa7_thermo_test_base.h"
 #include "nasa9_thermo_test_base.h"
 #include "antioch/chemical_mixture.h"
+#include "antioch/nasa7_curve_fit.h"
 #include "antioch/nasa9_curve_fit.h"
 #include "antioch/nasa_mixture.h"
 #include "antioch/nasa_mixture_parsing.h"
@@ -89,6 +91,50 @@ namespace AntiochTesting
 
   };
 
+  template<typename Scalar>
+  class NASA7XMLParsingTest : public NASA7ThermoTestBase<Scalar>
+  {
+  public:
+
+    void test_supplied_species()
+    {
+      std::vector<std::string> species_str_list(2);
+      species_str_list[0] = "H2";
+      species_str_list[1] = "N2";
+
+      Antioch::ChemicalMixture<Scalar> chem_mixture( species_str_list );
+      Antioch::NASAThermoMixture<Scalar, Antioch::NASA7CurveFit<Scalar> > nasa_mixture( chem_mixture );
+
+      std::string filename = std::string(ANTIOCH_TESTING_INPUT_FILES_PATH)+"nasa7_thermo_test.xml";
+
+      Antioch::read_nasa_mixture_data( nasa_mixture, filename, Antioch::XML );
+
+      const Antioch::NASA7CurveFit<Scalar>& H2_curve_fit =  nasa_mixture.curve_fit(0);
+      const Antioch::NASA7CurveFit<Scalar>& N2_curve_fit =  nasa_mixture.curve_fit(1);
+
+      CPPUNIT_ASSERT_EQUAL( (unsigned int)2, H2_curve_fit.n_intervals() );
+      CPPUNIT_ASSERT_EQUAL( (unsigned int)2, N2_curve_fit.n_intervals() );
+
+      // Check N2 coefficients
+      this->check_coefficients( H2_curve_fit.coefficients(0), this->_H2_coeffs_200_1000 );
+      this->check_coefficients( H2_curve_fit.coefficients(1), this->_H2_coeffs_1000_3500 );
+
+      // Check NO2 coefficients
+      this->check_coefficients( N2_curve_fit.coefficients(0), this->_N2_coeffs_300_1000 );
+      this->check_coefficients( N2_curve_fit.coefficients(1), this->_N2_coeffs_1000_5000 );
+     }
+
+    void check_coefficients( const Scalar* parsed_coeffs, std::vector<Scalar>& exact_coeffs )
+    {
+      for( unsigned int c = 0; c < exact_coeffs.size(); c++ )
+        CPPUNIT_ASSERT_DOUBLES_EQUAL( exact_coeffs[c], parsed_coeffs[c], this->tol() );
+    }
+
+    Scalar tol()
+    { return std::numeric_limits<Scalar>::epsilon() * 10; }
+
+  };
+
   class NASA9XMLParsingTestFloat : public NASA9XMLParsingTest<float>
   {
   public:
@@ -122,9 +168,45 @@ namespace AntiochTesting
 
   };
 
+  class NASA7XMLParsingTestFloat : public NASA7XMLParsingTest<float>
+  {
+  public:
+    CPPUNIT_TEST_SUITE( NASA7XMLParsingTestFloat );
+
+    CPPUNIT_TEST(test_supplied_species);
+
+    CPPUNIT_TEST_SUITE_END();
+
+  };
+
+  class NASA7XMLParsingTestDouble : public NASA7XMLParsingTest<double>
+  {
+  public:
+    CPPUNIT_TEST_SUITE( NASA7XMLParsingTestDouble );
+
+    CPPUNIT_TEST(test_supplied_species);
+
+    CPPUNIT_TEST_SUITE_END();
+
+  };
+
+  class NASA7XMLParsingTestLongDouble : public NASA7XMLParsingTest<long double>
+  {
+  public:
+    CPPUNIT_TEST_SUITE( NASA7XMLParsingTestLongDouble );
+
+    CPPUNIT_TEST(test_supplied_species);
+
+    CPPUNIT_TEST_SUITE_END();
+
+  };
+
   CPPUNIT_TEST_SUITE_REGISTRATION( NASA9XMLParsingTestFloat );
   CPPUNIT_TEST_SUITE_REGISTRATION( NASA9XMLParsingTestDouble );
   CPPUNIT_TEST_SUITE_REGISTRATION( NASA9XMLParsingTestLongDouble );
+  CPPUNIT_TEST_SUITE_REGISTRATION( NASA7XMLParsingTestFloat );
+  CPPUNIT_TEST_SUITE_REGISTRATION( NASA7XMLParsingTestDouble );
+  CPPUNIT_TEST_SUITE_REGISTRATION( NASA7XMLParsingTestLongDouble );
 
 } // end namespace AntiochTesting
 

--- a/test/standard_unit/nasa_mixture_xml_parsing_test.C
+++ b/test/standard_unit/nasa_mixture_xml_parsing_test.C
@@ -103,12 +103,19 @@ namespace AntiochTesting
       species_str_list[1] = "N2";
 
       Antioch::ChemicalMixture<Scalar> chem_mixture( species_str_list );
+
+      std::string thermo_filename = std::string(ANTIOCH_TESTING_INPUT_FILES_PATH)+"nasa7_thermo_test.xml";
+
       Antioch::NASAThermoMixture<Scalar, Antioch::NASA7CurveFit<Scalar> > nasa_mixture( chem_mixture );
 
-      std::string filename = std::string(ANTIOCH_TESTING_INPUT_FILES_PATH)+"nasa7_thermo_test.xml";
+      Antioch::read_nasa_mixture_data( nasa_mixture, thermo_filename, Antioch::XML );
 
-      Antioch::read_nasa_mixture_data( nasa_mixture, filename, Antioch::XML );
+      this->check_curve_fits(nasa_mixture);
+     }
 
+
+    void check_curve_fits( const Antioch::NASAThermoMixture<Scalar, Antioch::NASA7CurveFit<Scalar> >& nasa_mixture)
+    {
       const Antioch::NASA7CurveFit<Scalar>& H2_curve_fit =  nasa_mixture.curve_fit(0);
       const Antioch::NASA7CurveFit<Scalar>& N2_curve_fit =  nasa_mixture.curve_fit(1);
 
@@ -122,7 +129,7 @@ namespace AntiochTesting
       // Check NO2 coefficients
       this->check_coefficients( N2_curve_fit.coefficients(0), this->_N2_coeffs_300_1000 );
       this->check_coefficients( N2_curve_fit.coefficients(1), this->_N2_coeffs_1000_5000 );
-     }
+    }
 
     void check_coefficients( const Scalar* parsed_coeffs, std::vector<Scalar>& exact_coeffs )
     {


### PR DESCRIPTION
Updates the XML parser to support parsing NASA7 coefficients as well. The strategy is to just deduced, based on the `ThermoType` template parameter, whether we're NASA7 or NASA9, and then look for the appropriate keyword.

Most of the lines added here are actually unit testing of both `NASA7CurveFit` and the XML parsing of the NASA7 data. The testing includes parsing the species names from the test XML file instead of supplying them at compile time.

@dsondak, this branch should get your app working with the XML parsing. Please fetch the branch and report any issues you find.