### PR TITLE
NASAThermo Vectorized Evaluations Fix, More Unit Testing

### DIFF
--- a/src/thermo/include/antioch/nasa7_curve_fit.h
+++ b/src/thermo/include/antioch/nasa7_curve_fit.h
@@ -175,7 +175,7 @@ namespace Antioch
 
     for (unsigned int i=begin_interval; i != end_interval; ++i)
       {
-         const CoeffType *a = this->coefficients(interval);
+         const CoeffType *a = this->coefficients(i);
 
          /* h/RT = a0     + a1*T/2 + a2*T^2/3 + a3*T^3/4 + a4*T^4/5 + a5/T */
         returnval = Antioch::if_else
@@ -203,7 +203,7 @@ namespace Antioch
 
     for (unsigned int i=begin_interval; i != end_interval; ++i)
       {
-         const CoeffType *a = this->coefficients(interval);
+         const CoeffType *a = this->coefficients(i);
 
     /* s/R = a0*lnT + a1*T   + a2*T^2/2 + a3*T^3/3 + a4*T^4/4 + a6 */
         returnval = Antioch::if_else
@@ -232,7 +232,7 @@ namespace Antioch
 
     for (unsigned int i=begin_interval; i != end_interval; ++i)
       {
-         const CoeffType *a = this->coefficients(interval);
+         const CoeffType *a = this->coefficients(i);
 
     /* h/RT =  a[0]     + a[1]*T/2. + a[2]*T2/3. + a[3]*T3/4. + a[4]*T4/5. + a[5]/T,
        s/R  =  a[0]*lnT + a[1]*T    + a[2]*T2/2. + a[3]*T3/3. + a[4]*T4/4. + a[6]   */

--- a/src/thermo/include/antioch/nasa7_curve_fit.h
+++ b/src/thermo/include/antioch/nasa7_curve_fit.h
@@ -181,8 +181,11 @@ namespace Antioch
         returnval = Antioch::if_else
         ( interval == i,
            StateType(  a[0] +
-                       a[1]*cache.T/2.0L + a[2]*cache.T2/3.0L + a[3]*cache.T3/4.0L +
-                       a[4]*cache.T4/5.0L + a[5]/cache.T),
+                       a[1]*cache.T/2 +
+                       a[2]*cache.T2/3 +
+                       a[3]*cache.T3/4 +
+                       a[4]*cache.T4/5 +
+                       a[5]/cache.T),
            returnval);
        }
        return returnval;
@@ -208,9 +211,12 @@ namespace Antioch
     /* s/R = a0*lnT + a1*T   + a2*T^2/2 + a3*T^3/3 + a4*T^4/4 + a6 */
         returnval = Antioch::if_else
         ( interval == i,
-           StateType(   a[0]*cache.lnT
-                      + a[1]*cache.T + a[2]*cache.T2/2.0L + a[3]*cache.T3/3.0L
-                      + a[4]*cache.T4/4.0L + a[6]),
+           StateType(   a[0]*cache.lnT +
+                        a[1]*cache.T +
+                        a[2]*cache.T2/2 +
+                        a[3]*cache.T3/3 +
+                        a[4]*cache.T4/4 +
+                        a[6]),
            returnval);
        }
        return returnval;
@@ -240,8 +246,10 @@ namespace Antioch
         ( interval == i,
 	   StateType(a[5]/cache.T - a[0]*cache.lnT
                      + a[0] - a[6]
-		     - a[1]/2.L*cache.T   - a[2]*cache.T2/6.L
-                     - a[3]*cache.T3/12.L - a[4]*cache.T4/20.L),
+		     - a[1]/2*cache.T
+                     - a[2]*cache.T2/6
+                     - a[3]*cache.T3/12
+                     - a[4]*cache.T4/20 ),
            returnval);
        }
        return returnval;
@@ -271,8 +279,8 @@ namespace Antioch
 	returnval = Antioch::if_else
 	  (interval == i,
 	   StateType(- a[5]/cache.T2     - a[0]/cache.T
-		     - a[1]/2.L          - a[2]*cache.T/3.L
-                     - a[3]*cache.T2/4.L - a[4]*cache.T3/5.L),
+		     - a[1]/2          - a[2]*cache.T/3
+                     - a[3]*cache.T2/4 - a[4]*cache.T3/5 ),
 	   returnval);
       }
 

--- a/src/thermo/include/antioch/nasa9_curve_fit.h
+++ b/src/thermo/include/antioch/nasa9_curve_fit.h
@@ -243,9 +243,14 @@ namespace Antioch
          /* h/RT = -a0*T^-2   + a1*T^-1*lnT + a2     + a3*T/2 + a4*T^2/3 + a5*T^3/4 + a6*T^4/5 + a7/T */
         returnval = Antioch::if_else
         ( interval == i,
-           StateType( -a[0]/cache.T2 + a[1]*cache.lnT/cache.T + a[2] +
-                       a[3]*cache.T/2.0L + a[4]*cache.T2/3.0L + a[5]*cache.T3/4.0L +
-                       a[6]*cache.T4/5.0L + a[7]/cache.T),
+           StateType( -a[0]/cache.T2 +
+                      a[1]*cache.lnT/cache.T +
+                      a[2] +
+                      a[3]*cache.T/2 +
+                      a[4]*cache.T2/3 +
+                      a[5]*cache.T3/4 +
+                      a[6]*cache.T4/5 +
+                      a[7]/cache.T ),
            returnval);
        }
        return returnval;
@@ -271,9 +276,14 @@ namespace Antioch
     /* s/R = -a0*T^-2/2 - a1*T^-1     + a2*lnT + a3*T   + a4*T^2/2 + a5*T^3/3 + a6*T^4/4 + a8 */
         returnval = Antioch::if_else
         ( interval == i,
-           StateType( -a[0]/cache.T2/2.0 - a[1]/cache.T + a[2]*cache.lnT
-                      + a[3]*cache.T + a[4]*cache.T2/2.0 + a[5]*cache.T3/3.0
-                      + a[6]*cache.T4/4.0 + a[8]),
+          StateType( -a[0]/cache.T2/2 -
+                     a[1]/cache.T +
+                     a[2]*cache.lnT +
+                     a[3]*cache.T +
+                     a[4]*cache.T2/2 +
+                     a[5]*cache.T3/3 +
+                     a[6]*cache.T4/4 +
+                     a[8] ),
            returnval);
        }
        return returnval;
@@ -301,11 +311,15 @@ namespace Antioch
        s/R  = -a[0]/T2/2. - a[1]/T     + a[2]*lnT + a[3]*T    + a[4]*T2/2. + a[5]*T3/3. + a[6]*T4/4. + a[8]   */
         returnval = Antioch::if_else
         ( interval == i,
-           StateType(-a[0]/cache.T2/2.0 + (a[1] + a[7])/cache.T +
-                     a[1]*cache.lnT/cache.T - a[2]*cache.lnT +
-                     (a[2] - a[8]) - a[3]*cache.T/2.0 -
-                     a[4]*cache.T2/6.0 - a[5]*cache.T3/12.0 -
-                     a[6]*cache.T4/20.0),
+          StateType(-a[0]/cache.T2/2
+                    + (a[1] + a[7])/cache.T
+                    + a[1]*cache.lnT/cache.T
+                    - a[2]*cache.lnT
+                    + (a[2] - a[8])
+                    - a[3]*cache.T/2
+                    - a[4]*cache.T2/6
+                    - a[5]*cache.T3/12
+                    - a[6]*cache.T4/20 ),
            returnval);
        }
        return returnval;
@@ -336,8 +350,8 @@ namespace Antioch
           (interval == i,
            StateType(a[0]/cache.T3 - a[7]/cache.T2 -
                      a[1]*cache.lnT/cache.T2 - a[2]/cache.T -
-                     a[3]/2.  - a[4]*cache.T/3. - a[5]*cache.T2/4. -
-                     a[6]*cache.T3/5.),
+                     a[3]/2  - a[4]*cache.T/3 - a[5]*cache.T2/4 -
+                     a[6]*cache.T3/5 ),
            returnval);
       }
 

