### PR TITLE
Turn off -Wdeprecated-declarations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,6 @@ script:
   - echo apt-get install -qq libeigen3-dev libgsl0-dev libcppunit-1.13-0 libcppunit-dev fglrx=2:8.960-0ubuntu1 opencl-headers libboost-chrono1.48-dev libboost-date-time1.48-dev libboost-filesystem1.48-dev libboost-system1.48-dev libboost-thread1.48-dev libboost-program-options1.48-dev libboost-test1.48-dev
   - echo git clone https://github.com/ddemidov/vexcl
   - ./bootstrap
-  - echo ./configure --with-eigen-include=/usr/include/eigen3 --with-vexcl=${PWD}/vexcl "VexCL takes too much RAM to compile"
-  - ./configure --with-eigen-include=/usr/include/eigen3
+  - echo ./configure --with-eigen-include=/usr/include/eigen3 CXXFLAGS="-Wno-deprecated-declarations" --with-vexcl=${PWD}/vexcl "VexCL takes too much RAM to compile"
+  - ./configure --with-eigen-include=/usr/include/eigen3 CXXFLAGS="-Wno-deprecated-declarations"
   - make && make check || (cat test/test-suite.log && false)


### PR DESCRIPTION
This is a Clang option that's churning out so much output that it's
killing our Travis build with Clang, as seen in #201.  I tested with GCC
and no warnings or errors were emitted using this option.