### PR TITLE
Distribute antioch.sty

### DIFF
--- a/doxygen/Makefile.am
+++ b/doxygen/Makefile.am
@@ -1,6 +1,6 @@
 AUTOMAKE_OPTIONS = foreign
 
-EXTRA_DIST = antioch.dox antioch.page txt_common fig_common
+EXTRA_DIST = antioch.sty antioch.dox antioch.page txt_common fig_common
 
 DISTCLEANFILES  = antioch.dox
 DISTCLEANFILES += Makefile


### PR DESCRIPTION
This .sty file encapsulates the extra LaTeX packages we need in
the Doxygen comments. Is now being distributed in the tarball
so we can build the docs from a tarball now.