--- a/src/thermo/include/antioch/nasa9_curve_fit.h
+++ b/src/thermo/include/antioch/nasa9_curve_fit.h
@@ -238,7 +238,7 @@ namespace Antioch
 
     for (unsigned int i=begin_interval; i != end_interval; ++i)
       {
-         const CoeffType *a = this->coefficients(interval);
+         const CoeffType *a = this->coefficients(i);
 
          /* h/RT = -a0*T^-2   + a1*T^-1*lnT + a2     + a3*T/2 + a4*T^2/3 + a5*T^3/4 + a6*T^4/5 + a7/T */
         returnval = Antioch::if_else
@@ -266,7 +266,7 @@ namespace Antioch
 
     for (unsigned int i=begin_interval; i != end_interval; ++i)
       {
-         const CoeffType *a = this->coefficients(interval);
+         const CoeffType *a = this->coefficients(i);
 
     /* s/R = -a0*T^-2/2 - a1*T^-1     + a2*lnT + a3*T   + a4*T^2/2 + a5*T^3/3 + a6*T^4/4 + a8 */
         returnval = Antioch::if_else
@@ -295,7 +295,7 @@ namespace Antioch
 
     for (unsigned int i=begin_interval; i != end_interval; ++i)
       {
-         const CoeffType *a = this->coefficients(interval);
+         const CoeffType *a = this->coefficients(i);
 
     /* h/RT = -a[0]/T2    + a[1]*lnT/T + a[2]     + a[3]*T/2. + a[4]*T2/3. + a[5]*T3/4. + a[6]*T4/5. + a[7]/T,
        s/R  = -a[0]/T2/2. - a[1]/T     + a[2]*lnT + a[3]*T    + a[4]*T2/2. + a[5]*T3/3. + a[6]*T4/4. + a[8]   */

--- a/src/thermo/include/antioch/nasa_evaluator.h
+++ b/src/thermo/include/antioch/nasa_evaluator.h
@@ -276,9 +276,9 @@ namespace Antioch
   StateType NASAEvaluator<CoeffType,NASAFit>::h_over_RT( const TempCache<StateType>& cache, unsigned int species ) const
   {
     antioch_assert_less( species, this->n_species() );
-    antioch_assert_less( _nasa_mixture.curve_fit(species).interval(cache.T),
-                         _nasa_mixture.curve_fit(species).n_intervals() );
-
+    // FIXME - we need assert_less to be vectorizable
+    // antioch_assert_less( _nasa_mixture.curve_fit(species).interval(cache.T),
+    //                      _nasa_mixture.curve_fit(species).n_intervals() );
     return this->_nasa_mixture.curve_fit(species).h_over_RT(cache);
   }
 
@@ -289,9 +289,9 @@ namespace Antioch
   StateType NASAEvaluator<CoeffType,NASAFit>::s_over_R( const TempCache<StateType>& cache, unsigned int species ) const
   {
     antioch_assert_less( species, this->n_species() );
-    antioch_assert_less( _nasa_mixture.curve_fit(species).interval(cache.T),
-                         _nasa_mixture.curve_fit(species).n_intervals() );
-
+    // FIXME - we need assert_less to be vectorizable
+    // antioch_assert_less( _nasa_mixture.curve_fit(species).interval(cache.T),
+    //                      _nasa_mixture.curve_fit(species).n_intervals() );
     return this->_nasa_mixture.curve_fit(species).s_over_R(cache);
   }
 
@@ -306,7 +306,6 @@ namespace Antioch
     // FIXME - we need assert_less to be vectorizable
     // antioch_assert_less( _nasa_mixture.curve_fit(species).interval(cache.T),
     //                      _nasa_mixture.curve_fit(species).n_intervals() );
-
     return this->_nasa_mixture.curve_fit(species).h_RT_minus_s_R(cache);
   }
 
@@ -326,8 +325,6 @@ namespace Antioch
       {
         h_RT_minus_s_R[s] = this->h_RT_minus_s_R(cache,s);
       }
-
-    return;
   }
 
 
@@ -342,7 +339,6 @@ namespace Antioch
     // FIXME - we need assert_less to be vectorizable
     // antioch_assert_less( _nasa_mixture.curve_fit(species).interval(cache.T),
     //                      _nasa_mixture.curve_fit(species).n_intervals() );
-
     return this->_nasa_mixture.curve_fit(species).dh_RT_minus_s_R_dT(cache);
   }
 
@@ -362,8 +358,6 @@ namespace Antioch
       {
         dh_RT_minus_s_R_dT[s] = this->dh_RT_minus_s_R_dT(cache,s);
       }
-
-    return;
   }
 
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -113,6 +113,7 @@ eigen_unit_tests_SOURCES = eigen_unit/arrhenius_rate_eigen_test.C \
                            eigen_unit/eigen_unit_tests.C
 
 vexcl_unit_tests_SOURCES = vexcl_unit/arrhenius_rate_vexcl_test.C \
+                           vexcl_unit/nasa_mixture_vexcl_test.C \
                            vexcl_unit/vexcl_unit_tests.C
 
 metaphysicl_unit_tests_SOURCES = metaphysicl_unit/arrhenius_rate_metaphysicl_test.C \

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -109,6 +109,7 @@ standard_unit_tests_SOURCES = standard_unit/arrhenius_rate_test.C        \
                               standard_unit/standard_unit_tests.C
 
 eigen_unit_tests_SOURCES = eigen_unit/arrhenius_rate_eigen_test.C \
+                           eigen_unit/nasa_mixture_eigen_test.C \
                            eigen_unit/eigen_unit_tests.C
 
 vexcl_unit_tests_SOURCES = vexcl_unit/arrhenius_rate_vexcl_test.C \

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -105,6 +105,7 @@ standard_unit_tests_SOURCES = standard_unit/arrhenius_rate_test.C        \
                               standard_unit/nasa7_curve_fit_test.C \
                               standard_unit/nasa9_curve_fit_test.C \
                               standard_unit/nasa_mixture_xml_parsing_test.C \
+                              standard_unit/nasa_mixture_valarray_test.C \
                               standard_unit/standard_unit_tests.C
 
 eigen_unit_tests_SOURCES = eigen_unit/arrhenius_rate_eigen_test.C \
@@ -126,6 +127,9 @@ pkginclude_HEADERS += standard_unit/arrhenius_rate_test_helper.h
 pkginclude_HEADERS += standard_unit/arrhenius_rate_vector_test_base.h
 pkginclude_HEADERS += standard_unit/nasa7_thermo_test_base.h
 pkginclude_HEADERS += standard_unit/nasa9_thermo_test_base.h
+pkginclude_HEADERS += standard_unit/thermo_vector_test_base.h
+pkginclude_HEADERS += standard_unit/nasa7_mixture_vector_test_base.h
+pkginclude_HEADERS += standard_unit/nasa9_mixture_vector_test_base.h
 pkginclude_HEADERS += gsl_unit/gsl_spliner_test_base.h
 
 # Sources for these tests

