### PR TITLE
Bugfix/arrhenius kooij double agent

### DIFF
--- a/src/parsing/src/read_reaction_set_data.C
+++ b/src/parsing/src/read_reaction_set_data.C
@@ -359,7 +359,7 @@ namespace Antioch
               (is_k0)?std::cout << "  Low pressure limit rate constant\n":std::cout << "  High pressure limit rate constant\n";
             }
 
-            // pre-exponential
+            // pre-exponential, everyone
             if(parser->rate_constant_preexponential_parameter(par_value, par_unit, default_unit))
               {
                 // using Units object to build accepted_unit
@@ -395,8 +395,12 @@ namespace Antioch
                 data.push_back(par_value * def_unit.get_SI_factor());
               }
 
-            // beta
-            if(parser->rate_constant_power_parameter(par_value,par_unit,default_unit))
+            // beta, not everyone
+            if(( kineticsModel == KineticsModel::HERCOURT_ESSEN ||
+                 kineticsModel == KineticsModel::BHE            ||
+                 kineticsModel == KineticsModel::KOOIJ          ||
+                 kineticsModel == KineticsModel::VANTHOFF  )     &&
+               parser->rate_constant_power_parameter(par_value,par_unit,default_unit))
               {
                 accepted_unit.clear();
                 accepted_unit.push_back("");
@@ -427,8 +431,11 @@ namespace Antioch
                   }
               }
 
-            // activation energy
-            if(parser->rate_constant_activation_energy_parameter(par_value,par_unit,default_unit))
+            // activation energy, not everyone
+            if(( kineticsModel == KineticsModel::ARRHENIUS ||
+                 kineticsModel == KineticsModel::KOOIJ     ||
+                 kineticsModel == KineticsModel::VANTHOFF ) &&
+               parser->rate_constant_activation_energy_parameter(par_value,par_unit,default_unit))
               {
                 accepted_unit.clear();
                 accepted_unit.push_back("J/mol");
@@ -444,8 +451,11 @@ namespace Antioch
               }
 
 
-            // Berthelot coefficient (D)
-            if(parser->rate_constant_Berthelot_coefficient_parameter(par_value,par_unit,default_unit))
+            // Berthelot coefficient (D), not everyone
+            if(( kineticsModel == KineticsModel::BERTHELOT ||
+                kineticsModel == KineticsModel::BHE        ||
+                kineticsModel == KineticsModel::VANTHOFF  ) &&
+               parser->rate_constant_Berthelot_coefficient_parameter(par_value,par_unit,default_unit))
               {
                 accepted_unit.clear();
                 accepted_unit.push_back("K");

--- a/src/parsing/src/xml_parser.C
+++ b/src/parsing/src/xml_parser.C
@@ -667,9 +667,12 @@ namespace Antioch
     tinyxml2::XMLElement * rate_constant = _reaction->FirstChildElement(_map.at(ParsingKey::KINETICS_MODEL).c_str());
     antioch_assert(rate_constant->FirstChildElement("Arrhenius"));
     rate_constant = rate_constant->FirstChildElement("Arrhenius");
+    const char * chem_proc = _reaction->Attribute(_map.at(ParsingKey::CHEMICAL_PROCESS).c_str());
+    bool i_am_a_falloff = (chem_proc && std::string(chem_proc).compare(_gri_map.at(GRI30Comp::FALLOFF)) == 0);
     if(rate_constant->FirstChildElement(_map.at(ParsingKey::POWER).c_str()))
       {
-        if(std::atof(rate_constant->FirstChildElement(_map.at(ParsingKey::POWER).c_str())->GetText()) != 0.) //not a very good test
+        if(std::atof(rate_constant->FirstChildElement(_map.at(ParsingKey::POWER).c_str())->GetText()) != 0. || //not a very good test
+          i_am_a_falloff)
           out = true;
       }
 

--- a/test/input_files/test_parsing.xml
+++ b/test/input_files/test_parsing.xml
@@ -1099,6 +1099,47 @@
       <products>CH4:1</products>
     </reaction>
 
+    <!-- reaction 0039     -->
+    <reaction reversible="yes" type="falloff" id="0039">
+      <equation>NO [=] N + O </equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.e+12</A>
+           <b>0</b>
+           <E units="cal/mol">149943.0</E>
+        </Arrhenius>
+        <Arrhenius>
+           <A>3e+15</A>
+           <b>0</b>
+           <E units="cal/mol">200000.0</E>
+        </Arrhenius>
+        <falloff type='Lindemann'/>
+      </rateCoeff>
+      <reactants>NO:1</reactants>
+      <products>N:1 O:1</products>
+    </reaction>
+
+    <!-- reaction 0040    -->
+    <reaction reversible="yes" type="falloff" id="0040">
+      <equation>NO + O [=] O2 + N</equation>
+      <rateCoeff>
+        <Arrhenius name="k0">
+           <A>8.4e+09</A>
+           <b>0</b>
+           <E units="cal/mol">38526.0</E>
+        </Arrhenius>
+        <Arrhenius>
+           <A>8.4e+05</A>
+           <b>1.2</b>
+           <E units="cal/mol">3526.0</E>
+        </Arrhenius>
+        <falloff type="Lindemann"/>
+      </rateCoeff>
+      <reactants>NO:1 O:1</reactants>
+      <products>O2:1 N:1</products>
+    </reaction>
+
+
   </reactionData>
 
 </ctml>


### PR DESCRIPTION
Fix to issue #211.

As explained in the issue, the change are to test the rate constant model before checking if a parameter is found, which fixes the double agent Arrhenius falloff problem (first commit), and to keep the Kooij model anyway for the falloff to be sure not to trim the power parameter of the other rate constant (second commit).

Those two situations are added in the _parsing_xml_ test (last commit).
