### PR TITLE
0.4.0 release prep

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,24 @@
 Version 0.4.0 (currently in development)
+* Antioch no longer header-only
+  - The parsing and a few "core" class implementations
+    have been move to .C files and their symbols are
+    in libantioch. Thus, users must now link against
+    libantioch in their applications.
+* Added temperature exptrapolation capability to
+  KineticsTherory transport models
+* Added API to allow resetting kinetics parameters
+* Added capability to remove reaction from ReactionSet
+* Added (optional) CppUnit-based unit testing
+  - Migration of the many existing unit tests to CppUnit
+    is still in progress.
+* Added partial order support to kinetics
+  - Includes support for ChemKin-type specification
+    of forward and backward reaction orders
+* Several enhancements and bugfixes to XML, ChemKin
+  parsing classes
+* More testing of AD capabilities with (optional)
+  MetaPhsycL library
+* Several other smaller bugfixes
 
 Version 0.3.1
 * Critical Bugfix for NASA7 Thermo/ChemKin Parser

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,3 @@
-BUILT_SOURCES   = .license.stamp
-
 # Doxygen support
 include $(top_srcdir)/doxygen/aminclude.am
 
@@ -52,7 +50,7 @@ install-data-hook:
 	cd $(DESTDIR)$(includedir) && mv config.replaced antioch_config.h ;
 
 # Install config file
-BUILT_SOURCES += antioch_config.h
+BUILT_SOURCES = antioch_config.h
 include_HEADERS	= antioch_config.h
 
 # Additional files to be deleted by 'make distclean'
@@ -94,11 +92,16 @@ MAINTAINERCLEANFILES += m4/lt~obsolete.m4
 #     works.
 #STAMPED_FILES  = $(shell find $(top_srcdir)/src -name '*.h' -or -name '*.C')
 
+# Since we don't distribute the lic_utils, check and make sure it's there.
+# This way, we won't run this on distributed tarballs, only on the repos clones
+if ANTIOCH_LICENSESTAMPEXISTS
+BUILT_SOURCES += .license.stamp
 .license.stamp: $(top_srcdir)/LICENSE
 	@$(top_srcdir)/src/common/lic_utils/update_license.pl $(top_srcdir)/LICENSE $(ANTIOCH_STAMPED_FILES)
 	echo 'updated source license headers' >$@
 
 CLEANFILES = .license.stamp
+endif
 
 # -------------------------------------------
 # Optional support for code coverage analysis

--- a/Makefile.am
+++ b/Makefile.am
@@ -17,21 +17,8 @@ EXTRA_DIST       = CHANGES LICENSE COPYING share
 # trying to remove stuff.
 dist-hook:
 	chmod -R u+w $(distdir)
-	rm -rf `find $(distdir)/ -name .svn`
 	rm -rf $(distdir)/share/aclocal/antioch.m4
 	cp -L $(top_srcdir)/share/aclocal/antioch.m4 $(distdir)/share/aclocal
-
-#if SVN_CHECKOUT
-#  EXTRA_DIST     += dist_version
-#
-#TODO: check if dist_version is needed in BUILT_SOURCES (in addition to EXTRA_DIST)
-#  BUILT_SOURCES   = dist_version
-#
-#dist_version: FORCE
-#	@SVN_REVISION@ > $(top_srcdir)/dist_version
-#
-#FORCE:
-#endif
 
 # Tools in the auxiliary directory
 AUX_DIST         = build-aux/install-sh

--- a/configure.ac
+++ b/configure.ac
@@ -262,6 +262,11 @@ dnl-----------------------------------------------
 _AC_SRCDIRS(.)
 TOP_SEARCH_DIR=$ac_abs_top_srcdir
 
+# Since we don't distribute the lic_utils, check and make sure it's there.
+# This way, we won't run the license stamping perl script on distributed
+# tarballs, only on the repository clones
+AM_CONDITIONAL(ANTIOCH_LICENSESTAMPEXISTS, [test -f $TOP_SEARCH_DIR/src/common/lic_utils/update_license.pl])
+
 # We have to do this by subdirectory because otherwise distcheck
 # breaks as we start picking up files in the directories
 # that it uses.

--- a/m4/common/gsl_new.m4
+++ b/m4/common/gsl_new.m4
@@ -140,7 +140,7 @@ HAVE_GSL=0
     fi
 
     AC_MSG_CHECKING(for gsl - version >= $min_gsl_version)
-    version_succeeded=no
+    gsl_version_succeeded=no
 
     AC_LANG_PUSH([C++])
     AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[
@@ -155,13 +155,13 @@ HAVE_GSL=0
             #endif
         ]])],[
             AC_MSG_RESULT(yes)
-            version_succeeded=yes
+            gsl_version_succeeded=yes
         ],[
             AC_MSG_RESULT(no)
         ])
     AC_LANG_POP([C++])
 