--- a/test/eigen_unit/nasa_mixture_eigen_test.C
+++ b/test/eigen_unit/nasa_mixture_eigen_test.C
@@ -1,0 +1,180 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// Antioch - A Gas Dynamics Thermochemistry Library
+//
+// Copyright (C) 2014-2016 Paul T. Bauman, Benjamin S. Kirk,
+//                         Sylvain Plessis, Roy H. Stonger
+//
+// Copyright (C) 2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include "antioch_config.h"
+
+#ifdef ANTIOCH_HAVE_CPPUNIT
+
+#ifdef ANTIOCH_HAVE_EIGEN
+
+// Eigen
+#include "Eigen/Dense"
+
+// CppUnit
+#include <cppunit/TestCase.h>
+
+// Antioch
+#include "antioch/eigen_utils_decl.h"
+#include "antioch/physical_constants.h"
+#include "antioch/units.h"
+#include "nasa7_mixture_vector_test_base.h"
+#include "nasa9_mixture_vector_test_base.h"
+#include "antioch/eigen_utils.h"
+
+namespace AntiochTesting
+{
+  template <typename Scalar>
+  class NASA7MixtureEigenTest : public NASA7MixtureVectorTestBase<Eigen::Array<Scalar,2*ANTIOCH_N_TUPLES,1> >,
+                                   public CppUnit::TestCase
+  {
+  public:
+
+    virtual void setUp()
+    {
+      this->init();
+      this->_example = new Eigen::Array<Scalar, 2*ANTIOCH_N_TUPLES, 1>();
+    }
+
+    virtual void tearDown()
+    {
+      this->clear();
+      delete this->_example;
+    }
+
+  };
+
+  class NASA7MixtureEigenFloatTest : public NASA7MixtureEigenTest<float>
+  {
+  public:
+
+    CPPUNIT_TEST_SUITE( NASA7MixtureEigenFloatTest );
+
+    CPPUNIT_TEST( test_all_cp );
+    CPPUNIT_TEST( test_all_h );
+    CPPUNIT_TEST( test_all_s );
+
+    CPPUNIT_TEST_SUITE_END();
+  };
+
+  class NASA7MixtureEigenDoubleTest : public NASA7MixtureEigenTest<double>
+  {
+  public:
+
+    CPPUNIT_TEST_SUITE( NASA7MixtureEigenDoubleTest );
+
+    CPPUNIT_TEST( test_all_cp );
+    CPPUNIT_TEST( test_all_h );
+    CPPUNIT_TEST( test_all_s );
+
+    CPPUNIT_TEST_SUITE_END();
+  };
+
+  class NASA7MixtureEigenLongDoubleTest : public NASA7MixtureEigenTest<long double>
+  {
+  public:
+
+    CPPUNIT_TEST_SUITE( NASA7MixtureEigenLongDoubleTest );
+
+    CPPUNIT_TEST( test_all_cp );
+    CPPUNIT_TEST( test_all_h );
+    CPPUNIT_TEST( test_all_s );
+
+    CPPUNIT_TEST_SUITE_END();
+  };
+
+
+
+  template <typename Scalar>
+  class NASA9MixtureEigenTest : public NASA9MixtureVectorTestBase<Eigen::Array<Scalar,2*ANTIOCH_N_TUPLES,1> >,
+                                   public CppUnit::TestCase
+  {
+  public:
+
+    virtual void setUp()
+    {
+      this->init();
+      this->_example = new Eigen::Array<Scalar, 2*ANTIOCH_N_TUPLES, 1>();
+    }
+
+    virtual void tearDown()
+    {
+      this->clear();
+      delete this->_example;
+    }
+
+  };
+
+  class NASA9MixtureEigenFloatTest : public NASA9MixtureEigenTest<float>
+  {
+  public:
+
+    CPPUNIT_TEST_SUITE( NASA9MixtureEigenFloatTest );
+
+    CPPUNIT_TEST( test_all_cp );
+    CPPUNIT_TEST( test_all_h );
+    CPPUNIT_TEST( test_all_s );
+
+    CPPUNIT_TEST_SUITE_END();
+  };
+
+  class NASA9MixtureEigenDoubleTest : public NASA9MixtureEigenTest<double>
+  {
+  public:
+
+    CPPUNIT_TEST_SUITE( NASA9MixtureEigenDoubleTest );
+
+    CPPUNIT_TEST( test_all_cp );
+    CPPUNIT_TEST( test_all_h );
+    CPPUNIT_TEST( test_all_s );
+
+    CPPUNIT_TEST_SUITE_END();
+  };
+
+  class NASA9MixtureEigenLongDoubleTest : public NASA9MixtureEigenTest<long double>
+  {
+  public:
+
+    CPPUNIT_TEST_SUITE( NASA9MixtureEigenLongDoubleTest );
+
+    CPPUNIT_TEST( test_all_cp );
+    CPPUNIT_TEST( test_all_h );
+    CPPUNIT_TEST( test_all_s );
+
+    CPPUNIT_TEST_SUITE_END();
+  };
+
+  CPPUNIT_TEST_SUITE_REGISTRATION( NASA7MixtureEigenFloatTest );
+  CPPUNIT_TEST_SUITE_REGISTRATION( NASA7MixtureEigenDoubleTest );
+  CPPUNIT_TEST_SUITE_REGISTRATION( NASA7MixtureEigenLongDoubleTest );
+  CPPUNIT_TEST_SUITE_REGISTRATION( NASA9MixtureEigenFloatTest );
+  CPPUNIT_TEST_SUITE_REGISTRATION( NASA9MixtureEigenDoubleTest );
+  CPPUNIT_TEST_SUITE_REGISTRATION( NASA9MixtureEigenLongDoubleTest );
+
+} // end namespace AntiochTesting
+
+#endif // ANTIOCH_HAVE_EIGEN
+
+#endif // ANTIOCH_HAVE_CPPUNIT

