### PR TITLE
Fix Clang warnings about std::abs

### DIFF
--- a/test/berthelot_rate_unit.C
+++ b/test/berthelot_rate_unit.C
@@ -36,6 +36,9 @@ int check_rate_and_derivative(const Scalar & rate_exact, const Scalar & derive_e
 {
     const Scalar tol = std::numeric_limits<Scalar>::epsilon() * 2;
     int return_flag(0);
+
+    using std::abs;
+
     if( abs( (rate - rate_exact)/rate_exact ) > tol )
       {
         std::cout << std::scientific << std::setprecision(16)

--- a/test/berthelot_rate_vec_unit.C
+++ b/test/berthelot_rate_vec_unit.C
@@ -72,6 +72,9 @@ int check_rate_and_derivative(const PairScalars & rate_exact, const PairScalars 
     const Scalar tol = std::numeric_limits<Scalar>::epsilon() * 2;
 
     int return_flag(0);
+
+   using std::abs;
+
    for (unsigned int tuple=0; tuple != ANTIOCH_N_TUPLES; ++tuple)
    {
     if( abs( (rate[2*tuple] - rate_exact[2*tuple])/rate_exact[2*tuple] ) > tol )

--- a/test/berthelothercourtessen_rate_unit.C
+++ b/test/berthelothercourtessen_rate_unit.C
@@ -35,9 +35,13 @@ template <typename Scalar>
 int check_rate_and_derivative(const Scalar & rate_exact, const Scalar & derive_exact,
                               const Scalar & rate, const Scalar & derive, const Scalar & T)
 {
-    const Scalar tol = std::numeric_limits<Scalar>::epsilon() * 2;
+    const Scalar tol = std::numeric_limits<Scalar>::epsilon() * 50;
     int return_flag(0);
-    if( abs( (rate - rate_exact)/rate_exact ) > tol )
+
+    using std::abs;
+    using std::max;
+
+    if( abs(rate - rate_exact)/max(abs(rate_exact),tol) > tol )
       {
         std::cout << std::scientific << std::setprecision(16)
                   << "Error: Mismatch in rate values." << std::endl
@@ -49,7 +53,7 @@ int check_rate_and_derivative(const Scalar & rate_exact, const Scalar & derive_e
 
         return_flag = 1;
       }
-    if( abs( (derive - derive_exact)/derive_exact ) > tol )
+    if( abs(derive - derive_exact)/max(abs(derive_exact),tol) > tol )
       {
         std::cout << std::scientific << std::setprecision(16)
                   << "Error: Mismatch in rate derivative values." << std::endl

--- a/test/constant_rate_unit.C
+++ b/test/constant_rate_unit.C
@@ -36,6 +36,9 @@ int check_rate_and_derivative(const Scalar & rate_exact, const Scalar & derive_e
 {
     const Scalar tol = std::numeric_limits<Scalar>::epsilon() * 2;
     int return_flag(0);
+
+    using std::abs;
+
     if( abs( (rate - rate_exact)/rate_exact ) > tol )
       {
         std::cout << std::scientific << std::setprecision(16)

--- a/test/constant_rate_vec_unit.C
+++ b/test/constant_rate_vec_unit.C
@@ -73,6 +73,9 @@ int check_rate_and_derivative(const PairScalars & rate_exact, const PairScalars 
     const Scalar tol = std::numeric_limits<Scalar>::epsilon() * 2;
 
     int return_flag(0);
+
+   using std::abs;
+
    for (unsigned int tuple=0; tuple != ANTIOCH_N_TUPLES; ++tuple)
    {
     if( abs( (rate[2*tuple] - rate_exact[2*tuple])/rate_exact[2*tuple] ) > tol )

--- a/test/hercourtessen_rate_unit.C
+++ b/test/hercourtessen_rate_unit.C
@@ -34,8 +34,11 @@ template <typename Scalar>
 int check_rate_and_derivative(const Scalar & rate_exact, const Scalar & derive_exact,
                               const Scalar & rate, const Scalar & derive, const Scalar & T)
 {
-    const Scalar tol = std::numeric_limits<Scalar>::epsilon() * 2;
+    const Scalar tol = std::numeric_limits<Scalar>::epsilon() * 100;
     int return_flag(0);
+
+    using std::abs;
+
     if( abs( (rate - rate_exact)/rate_exact ) > tol )
       {
         std::cout << std::scientific << std::setprecision(16)

--- a/test/hercourtessen_rate_vec_unit.C
+++ b/test/hercourtessen_rate_vec_unit.C
@@ -73,6 +73,9 @@ int check_rate_and_derivative(const PairScalars & rate_exact, const PairScalars 
     const Scalar tol = std::numeric_limits<Scalar>::epsilon() * 2;
 
     int return_flag(0);
+
+   using std::abs;
+
    for (unsigned int tuple=0; tuple != ANTIOCH_N_TUPLES; ++tuple)
    {
     if( abs( (rate[2*tuple] - rate_exact[2*tuple])/rate_exact[2*tuple] ) > tol )

--- a/test/kooij_rate_unit.C
+++ b/test/kooij_rate_unit.C
@@ -36,8 +36,11 @@ template <typename Scalar>
 int check_rate_and_derivative(const Scalar & rate_exact, const Scalar & derive_exact,
                               const Scalar & rate, const Scalar & derive, const Scalar & T)
 {
-    const Scalar tol = std::numeric_limits<Scalar>::epsilon() * 2;
+    const Scalar tol = std::numeric_limits<Scalar>::epsilon() * 100;
     int return_flag(0);
+
+    using std::abs;
+
     if( abs( (rate - rate_exact)/rate_exact ) > tol )
       {
         std::cout << std::scientific << std::setprecision(16)

--- a/test/rotational_relaxation_vec_unit.C
+++ b/test/rotational_relaxation_vec_unit.C
@@ -124,7 +124,7 @@ std::cout << "entering " << testname << std::endl;
       const Scalar Z_exact0 = z( (Scalar)1500.1, eps_kb, z_298);
       const Scalar Z_exact1 = z( (Scalar)1600.1, eps_kb, z_298);
 
-      if( abs( (Z[2*tuple] - Z_exact0)/Z_exact0 ) > tol )
+      if( std::abs( (Z[2*tuple] - Z_exact0)/Z_exact0 ) > tol )
         {
           std::cout << std::scientific << std::setprecision(20)
                     << "Error: Mismatch in Z values in test " << testname << std::endl
@@ -138,7 +138,7 @@ std::cout << "entering " << testname << std::endl;
 	  break;
         }
 
-      if( abs( (Z[2*tuple+1] - Z_exact1)/Z_exact1 ) > tol )
+      if( std::abs( (Z[2*tuple+1] - Z_exact1)/Z_exact1 ) > tol )
         {
           std::cout << std::scientific << std::setprecision(20)
                     << "Error: Mismatch in Z values in test " << testname << std::endl


### PR DESCRIPTION
Mentioned in #201. Also, had to adjust tolerances on some of the
tests. For the berthelothercourtessen_rate_unit, I used @roystgnr's
solution in #198 for comparing very small rates.

I just updated the existing tests because I don't have the time at the moment to sink into converting these to the CppUnit framework. But it would be nice to move that direction.