-    if test "$version_succeeded" != "yes";then
+    if test "$gsl_version_succeeded" != "yes";then
        if test "$gsl_is_package_required" = yes; then
           AC_MSG_ERROR([
 
@@ -178,7 +178,7 @@ HAVE_GSL=0
     #-------------------------
 
     AC_LANG_PUSH([C])
-    AC_CHECK_HEADER([gsl/gsl_math.h],[found_header=yes],[found_header=no])
+    AC_CHECK_HEADER([gsl/gsl_math.h],[gsl_found_header=yes],[gsl_found_header=no])
     AC_LANG_POP([C])
 
 
@@ -187,32 +187,33 @@ HAVE_GSL=0
     # gamma function has been around 
     # since before v1.0
     #-------------------------------
+    gsl_succeeded=no
 
-    AC_MSG_CHECKING([for -lgsl linkage])
+    # Don't bother checking the lib unless we actually found the header
+    if test "$gsl_found_header" = "yes"; then
+       AC_MSG_CHECKING([for -lgsl linkage])
 
-    AC_LANG_PUSH([C])
+       AC_LANG_PUSH([C])
 
-    AC_CHECK_LIB([gsl],
-                 [gsl_sf_gamma],
-                 [found_library=yes],
-                 [found_library=no])
+       AC_CHECK_LIB([gsl],
+                    [gsl_sf_gamma],
+                    [gsl_found_library=yes],
+                    [gsl_found_library=no])
 
-    AC_LANG_POP([C])
+       AC_LANG_POP([C])
+
+        if test "$gsl_version_succeeded" = yes; then
+           if test "$gsl_found_library" = yes; then
+              gsl_succeeded=yes
+           fi
+        fi
+    fi
 
     CPPFLAGS="$ac_GSL_save_CPPFLAGS"
     LDFLAGS="$ac_GSL_save_LDFLAGS"
     LIBS="$ac_GSL_save_LIBS"
 
-    succeeded=no
-    if test "$found_header" = yes; then
-        if test "$version_succeeded" = yes; then
-           if test "$found_library" = yes; then
-              succeeded=yes
-           fi
-        fi
-    fi
-
-    if test "$succeeded" = no; then
+    if test "$gsl_succeeded" = no; then
        if test "$gsl_is_package_required" = yes; then
           AC_MSG_ERROR([GSL not found.  Try either --with-gsl or setting GSL_DIR.])
        else

--- a/m4/common/gsl_new.m4
+++ b/m4/common/gsl_new.m4
@@ -52,7 +52,7 @@ fi
 # package requirement; if not specified, the default is to assume that
 # the package is optional
 
-is_package_required=ifelse([$2], ,no, $2 )
+gsl_is_package_required=ifelse([$2], ,no, $2 )
 
 HAVE_GSL=0
 
@@ -86,10 +86,13 @@ HAVE_GSL=0
                  [gsl-config], 
                  [])
 
-    if test "x$GSL_CONFIG" = "x"; then
-       AC_MSG_ERROR([ Could not find gsl-config problem. 
-                   Please use --with-gsl to specify the location
-                   of the GSL library. ])
+    # Only error out if the user required GSL
+    if test "gsl_is_package_required" = "yes"; then
+       if test "x$GSL_CONFIG" = "x"; then
+          AC_MSG_ERROR([ Could not find gsl-config problem.
+                         Please use --with-gsl to specify the location
+                         of the GSL library. ])
+       fi
     fi
 
     min_gsl_version=ifelse([$1], ,1.0, $1)
@@ -152,7 +155,7 @@ HAVE_GSL=0
     AC_LANG_POP([C++])
 
     if test "$version_succeeded" != "yes";then
-       if test "$is_package_required" = yes; then
+       if test "$gsl_is_package_required" = yes; then
           AC_MSG_ERROR([
 
    Your GSL version does not meet the minimum versioning
@@ -203,7 +206,7 @@ HAVE_GSL=0
     fi
 
     if test "$succeeded" = no; then
-       if test "$is_package_required" = yes; then
+       if test "$gsl_is_package_required" = yes; then
           AC_MSG_ERROR([GSL not found.  Try either --with-gsl or setting GSL_DIR.])
        else
           AC_MSG_NOTICE([optional GSL library not found])

--- a/m4/common/gsl_new.m4
+++ b/m4/common/gsl_new.m4
@@ -54,6 +54,13 @@ fi
 
 gsl_is_package_required=ifelse([$2], ,no, $2 )
 
+if test "$gsl_is_package_required" != "yes"; then
+   if test "$gsl_is_package_required" != "no"; then
+      AC_MSG_ERROR([ Must specify "yes" or "no" for package requirement.
+                     This is specified within the build system, not the command line.])
+   fi
+fi
+
 HAVE_GSL=0
 
 # logic change: if the user called the macro, check for package,

--- a/m4/common/gsl_new.m4
+++ b/m4/common/gsl_new.m4
@@ -89,8 +89,8 @@ HAVE_GSL=0
     # Minimum version check
     #----------------------
 
-    AC_PATH_PROG([GSL_CONFIG], 
-                 [gsl-config], 
+    AC_PATH_PROG([GSL_CONFIG],
+                 [gsl-config],
                  [])
 
     # Only error out if the user required GSL
@@ -184,7 +184,7 @@ HAVE_GSL=0
 
     #-------------------------------
     # Check for a common function
-    # gamma function has been around 
+    # gamma function has been around
     # since before v1.0
     #-------------------------------
     gsl_succeeded=no

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -233,4 +233,4 @@ if CODE_COVERAGE_ENABLED
   CLEANFILES += *.gcda *.gcno
 endif
 
-EXTRA_DIST = common
+EXTRA_DIST = common/lcov

--- a/src/thermo/include/antioch/stat_mech_thermo.h
+++ b/src/thermo/include/antioch/stat_mech_thermo.h
@@ -516,9 +516,9 @@ namespace Antioch
     return CoeffType(1.5)*_chem_mixture.R(species);
   }
 
-   template<typename CoeffType>
-   inline
-  CoeffType StatMechThermodynamics<CoeffType>::cv_trans_over_R( const unsigned int species ) const
+  template<typename CoeffType>
+  inline
+  CoeffType StatMechThermodynamics<CoeffType>::cv_trans_over_R( const unsigned int /*species*/ ) const
   {
     return CoeffType(1.5);
   }

--- a/src/transport/include/antioch/mixture_diffusion.h
+++ b/src/transport/include/antioch/mixture_diffusion.h
@@ -192,11 +192,11 @@ namespace Antioch
 
     //! Invalid to call species diffusivity calculation with BinaryDiffusionBase model
     template<typename StateType>
-    void private_species_diff_impl( unsigned int s,
-                                    const StateType& rho,
-                                    const StateType& cp,
-                                    const StateType& k,
-                                    StateType& D,
+    void private_species_diff_impl( unsigned int /*s*/,
+                                    const StateType& /*rho*/,
+                                    const StateType& /*cp*/,
+                                    const StateType& /*k*/,
+                                    StateType& /*D*/,
                                     AntiochPrivate::diffusion_tag<BinaryDiffusionBase<Diffusion,CoeffType> >& /*tag*/ ) const
     {
       antioch_error();

--- a/test/gsl_unit/gsl_spliner_test.C
+++ b/test/gsl_unit/gsl_spliner_test.C
@@ -26,6 +26,7 @@
 
 #include "antioch_config.h"
 
+#ifdef ANTIOCH_HAVE_GSL
 #ifdef ANTIOCH_HAVE_CPPUNIT
 
 // C++
@@ -174,3 +175,4 @@ namespace AntiochTesting
 } // end namespace AntiochTesting
 
 #endif // ANTIOCH_HAVE_CPPUNIT
+#endif // ANTIOCH_HAVE_GSL

--- a/test/gsl_unit/gsl_spliner_test_base.h
+++ b/test/gsl_unit/gsl_spliner_test_base.h
@@ -29,6 +29,7 @@
 
 #include "antioch_config.h"
 
+#ifdef ANTIOCH_HAVE_GSL
 #ifdef ANTIOCH_HAVE_CPPUNIT
 
 #include <cppunit/extensions/HelperMacros.h>
@@ -143,5 +144,6 @@ namespace AntiochTesting
 } // end namespace AntiochTesting
 
 #endif // ANTIOCH_HAVE_CPPUNIT
+#endif // ANTIOCH_HAVE_GSL
 
 #endif // ANTIOCH_GSL_SPLINER_TEST_BASE_H

--- a/test/gsl_unit/gsl_spliner_vec_test.C
+++ b/test/gsl_unit/gsl_spliner_vec_test.C
@@ -26,6 +26,7 @@
 
 #include "antioch_config.h"
 
+#ifdef ANTIOCH_HAVE_GSL
 #ifdef ANTIOCH_HAVE_CPPUNIT
 
 // C++
@@ -468,3 +469,4 @@ namespace AntiochTesting
 } // end namespace AntiochTesting
 
 #endif // ANTIOCH_HAVE_CPPUNIT
+#endif // ANTIOCH_HAVE_GSL


### PR DESCRIPTION
Work for 0.4.0 release prep. Cleaned up a couple of warnings, updated, CHANGES, fixed #110 (and a little extra cleanup of gsl_new.m4), and made it so we don't drop the license tool in the distributed tarball (so we get rid of the plethora of output from the license-tool in the builds from tarballs, which would be very confusing to users, probably).