--- a/test/nasa_evaluator_unit.C
+++ b/test/nasa_evaluator_unit.C
@@ -84,7 +84,7 @@ int test_h( const std::string& species_name, unsigned int species, Scalar h_exac
 
   int return_flag = 0;
 
-  const Scalar tol = std::numeric_limits<Scalar>::epsilon() * 10;
+  const Scalar tol = std::numeric_limits<Scalar>::epsilon() * 100;
 
   typedef typename Antioch::template TempCache<Scalar> Cache;
 

--- a/test/standard_unit/nasa7_curve_fit_test.C
+++ b/test/standard_unit/nasa7_curve_fit_test.C
@@ -28,6 +28,10 @@
 
 #ifdef ANTIOCH_HAVE_CPPUNIT
 
+// CppUnit
+#include <cppunit/TestCase.h>
+#include <cppunit/extensions/HelperMacros.h>
+
 // C++
 #include <limits>
 
@@ -39,9 +43,15 @@
 namespace AntiochTesting
 {
   template<typename Scalar>
-  class NASA7CurveFitTest : public NASA7ThermoTestBase<Scalar>
+  class NASA7CurveFitTest : public NASA7ThermoTestBase<Scalar>,
+                            public CppUnit::TestCase
   {
   public:
+
+    virtual void setUp()
+    {
+      this->init();
+    }
 
     void test_nasa7_default_temp_intervals()
     {

--- a/test/standard_unit/nasa7_curve_fit_test.C
+++ b/test/standard_unit/nasa7_curve_fit_test.C
@@ -136,21 +136,6 @@ namespace AntiochTesting
     Scalar tol()
     { return std::numeric_limits<Scalar>::epsilon() * 500; }
 
-    Scalar cp_exact( Scalar T, Scalar a0, Scalar a1, Scalar a2, Scalar a3, Scalar a4 )
-    {
-      return a0 + a1*T + a2*T*T + a3*T*T*T + a4*(T*T*T*T);
-    }
-
-    Scalar h_exact( Scalar T, Scalar a0, Scalar a1, Scalar a2, Scalar a3, Scalar a4, Scalar a5 )
-    {
-      return a0 + a1/2.0L*T + a2/3.0L*T*T + a3/4.0L*T*T*T + a4/5.0L*(T*T*T*T) + a5/T;
-    }
-
-    Scalar s_exact( Scalar T, Scalar a0, Scalar a1, Scalar a2, Scalar a3, Scalar a4, Scalar a6 )
-    {
-      return a0*std::log(T) + a1*T + a2/2.0L*T*T + a3/3.0L*T*T*T + a4/4.0L*(T*T*T*T) + a6;
-    }
-
   };
 
   class NASA7CurveFitTestFloat : public NASA7CurveFitTest<float>

--- a/test/standard_unit/nasa7_mixture_vector_test_base.h
+++ b/test/standard_unit/nasa7_mixture_vector_test_base.h
@@ -1,0 +1,177 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// Antioch - A Gas Dynamics Thermochemistry Library
+//
+// Copyright (C) 2014-2016 Paul T. Bauman, Benjamin S. Kirk,
+//                         Sylvain Plessis, Roy H. Stonger
+//
+// Copyright (C) 2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef ANTIOCH_NASA7_MIXTURE_VECTOR_TEST_BASE_H
+#define ANTIOCH_NASA7_MIXTURE_VECTOR_TEST_BASE_H
+
+#include "antioch_config.h"
+
+#ifdef ANTIOCH_HAVE_CPPUNIT
+
+#include "thermo_vector_test_base.h"
+#include "nasa7_thermo_test_base.h"
+
+// Antioch
+#include "antioch/chemical_mixture.h"
+#include "antioch/nasa7_curve_fit.h"
+#include "antioch/nasa_mixture.h"
+#include "antioch/nasa_mixture_parsing.h"
+#include "antioch/xml_parser.h"
+
+namespace AntiochTesting
+{
+  template<typename PairScalars>
+  class NASA7MixtureVectorTestBase :
+    public ThermoVectorTestBase<Antioch::NASA7CurveFit<typename Antioch::value_type<PairScalars>::type>, PairScalars>,
+    public NASA7ThermoTestBase<typename Antioch::value_type<PairScalars>::type>
+  {
+
+  private:
+
+    typedef typename Antioch::value_type<PairScalars>::type Scalar;
+    typedef typename Antioch::NASA7CurveFit<Scalar> NASA7Fit;
+
+  public:
+
+    virtual void init()
+    {
+      NASA7ThermoTestBase<Scalar>::init();
+
+      std::vector<std::string> species_str_list(2);
+      species_str_list[0] = "H2";
+      species_str_list[1] = "N2";
+
+      this->_chem_mixture = new Antioch::ChemicalMixture<Scalar> ( species_str_list );
+
+      std::string thermo_filename = std::string(ANTIOCH_TESTING_INPUT_FILES_PATH)+"nasa7_thermo_test.xml";
+
+      this->_nasa_mixture = new Antioch::NASAThermoMixture<Scalar,NASA7Fit>( *(this->_chem_mixture) );
+
+      Antioch::read_nasa_mixture_data( *(this->_nasa_mixture), thermo_filename, Antioch::XML );
+    }
+
+    virtual void clear()
+    {
+      delete this->_nasa_mixture;
+      delete this->_chem_mixture;
+    }
+
+  protected:
+
+    virtual void prep_coeffs( Scalar T, unsigned int species,
+                              std::vector<Scalar>& coeffs )
+    {
+      unsigned int n_coeffs = 7;
+      coeffs.resize(n_coeffs);
+
+      std::string species_name =
+        this->_chem_mixture->chemical_species()[species]->species();
+
+      if( species == 0 )
+        {
+          CPPUNIT_ASSERT_EQUAL( std::string("H2"), species_name );
+
+          if( T > 200 && T <= 1000 )
+            {
+              for( unsigned int i = 0; i < n_coeffs; i++ )
+                coeffs[i] = this->_H2_coeffs_200_1000[i];
+            }
+          else if( T > 1000 && T <= 3500 )
+            {
+              for( unsigned int i = 0; i < n_coeffs; i++ )
+                coeffs[i] = this->_H2_coeffs_1000_3500[i];
+            }
+          else
+            CPPUNIT_FAIL("ERROR: Invalid temperature for species H2!");
+        }
+      else if( species == 1 )
+        {
+          CPPUNIT_ASSERT_EQUAL( std::string("N2"), species_name );
+
+          if( T > 300 && T <= 1000 )
+            {
+              for( unsigned int i = 0; i < n_coeffs; i++ )
+                coeffs[i] = this->_N2_coeffs_300_1000[i];
+            }
+          else if( T > 1000 && T <= 5000 )
+            {
+              for( unsigned int i = 0; i < n_coeffs; i++ )
+                coeffs[i] = this->_N2_coeffs_1000_5000[i];
+            }
+          else
+            CPPUNIT_FAIL("ERROR: Invalid temperature for species N2!");
+        }
+      else
+        CPPUNIT_FAIL("ERROR: Invalid species index!");
+    }
+
+    virtual Scalar cp_over_R_exact( Scalar T, const std::vector<Scalar>& coeffs )
+    {
+      CPPUNIT_ASSERT_MESSAGE("ERROR: Not enough coeffs!",
+                             coeffs.size() >= 5 );
+      return this->cp_exact( T,
+                             coeffs[0],
+                             coeffs[1],
+                             coeffs[2],
+                             coeffs[3],
+                             coeffs[4] );
+    }
+
+    virtual Scalar h_over_RT_exact( Scalar T, const std::vector<Scalar>& coeffs )
+    {
+      CPPUNIT_ASSERT_MESSAGE("ERROR: Not enough coeffs!",
+                             coeffs.size() >= 6 );
+
+      return this->h_exact( T,
+                            coeffs[0],
+                            coeffs[1],
+                            coeffs[2],
+                            coeffs[3],
+                            coeffs[4],
+                            coeffs[5] );
+    }
+
+    virtual Scalar s_over_R_exact( Scalar T, const std::vector<Scalar>& coeffs )
+    {
+      CPPUNIT_ASSERT_MESSAGE("ERROR: Not enough coeffs!",
+                             coeffs.size() >= 7 );
+
+      return this->s_exact( T,
+                            coeffs[0],
+                            coeffs[1],
+                            coeffs[2],
+                            coeffs[3],
+                            coeffs[4],
+                            coeffs[6] );
+    }
+
+  };
+
+} // end namespace AntiochTesting
+
+#endif // ANTIOCH_HAVE_CPPUNIT
+
+#endif // ANTIOCH_NASA7_MIXTURE_VECTOR_TEST_BASE_H

--- a/test/standard_unit/nasa7_thermo_test_base.h
+++ b/test/standard_unit/nasa7_thermo_test_base.h
@@ -35,6 +35,9 @@
 #include <cppunit/extensions/HelperMacros.h>
 #include <cppunit/TestCase.h>
 
+// Antioch
+#include "antioch/cmath_shims.h"
+
 namespace AntiochTesting
 {
   template<typename Scalar>
@@ -42,7 +45,7 @@ namespace AntiochTesting
   {
   public:
 
-    void setUp()
+    virtual void setUp()
     {
       this->init_H2_coeffs_200_1000();
       this->init_H2_coeffs_1000_3500();
@@ -53,7 +56,22 @@ namespace AntiochTesting
       this->init_all_N2_coeffs();
     }
 
-    void tearDown(){}
+    virtual void tearDown(){}
+
+    Scalar cp_exact( Scalar T, Scalar a0, Scalar a1, Scalar a2, Scalar a3, Scalar a4 )
+    {
+      return a0 + a1*T + a2*T*T + a3*T*T*T + a4*(T*T*T*T);
+    }
+
+    Scalar h_exact( Scalar T, Scalar a0, Scalar a1, Scalar a2, Scalar a3, Scalar a4, Scalar a5 )
+    {
+      return a0 + a1/2.0L*T + a2/3.0L*T*T + a3/4.0L*T*T*T + a4/5.0L*(T*T*T*T) + a5/T;
+    }
+
+    Scalar s_exact( Scalar T, Scalar a0, Scalar a1, Scalar a2, Scalar a3, Scalar a4, Scalar a6 )
+    {
+      return a0*std::log(T) + a1*T + a2/2.0L*T*T + a3/3.0L*T*T*T + a4/4.0L*(T*T*T*T) + a6;
+    }
 
     void init_H2_coeffs_200_1000()
     {

--- a/test/standard_unit/nasa7_thermo_test_base.h
+++ b/test/standard_unit/nasa7_thermo_test_base.h
@@ -27,25 +27,17 @@
 #ifndef ANTIOCH_NASA7_THERMO_TEST_BASE_H
 #define ANTIOCH_NASA7_THERMO_TEST_BASE_H
 
-#include "antioch_config.h"
-
-#ifdef ANTIOCH_HAVE_CPPUNIT
-
-// CppUnit
-#include <cppunit/extensions/HelperMacros.h>
-#include <cppunit/TestCase.h>
-
 // Antioch
 #include "antioch/cmath_shims.h"
 
 namespace AntiochTesting
 {
   template<typename Scalar>
-  class NASA7ThermoTestBase : public CppUnit::TestCase
+  class NASA7ThermoTestBase
   {
   public:
 
-    virtual void setUp()
+    virtual void init()
     {
       this->init_H2_coeffs_200_1000();
       this->init_H2_coeffs_1000_3500();
@@ -55,8 +47,6 @@ namespace AntiochTesting
       this->init_N2_coeffs_1000_5000();
       this->init_all_N2_coeffs();
     }
-
-    virtual void tearDown(){}
 
     Scalar cp_exact( Scalar T, Scalar a0, Scalar a1, Scalar a2, Scalar a3, Scalar a4 )
     {
@@ -158,7 +148,5 @@ namespace AntiochTesting
   };
 
 } // end namespace AntiochTesting
-
-#endif // ANTIOCH_HAVE_CPPUNIT
 
 #endif // ANTIOCH_NASA7_THERMO_TEST_BASE_H

--- a/test/standard_unit/nasa9_curve_fit_test.C
+++ b/test/standard_unit/nasa9_curve_fit_test.C
@@ -28,6 +28,10 @@
 
 #ifdef ANTIOCH_HAVE_CPPUNIT
 
+// CppUnit
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/TestCase.h>
+
 // C++
 #include <limits>
 
@@ -39,9 +43,15 @@
 namespace AntiochTesting
 {
   template<typename Scalar>
-  class NASA9CurveFitTest : public NASA9ThermoTestBase<Scalar>
+  class NASA9CurveFitTest : public NASA9ThermoTestBase<Scalar>,
+                            public CppUnit::TestCase
   {
   public:
+
+    virtual void setUp()
+    {
+      this->init();
+    }
 
     void test_nasa9_default_temp_intervals()
     {
@@ -168,28 +178,6 @@ namespace AntiochTesting
 
     Scalar tol()
     { return std::numeric_limits<Scalar>::epsilon() * 500; }
-
-    Scalar cp_exact( Scalar T, Scalar a0, Scalar a1, Scalar a2,
-                     Scalar a3, Scalar a4, Scalar a5, Scalar a6 )
-    {
-      return a0/(T*T) + a1/T + a2 + a3*T + a4*(T*T) + a5*(T*T*T) + a6*(T*T*T*T);
-    }
-
-    Scalar h_exact( Scalar T, Scalar a0, Scalar a1, Scalar a2,
-                    Scalar a3, Scalar a4, Scalar a5, Scalar a6,
-                    Scalar a7 )
-    {
-      return -a0/(T*T) + a1*std::log(T)/T + a2 + a3*T/2.0L + a4*(T*T)/3.0L
-        + a5*(T*T*T)/4.0L + a6*(T*T*T*T)/5.0L + a7/T;
-    }
-
-    Scalar s_exact( Scalar T, Scalar a0, Scalar a1, Scalar a2,
-                    Scalar a3, Scalar a4, Scalar a5, Scalar a6,
-                    Scalar a8 )
-    {
-      return -a0/(2.L*T*T) - a1/T + a2*std::log(T) + a3*T + a4*(T*T)/2.0L
-        + a5*(T*T*T)/3.0L + a6*(T*T*T*T)/4.0L + a8;
-    }
 
   };
 

--- a/test/standard_unit/nasa9_mixture_vector_test_base.h
+++ b/test/standard_unit/nasa9_mixture_vector_test_base.h
@@ -1,0 +1,183 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// Antioch - A Gas Dynamics Thermochemistry Library
+//
+// Copyright (C) 2014-2016 Paul T. Bauman, Benjamin S. Kirk,
+//                         Sylvain Plessis, Roy H. Stonger
+//
+// Copyright (C) 2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef ANTIOCH_NASA9_MIXTURE_VECTOR_TEST_BASE_H
+#define ANTIOCH_NASA9_MIXTURE_VECTOR_TEST_BASE_H
+
+#include "antioch_config.h"
+
+#ifdef ANTIOCH_HAVE_CPPUNIT
+
+#include "thermo_vector_test_base.h"
+#include "nasa9_thermo_test_base.h"
+
+// Antioch
+#include "antioch/chemical_mixture.h"
+#include "antioch/nasa9_curve_fit.h"
+#include "antioch/nasa_mixture.h"
+#include "antioch/nasa_mixture_parsing.h"
+#include "antioch/xml_parser.h"
+
+namespace AntiochTesting
+{
+  template<typename PairScalars>
+  class NASA9MixtureVectorTestBase :
+    public ThermoVectorTestBase<Antioch::NASA9CurveFit<typename Antioch::value_type<PairScalars>::type>, PairScalars>,
+    public NASA9ThermoTestBase<typename Antioch::value_type<PairScalars>::type>
+  {
+
+  private:
+
+    typedef typename Antioch::value_type<PairScalars>::type Scalar;
+    typedef typename Antioch::NASA9CurveFit<Scalar> NASA9Fit;
+
+  public:
+
+    virtual void init()
+    {
+      NASA9ThermoTestBase<Scalar>::init();
+
+      std::vector<std::string> species_str_list(2);
+      species_str_list[0] = "N2";
+      species_str_list[1] = "NO2";
+
+      this->_chem_mixture = new Antioch::ChemicalMixture<Scalar> ( species_str_list );
+
+      std::string thermo_filename = std::string(ANTIOCH_SHARE_XML_INPUT_FILES_SOURCE_PATH)+"nasa9_thermo.xml";
+
+      this->_nasa_mixture = new Antioch::NASAThermoMixture<Scalar,NASA9Fit>( *(this->_chem_mixture) );
+
+      Antioch::read_nasa_mixture_data( *(this->_nasa_mixture), thermo_filename, Antioch::XML );
+    }
+
+    virtual void clear()
+    {
+      delete this->_nasa_mixture;
+      delete this->_chem_mixture;
+    }
+
+  protected:
+
+    virtual void prep_coeffs( Scalar T, unsigned int species,
+                              std::vector<Scalar>& coeffs )
+    {
+      unsigned int n_coeffs = 9;
+      coeffs.resize(n_coeffs);
+
+      std::string species_name =
+        this->_chem_mixture->chemical_species()[species]->species();
+
+      if( species == 0 )
+        {
+          CPPUNIT_ASSERT_EQUAL( std::string("N2"), species_name );
+
+          if( T > 200 && T <= 1000 )
+            {
+              for( unsigned int i = 0; i < n_coeffs; i++ )
+                coeffs[i] = this->_N2_coeffs_200_1000[i];
+            }
+          else if( T > 1000 && T <= 3500 )
+            {
+              for( unsigned int i = 0; i < n_coeffs; i++ )
+                coeffs[i] = this->_N2_coeffs_1000_6000[i];
+            }
+          else
+            CPPUNIT_FAIL("ERROR: Invalid temperature for species N2!");
+        }
+      else if( species == 1 )
+        {
+          CPPUNIT_ASSERT_EQUAL( std::string("NO2"), species_name );
+
+          if( T > 200 && T <= 1000 )
+            {
+              for( unsigned int i = 0; i < n_coeffs; i++ )
+                coeffs[i] = this->_NO2_coeffs_200_1000[i];
+            }
+          else if( T > 1000 && T <= 6000 )
+            {
+              for( unsigned int i = 0; i < n_coeffs; i++ )
+                coeffs[i] = this->_NO2_coeffs_1000_6000[i];
+            }
+          else
+            CPPUNIT_FAIL("ERROR: Invalid temperature for species NO2!");
+        }
+      else
+        CPPUNIT_FAIL("ERROR: Invalid species index!");
+    }
+
+    virtual Scalar cp_over_R_exact( Scalar T, const std::vector<Scalar>& coeffs )
+    {
+      CPPUNIT_ASSERT_MESSAGE("ERROR: Not enough coeffs!",
+                             coeffs.size() >= 7 );
+      return this->cp_exact( T,
+                             coeffs[0],
+                             coeffs[1],
+                             coeffs[2],
+                             coeffs[3],
+                             coeffs[4],
+                             coeffs[5],
+                             coeffs[6] );
+    }
+
+    virtual Scalar h_over_RT_exact( Scalar T, const std::vector<Scalar>& coeffs )
+    {
+      CPPUNIT_ASSERT_MESSAGE("ERROR: Not enough coeffs!",
+                             coeffs.size() >= 8 );
+
+      return this->h_exact( T,
+                            coeffs[0],
+                            coeffs[1],
+                            coeffs[2],
+                            coeffs[3],
+                            coeffs[4],
+                            coeffs[5],
+                            coeffs[6],
+                            coeffs[7] );
+    }
+
+    virtual Scalar s_over_R_exact( Scalar T, const std::vector<Scalar>& coeffs )
+    {
+      CPPUNIT_ASSERT_MESSAGE("ERROR: Not enough coeffs!",
+                             coeffs.size() >= 9 );
+
+      return this->s_exact( T,
+                            coeffs[0],
+                            coeffs[1],
+                            coeffs[2],
+                            coeffs[3],
+                            coeffs[4],
+                            coeffs[5],
+                            coeffs[6],
+                            coeffs[8] );
+    }
+
+  };
+
+} // end namespace AntiochTesting
+
+#endif // ANTIOCH_HAVE_CPPUNIT
+
+#endif // ANTIOCH_NASA9_MIXTURE_VECTOR_TEST_BASE_H

--- a/test/standard_unit/nasa9_thermo_test_base.h
+++ b/test/standard_unit/nasa9_thermo_test_base.h
@@ -27,22 +27,17 @@
 #ifndef ANTIOCH_NASA9_THERMO_TEST_BASE_H
 #define ANTIOCH_NASA9_THERMO_TEST_BASE_H
 
-#include "antioch_config.h"
-
-#ifdef ANTIOCH_HAVE_CPPUNIT
-
-// CppUnit
-#include <cppunit/extensions/HelperMacros.h>
-#include <cppunit/TestCase.h>
+// Antioch
+#include "antioch/cmath_shims.h"
 
 namespace AntiochTesting
 {
   template<typename Scalar>
-  class NASA9ThermoTestBase : public CppUnit::TestCase
+  class NASA9ThermoTestBase
   {
   public:
 
-    void setUp()
+    void init()
     {
       this->init_N2_coeffs_0_200();
       this->init_N2_coeffs_200_1000();
@@ -58,7 +53,27 @@ namespace AntiochTesting
       this->init_all_NO2_coeffs();
     }
 
-    void tearDown(){}
+    Scalar cp_exact( Scalar T, Scalar a0, Scalar a1, Scalar a2,
+                     Scalar a3, Scalar a4, Scalar a5, Scalar a6 )
+    {
+      return a0/(T*T) + a1/T + a2 + a3*T + a4*(T*T) + a5*(T*T*T) + a6*(T*T*T*T);
+    }
+
+    Scalar h_exact( Scalar T, Scalar a0, Scalar a1, Scalar a2,
+                    Scalar a3, Scalar a4, Scalar a5, Scalar a6,
+                    Scalar a7 )
+    {
+      return -a0/(T*T) + a1*std::log(T)/T + a2 + a3*T/2.0L + a4*(T*T)/3.0L
+        + a5*(T*T*T)/4.0L + a6*(T*T*T*T)/5.0L + a7/T;
+    }
+
+    Scalar s_exact( Scalar T, Scalar a0, Scalar a1, Scalar a2,
+                    Scalar a3, Scalar a4, Scalar a5, Scalar a6,
+                    Scalar a8 )
+    {
+      return -a0/(2.L*T*T) - a1/T + a2*std::log(T) + a3*T + a4*(T*T)/2.0L
+        + a5*(T*T*T)/3.0L + a6*(T*T*T*T)/4.0L + a8;
+    }
 
     void init_N2_coeffs_0_200()
     {
@@ -208,7 +223,5 @@ namespace AntiochTesting
   };
 
 } // end namespace AntiochTesting
-
-#endif // ANTIOCH_HAVE_CPPUNIT
 
 #endif // ANTIOCH_NASA9_THERMO_TEST_BASE_H

--- a/test/standard_unit/nasa_mixture_valarray_test.C
+++ b/test/standard_unit/nasa_mixture_valarray_test.C
@@ -1,0 +1,176 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// Antioch - A Gas Dynamics Thermochemistry Library
+//
+// Copyright (C) 2014-2016 Paul T. Bauman, Benjamin S. Kirk,
+//                         Sylvain Plessis, Roy H. Stonger
+//
+// Copyright (C) 2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include "antioch_config.h"
+
+#ifdef ANTIOCH_HAVE_CPPUNIT
+
+// CppUnit
+#include <cppunit/TestCase.h>
+
+// C++
+#include <valarray>
+
+// Antioch
+#include "antioch/valarray_utils_decl.h"
+#include "antioch/physical_constants.h"
+#include "antioch/units.h"
+#include "nasa7_mixture_vector_test_base.h"
+#include "nasa9_mixture_vector_test_base.h"
+#include "antioch/valarray_utils.h"
+
+namespace AntiochTesting
+{
+  template <typename Scalar>
+  class NASA7MixtureValarrayTest : public NASA7MixtureVectorTestBase<std::valarray<Scalar> >,
+                                   public CppUnit::TestCase
+  {
+  public:
+
+    virtual void setUp()
+    {
+      this->init();
+      this->_example = new std::valarray<Scalar>(2*ANTIOCH_N_TUPLES);
+    }
+
+    virtual void tearDown()
+    {
+      this->clear();
+      delete this->_example;
+    }
+
+  };
+
+  class NASA7MixtureValarrayFloatTest : public NASA7MixtureValarrayTest<float>
+  {
+  public:
+
+    CPPUNIT_TEST_SUITE( NASA7MixtureValarrayFloatTest );
+
+    CPPUNIT_TEST( test_all_cp );
+    CPPUNIT_TEST( test_all_h );
+    CPPUNIT_TEST( test_all_s );
+
+    CPPUNIT_TEST_SUITE_END();
+  };
+
+  class NASA7MixtureValarrayDoubleTest : public NASA7MixtureValarrayTest<double>
+  {
+  public:
+
+    CPPUNIT_TEST_SUITE( NASA7MixtureValarrayDoubleTest );
+
+    CPPUNIT_TEST( test_all_cp );
+    CPPUNIT_TEST( test_all_h );
+    CPPUNIT_TEST( test_all_s );
+
+    CPPUNIT_TEST_SUITE_END();
+  };
+
+  class NASA7MixtureValarrayLongDoubleTest : public NASA7MixtureValarrayTest<long double>
+  {
+  public:
+
+    CPPUNIT_TEST_SUITE( NASA7MixtureValarrayLongDoubleTest );
+
+    CPPUNIT_TEST( test_all_cp );
+    CPPUNIT_TEST( test_all_h );
+    CPPUNIT_TEST( test_all_s );
+
+    CPPUNIT_TEST_SUITE_END();
+  };
+
+
+
+  template <typename Scalar>
+  class NASA9MixtureValarrayTest : public NASA9MixtureVectorTestBase<std::valarray<Scalar> >,
+                                   public CppUnit::TestCase
+  {
+  public:
+
+    virtual void setUp()
+    {
+      this->init();
+      this->_example = new std::valarray<Scalar>(2*ANTIOCH_N_TUPLES);
+    }
+
+    virtual void tearDown()
+    {
+      this->clear();
+      delete this->_example;
+    }
+
+  };
+
+  class NASA9MixtureValarrayFloatTest : public NASA9MixtureValarrayTest<float>
+  {
+  public:
+
+    CPPUNIT_TEST_SUITE( NASA9MixtureValarrayFloatTest );
+
+    CPPUNIT_TEST( test_all_cp );
+    CPPUNIT_TEST( test_all_h );
+    CPPUNIT_TEST( test_all_s );
+
+    CPPUNIT_TEST_SUITE_END();
+  };
+
+  class NASA9MixtureValarrayDoubleTest : public NASA9MixtureValarrayTest<double>
+  {
+  public:
+
+    CPPUNIT_TEST_SUITE( NASA9MixtureValarrayDoubleTest );
+
+    CPPUNIT_TEST( test_all_cp );
+    CPPUNIT_TEST( test_all_h );
+    CPPUNIT_TEST( test_all_s );
+
+    CPPUNIT_TEST_SUITE_END();
+  };
+
+  class NASA9MixtureValarrayLongDoubleTest : public NASA9MixtureValarrayTest<long double>
+  {
+  public:
+
+    CPPUNIT_TEST_SUITE( NASA9MixtureValarrayLongDoubleTest );
+
+    CPPUNIT_TEST( test_all_cp );
+    CPPUNIT_TEST( test_all_h );
+    CPPUNIT_TEST( test_all_s );
+
+    CPPUNIT_TEST_SUITE_END();
+  };
+
+  CPPUNIT_TEST_SUITE_REGISTRATION( NASA7MixtureValarrayFloatTest );
+  CPPUNIT_TEST_SUITE_REGISTRATION( NASA7MixtureValarrayDoubleTest );
+  CPPUNIT_TEST_SUITE_REGISTRATION( NASA7MixtureValarrayLongDoubleTest );
+  CPPUNIT_TEST_SUITE_REGISTRATION( NASA9MixtureValarrayFloatTest );
+  CPPUNIT_TEST_SUITE_REGISTRATION( NASA9MixtureValarrayDoubleTest );
+  CPPUNIT_TEST_SUITE_REGISTRATION( NASA9MixtureValarrayLongDoubleTest );
+
+} // end namespace AntiochTesting
+
+#endif // ANTIOCH_HAVE_CPPUNIT

--- a/test/standard_unit/nasa_mixture_xml_parsing_test.C
+++ b/test/standard_unit/nasa_mixture_xml_parsing_test.C
@@ -28,6 +28,10 @@
 
 #ifdef ANTIOCH_HAVE_CPPUNIT
 
+// CppUnit
+#include <cppunit/TestCase.h>
+#include <cppunit/extensions/HelperMacros.h>
+
 // C++
 #include <limits>
 
@@ -93,9 +97,15 @@ namespace AntiochTesting
   };
 
   template<typename Scalar>
-  class NASA7XMLParsingTest : public NASA7ThermoTestBase<Scalar>
+  class NASA7XMLParsingTest : public NASA7ThermoTestBase<Scalar>,
+                              public CppUnit::TestCase
   {
   public:
+
+    virtual void setUp()
+    {
+      this->init();
+    }
 
     void test_supplied_species()
     {

--- a/test/standard_unit/nasa_mixture_xml_parsing_test.C
+++ b/test/standard_unit/nasa_mixture_xml_parsing_test.C
@@ -48,7 +48,8 @@
 namespace AntiochTesting
 {
   template<typename Scalar>
-  class NASA9XMLParsingTest : public NASA9ThermoTestBase<Scalar>
+  class NASA9XMLParsingTest : public NASA9ThermoTestBase<Scalar>,
+                              public CppUnit::TestCase
   {
   public:
 

--- a/test/standard_unit/thermo_vector_test_base.h
+++ b/test/standard_unit/thermo_vector_test_base.h
@@ -1,0 +1,248 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// Antioch - A Gas Dynamics Thermochemistry Library
+//
+// Copyright (C) 2014-2016 Paul T. Bauman, Benjamin S. Kirk,
+//                         Sylvain Plessis, Roy H. Stonger
+//
+// Copyright (C) 2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef ANTIOCH_THERMO_VECTOR_TEST_BASE_H
+#define ANTIOCH_THERMO_VECTOR_TEST_BASE_H
+
+#include "antioch_config.h"
+
+#ifdef ANTIOCH_HAVE_CPPUNIT
+
+// CppUnit
+#include <cppunit/extensions/HelperMacros.h>
+
+// Antioch
+#include "antioch/nasa_evaluator.h"
+#include "antioch/temp_cache.h"
+
+namespace AntiochTesting
+{
+  template <typename NASAFit, typename PairScalars>
+  class ThermoVectorTestBase
+  {
+  private:
+
+    typedef typename Antioch::value_type<PairScalars>::type Scalar;
+
+  public:
+
+    Scalar tol()
+    { return std::numeric_limits<Scalar>::epsilon() * 500; }
+
+    //! Test that we actually run from the CppUnit driver
+    void test_all_cp()
+    {
+      Antioch::NASAEvaluator<Scalar,NASAFit> thermo_evaluator( (*_nasa_mixture) );
+      PairScalars T = this->setup_T(*(this->_example));
+
+      // Test for each species (0 or 1, species names depend on subclass)
+      this->test_cp(thermo_evaluator,0,T,this->tol());
+      this->test_cp(thermo_evaluator,1,T,this->tol());
+    }
+
+    //! Test that we actually run from the CppUnit driver
+    void test_all_h()
+    {
+      Antioch::NASAEvaluator<Scalar,NASAFit> thermo_evaluator( (*_nasa_mixture) );
+      PairScalars T = this->setup_T(*(this->_example));
+
+      // Test for each species (0 or 1, species names depend on subclass)
+      this->test_h(thermo_evaluator,0,T,this->tol());
+      this->test_h(thermo_evaluator,1,T,this->tol());
+    }
+
+    //! Test that we actually run from the CppUnit driver
+    void test_all_s()
+    {
+      Antioch::NASAEvaluator<Scalar,NASAFit> thermo_evaluator( (*_nasa_mixture) );
+      PairScalars T = this->setup_T(*(this->_example));
+
+      // Test for each species (0 or 1, species names depend on subclass)
+      this->test_s(thermo_evaluator,0,T,this->tol());
+      this->test_s(thermo_evaluator,1,T,this->tol());
+    }
+
+  protected:
+
+    Antioch::ChemicalMixture<Scalar>* _chem_mixture;
+    Antioch::NASAThermoMixture<Scalar,NASAFit>* _nasa_mixture;
+
+    void test_cp( const Antioch::NASAEvaluator<Scalar,NASAFit>& thermo,
+                  unsigned int species,
+                  const PairScalars& T,
+                  Scalar tol )
+    {
+      Antioch::TempCache<PairScalars> cache(T);
+      const PairScalars cp = thermo.cp_over_R(cache,species);
+
+      const PairScalars exact_cp = this->exact_cp_over_R(cache,species);
+
+      for (unsigned int tuple=0; tuple != ANTIOCH_N_TUPLES; ++tuple)
+        {
+          CPPUNIT_ASSERT_DOUBLES_EQUAL( cp[2*tuple],
+                                        exact_cp[0],
+                                        tol );
+
+          CPPUNIT_ASSERT_DOUBLES_EQUAL( cp[2*tuple+1],
+                                        exact_cp[1],
+                                        tol );
+        }
+    }
+
+    void test_h( const Antioch::NASAEvaluator<Scalar,NASAFit>& thermo,
+                 unsigned int species,
+                 const PairScalars& T,
+                 Scalar tol )
+    {
+      Antioch::TempCache<PairScalars> cache(T);
+      const PairScalars h = thermo.h_over_RT(cache,species);
+
+      const PairScalars exact_h = this->exact_h_over_RT(cache,species);
+
+      for (unsigned int tuple=0; tuple != ANTIOCH_N_TUPLES; ++tuple)
+        {
+          CPPUNIT_ASSERT_DOUBLES_EQUAL( h[2*tuple],
+                                        exact_h[0],
+                                        tol );
+
+          CPPUNIT_ASSERT_DOUBLES_EQUAL( h[2*tuple+1],
+                                        exact_h[1],
+                                        tol );
+        }
+    }
+
+    void test_s( const Antioch::NASAEvaluator<Scalar,NASAFit>& thermo,
+                 unsigned int species,
+                 const PairScalars& T,
+                 Scalar tol )
+    {
+      Antioch::TempCache<PairScalars> cache(T);
+      const PairScalars s = thermo.s_over_R(cache,species);
+
+      const PairScalars exact_s = this->exact_s_over_R(cache,species);
+
+      for (unsigned int tuple=0; tuple != ANTIOCH_N_TUPLES; ++tuple)
+        {
+          CPPUNIT_ASSERT_DOUBLES_EQUAL( s[2*tuple],
+                                        exact_s[0],
+                                        tol );
+
+          CPPUNIT_ASSERT_DOUBLES_EQUAL( s[2*tuple+1],
+                                        exact_s[1],
+                                        tol );
+        }
+    }
+
+    // Should be new'd/deleted in subclasses for each PairScalar type
+    PairScalars* _example;
+
+    PairScalars setup_T( const PairScalars& example )
+    {
+      // Construct from example to avoid resizing issues
+      PairScalars T = example;
+      for (unsigned int tuple=0; tuple != ANTIOCH_N_TUPLES; ++tuple)
+        {
+          // Make sure we hit two different intervals
+          T[2*tuple]   = 500.1;
+          T[2*tuple+1] = 1600.1;
+        }
+      return T;
+    }
+
+    PairScalars exact_cp_over_R( const Antioch::TempCache<PairScalars>& cache, unsigned species )
+    {
+      PairScalars e_cp = *(this->_example);
+      for (unsigned int tuple=0; tuple != ANTIOCH_N_TUPLES; ++tuple)
+        {
+          e_cp[2*tuple]   =  this->eval_cp_over_R( cache.T[2*tuple], species );
+          e_cp[2*tuple+1] =  this->eval_cp_over_R( cache.T[2*tuple+1], species );
+        }
+      return e_cp;
+    }
+
+    PairScalars exact_s_over_R( const Antioch::TempCache<PairScalars>& cache, unsigned species )
+    {
+      PairScalars e_s = *(this->_example);
+      for (unsigned int tuple=0; tuple != ANTIOCH_N_TUPLES; ++tuple)
+        {
+          e_s[2*tuple]   =  this->eval_s_over_R( cache.T[2*tuple], species );
+          e_s[2*tuple+1] =  this->eval_s_over_R( cache.T[2*tuple+1], species );
+        }
+      return e_s;
+    }
+
+    PairScalars exact_h_over_RT( const Antioch::TempCache<PairScalars>& cache, unsigned species )
+    {
+      PairScalars e_h = *(this->_example);
+      for (unsigned int tuple=0; tuple != ANTIOCH_N_TUPLES; ++tuple)
+        {
+          e_h[2*tuple]   =  this->eval_h_over_RT( cache.T[2*tuple], species );
+          e_h[2*tuple+1] =  this->eval_h_over_RT( cache.T[2*tuple+1], species );
+        }
+      return e_h;
+    }
+
+    Scalar eval_cp_over_R( Scalar T, unsigned int species )
+    {
+      std::vector<Scalar> coeffs;
+
+      this->prep_coeffs(T,species,coeffs);
+
+      return this->cp_over_R_exact(T,coeffs);
+    }
+
+    Scalar eval_h_over_RT( Scalar T, unsigned int species )
+    {
+      std::vector<Scalar> coeffs;
+
+      this->prep_coeffs(T,species,coeffs);
+
+      return this->h_over_RT_exact(T,coeffs);
+    }
+
+    Scalar eval_s_over_R( Scalar T, unsigned int species )
+    {
+      std::vector<Scalar> coeffs;
+
+      this->prep_coeffs(T,species,coeffs);
+
+      return this->s_over_R_exact(T,coeffs);
+    }
+
+    virtual void prep_coeffs( Scalar T, unsigned int species,
+                              std::vector<Scalar>& coeffs ) =0;
+
+    virtual Scalar cp_over_R_exact( Scalar T, const std::vector<Scalar>& coeffs ) =0;
+    virtual Scalar h_over_RT_exact( Scalar T, const std::vector<Scalar>& coeffs ) =0;
+    virtual Scalar s_over_R_exact( Scalar T, const std::vector<Scalar>& coeffs ) =0;
+
+  };
+
+} // end namespace AntiochTesting
+
+#endif // ANTIOCH_HAVE_CPPUNIT
+
+#endif // ANTIOCH_THERMO_VECTOR_TEST_BASE_H

--- a/test/vexcl_unit/nasa_mixture_vexcl_test.C
+++ b/test/vexcl_unit/nasa_mixture_vexcl_test.C
@@ -1,0 +1,200 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// Antioch - A Gas Dynamics Thermochemistry Library
+//
+// Copyright (C) 2014-2016 Paul T. Bauman, Benjamin S. Kirk,
+//                         Sylvain Plessis, Roy H. Stonger
+//
+// Copyright (C) 2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include "antioch_config.h"
+
+#ifdef ANTIOCH_HAVE_CPPUNIT
+
+#ifdef ANTIOCH_HAVE_VEXCL
+
+// VexCL
+#include "vexcl/vexcl.hpp"
+
+// CppUnit
+#include <cppunit/TestCase.h>
+
+// Antioch
+#include "antioch/vexcl_utils_decl.h"
+#include "antioch/physical_constants.h"
+#include "antioch/units.h"
+#include "nasa7_mixture_vector_test_base.h"
+#include "nasa9_mixture_vector_test_base.h"
+#include "antioch/vexcl_utils.h"
+
+namespace AntiochTesting
+{
+  class NASA7MixtureVexCLFloatTest : public NASA7MixtureVectorTestBase<vex::vector<float> >,
+                                     public CppUnit::TestCase
+  {
+  public:
+
+    CPPUNIT_TEST_SUITE( NASA7MixtureVexCLFloatTest );
+
+    CPPUNIT_TEST( test_all_cp );
+    CPPUNIT_TEST( test_all_h );
+    CPPUNIT_TEST( test_all_s );
+
+    CPPUNIT_TEST_SUITE_END();
+
+  private:
+
+    vex::Context* _ctx;
+
+  public:
+
+    virtual void setUp()
+    {
+      this->init();
+      _ctx = new vex::Context(vex::Filter::All);
+      this->_example = new vex::vector<float>(*_ctx, 2*ANTIOCH_N_TUPLES);
+    }
+
+    virtual void tearDown()
+    {
+      this->clear();
+      delete _ctx;
+      delete this->_example;
+    }
+
+  };
+
+  class NASA7MixtureVexCLDoubleTest : public NASA7MixtureVectorTestBase<vex::vector<double> >,
+                                      public CppUnit::TestCase
+  {
+  public:
+
+    CPPUNIT_TEST_SUITE( NASA7MixtureVexCLDoubleTest );
+
+    CPPUNIT_TEST( test_all_cp );
+    CPPUNIT_TEST( test_all_h );
+    CPPUNIT_TEST( test_all_s );
+
+    CPPUNIT_TEST_SUITE_END();
+
+  private:
+
+    vex::Context* _ctx;
+
+  public:
+
+    virtual void setUp()
+    {
+      this->init();
+      _ctx = new vex::Context(vex::Filter::DoublePrecision);
+      this->_example = new vex::vector<double>(*_ctx, 2*ANTIOCH_N_TUPLES);
+    }
+
+    virtual void tearDown()
+    {
+      this->clear();
+      delete _ctx;
+      delete this->_example;
+    }
+
+  };
+
+
+
+  class NASA9MixtureVexCLFloatTest : public NASA9MixtureVectorTestBase<vex::vector<float> >,
+                                     public CppUnit::TestCase
+  {
+  public:
+
+    CPPUNIT_TEST_SUITE( NASA9MixtureVexCLFloatTest );
+
+    CPPUNIT_TEST( test_all_cp );
+    CPPUNIT_TEST( test_all_h );
+    CPPUNIT_TEST( test_all_s );
+
+    CPPUNIT_TEST_SUITE_END();
+
+  private:
+
+    vex::Context* _ctx;
+
+  public:
+
+    virtual void setUp()
+    {
+      this->init();
+      _ctx = new vex::Context(vex::Filter::All);
+      this->_example = new vex::vector<float>(*_ctx, 2*ANTIOCH_N_TUPLES);
+    }
+
+    virtual void tearDown()
+    {
+      this->clear();
+      delete _ctx;
+      delete this->_example;
+    }
+
+  };
+
+  class NASA9MixtureVexCLDoubleTest : public NASA9MixtureVectorTestBase<vex::vector<double> >,
+                                      public CppUnit::TestCase
+  {
+  public:
+
+    CPPUNIT_TEST_SUITE( NASA9MixtureVexCLDoubleTest );
+
+    CPPUNIT_TEST( test_all_cp );
+    CPPUNIT_TEST( test_all_h );
+    CPPUNIT_TEST( test_all_s );
+
+    CPPUNIT_TEST_SUITE_END();
+
+  private:
+
+    vex::Context* _ctx;
+
+  public:
+
+    virtual void setUp()
+    {
+      this->init();
+      _ctx = new vex::Context(vex::Filter::DoublePrecision);
+      this->_example = new vex::vector<double>(*_ctx, 2*ANTIOCH_N_TUPLES);
+    }
+
+    virtual void tearDown()
+    {
+      this->clear();
+      delete _ctx;
+      delete this->_example;
+    }
+
+  };
+
+  CPPUNIT_TEST_SUITE_REGISTRATION( NASA7MixtureVexCLFloatTest );
+  CPPUNIT_TEST_SUITE_REGISTRATION( NASA7MixtureVexCLDoubleTest );
+  CPPUNIT_TEST_SUITE_REGISTRATION( NASA9MixtureVexCLFloatTest );
+  CPPUNIT_TEST_SUITE_REGISTRATION( NASA9MixtureVexCLDoubleTest );
+
+} // end namespace AntiochTesting
+
+#endif // ANTIOCH_HAVE_VEXCL
+
+#endif // ANTIOCH_HAVE_CPPUNIT


### PR DESCRIPTION
Builds on #200.

Went down this rabbit hole when removing `CEAThermodynamics` (that's the next PR after this one). The NASAThermoMixture/Evaluators and, therefore, the underlying curve fits, were not exercised in unit tests using vectorized types. This PR makes several fixes to allow that and adds unit testing (in the CppUnit testing framework) for valarray, Eigen, and VexCL types for the NASAThermo. I'll note in the testing, I made sure that the temperatures were such that two different intervals will be need. I'm pretty sure there was a bug in the old `CEAThermodynamics` implementation for vectorized types that we didn't see because we were always in the same temperature interval in the test.

All tests pass for me with Eigen 3.2.8 and VexCL 1.3.3 using GCC 4.9.3. GCC 5.3 has failures in a few of the Eigen tests (nans).