### PR TITLE
Bug Fix for Antioch::remove_newline_from_strings, add GRI3 XML to share

### DIFF
--- a/share/xml_inputs/gri30.xml
+++ b/share/xml_inputs/gri30.xml
@@ -1,0 +1,6213 @@
+<?xml version="1.0"?>
+<ctml>
+  <validate reactions="yes" species="yes"/>
+
+  <!-- phase gri30     -->
+  <phase dim="3" id="gri30">
+    <elementArray datasrc="elements.xml">O  H  C  N  Ar </elementArray>
+    <speciesArray datasrc="#species_data">
+      H2  H  O  O2  OH  H2O  HO2  H2O2  C  CH 
+      CH2  CH2(S)  CH3  CH4  CO  CO2  HCO  CH2O  CH2OH  CH3O 
+      CH3OH  C2H  C2H2  C2H3  C2H4  C2H5  C2H6  HCCO  CH2CO  HCCOH 
+      N  NH  NH2  NH3  NNH  NO  NO2  N2O  HNO  CN 
+      HCN  H2CN  HCNN  HCNO  HOCN  HNCO  NCO  N2  AR  C3H7 
+      C3H8  CH2CHO  CH3CHO </speciesArray>
+    <reactionArray datasrc="#reaction_data"/>
+    <state>
+      <temperature units="K">300.0</temperature>
+      <pressure units="Pa">101325.0</pressure>
+    </state>
+    <thermo model="IdealGas"/>
+    <kinetics model="GasKinetics"/>
+    <transport model="None"/>
+  </phase>
+
+  <!-- phase gri30_mix     -->
+  <phase dim="3" id="gri30_mix">
+    <elementArray datasrc="elements.xml">O  H  C  N  Ar </elementArray>
+    <speciesArray datasrc="#species_data">
+      H2  H  O  O2  OH  H2O  HO2  H2O2  C  CH 
+      CH2  CH2(S)  CH3  CH4  CO  CO2  HCO  CH2O  CH2OH  CH3O 
+      CH3OH  C2H  C2H2  C2H3  C2H4  C2H5  C2H6  HCCO  CH2CO  HCCOH 
+      N  NH  NH2  NH3  NNH  NO  NO2  N2O  HNO  CN 
+      HCN  H2CN  HCNN  HCNO  HOCN  HNCO  NCO  N2  AR  C3H7 
+      C3H8  CH2CHO  CH3CHO </speciesArray>
+    <reactionArray datasrc="#reaction_data"/>
+    <state>
+      <temperature units="K">300.0</temperature>
+      <pressure units="Pa">101325.0</pressure>
+    </state>
+    <thermo model="IdealGas"/>
+    <kinetics model="GasKinetics"/>
+    <transport model="Mix"/>
+  </phase>
+
+  <!-- phase gri30_multi     -->
+  <phase dim="3" id="gri30_multi">
+    <elementArray datasrc="elements.xml">O  H  C  N  Ar </elementArray>
+    <speciesArray datasrc="#species_data">
+      H2  H  O  O2  OH  H2O  HO2  H2O2  C  CH 
+      CH2  CH2(S)  CH3  CH4  CO  CO2  HCO  CH2O  CH2OH  CH3O 
+      CH3OH  C2H  C2H2  C2H3  C2H4  C2H5  C2H6  HCCO  CH2CO  HCCOH 
+      N  NH  NH2  NH3  NNH  NO  NO2  N2O  HNO  CN 
+      HCN  H2CN  HCNN  HCNO  HOCN  HNCO  NCO  N2  AR  C3H7 
+      C3H8  CH2CHO  CH3CHO </speciesArray>
+    <reactionArray datasrc="#reaction_data"/>
+    <state>
+      <temperature units="K">300.0</temperature>
+      <pressure units="Pa">101325.0</pressure>
+    </state>
+    <thermo model="IdealGas"/>
+    <kinetics model="GasKinetics"/>
+    <transport model="Multi"/>
+  </phase>
+
+  <!-- species definitions     -->
+  <speciesData id="species_data">
+
+    <!-- species H2    -->
+    <species name="H2">
+      <atomArray>H:2 </atomArray>
+      <note>TPIS78</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.344331120E+00,   7.980520750E-03,  -1.947815100E-05,   2.015720940E-08, 
+             -7.376117610E-12,  -9.179351730E+02,   6.830102380E-01</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.337279200E+00,  -4.940247310E-05,   4.994567780E-07,  -1.795663940E-10, 
+             2.002553760E-14,  -9.501589220E+02,  -3.205023310E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">linear</string>
+        <LJ_welldepth units="K">38.000</LJ_welldepth>
+        <LJ_diameter units="A">2.920</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.790</polarizability>
+        <rotRelax>280.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species H    -->
+    <species name="H">
+      <atomArray>H:1 </atomArray>
+      <note>L 7/88</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.500000000E+00,   7.053328190E-13,  -1.995919640E-15,   2.300816320E-18, 
+             -9.277323320E-22,   2.547365990E+04,  -4.466828530E-01</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.500000010E+00,  -2.308429730E-11,   1.615619480E-14,  -4.735152350E-18, 
+             4.981973570E-22,   2.547365990E+04,  -4.466829140E-01</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">atom</string>
+        <LJ_welldepth units="K">145.000</LJ_welldepth>
+        <LJ_diameter units="A">2.050</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>0.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species O    -->
+    <species name="O">
+      <atomArray>O:1 </atomArray>
+      <note>L 1/90</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.168267100E+00,  -3.279318840E-03,   6.643063960E-06,  -6.128066240E-09, 
+             2.112659710E-12,   2.912225920E+04,   2.051933460E+00</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.569420780E+00,  -8.597411370E-05,   4.194845890E-08,  -1.001777990E-11, 
+             1.228336910E-15,   2.921757910E+04,   4.784338640E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">atom</string>
+        <LJ_welldepth units="K">80.000</LJ_welldepth>
+        <LJ_diameter units="A">2.750</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>0.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species O2    -->
+    <species name="O2">
+      <atomArray>O:2 </atomArray>
+      <note>TPIS89</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.782456360E+00,  -2.996734160E-03,   9.847302010E-06,  -9.681295090E-09, 
+             3.243728370E-12,  -1.063943560E+03,   3.657675730E+00</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.282537840E+00,   1.483087540E-03,  -7.579666690E-07,   2.094705550E-10, 
+             -2.167177940E-14,  -1.088457720E+03,   5.453231290E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">linear</string>
+        <LJ_welldepth units="K">107.400</LJ_welldepth>
+        <LJ_diameter units="A">3.460</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">1.600</polarizability>
+        <rotRelax>3.800</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species OH    -->
+    <species name="OH">
+      <atomArray>H:1 O:1 </atomArray>
+      <note>RUS 78</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.992015430E+00,  -2.401317520E-03,   4.617938410E-06,  -3.881133330E-09, 
+             1.364114700E-12,   3.615080560E+03,  -1.039254580E-01</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.092887670E+00,   5.484297160E-04,   1.265052280E-07,  -8.794615560E-11, 
+             1.174123760E-14,   3.858657000E+03,   4.476696100E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">linear</string>
+        <LJ_welldepth units="K">80.000</LJ_welldepth>
+        <LJ_diameter units="A">2.750</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>0.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species H2O    -->
+    <species name="H2O">
+      <atomArray>H:2 O:1 </atomArray>
+      <note>L 8/89</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             4.198640560E+00,  -2.036434100E-03,   6.520402110E-06,  -5.487970620E-09, 
+             1.771978170E-12,  -3.029372670E+04,  -8.490322080E-01</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.033992490E+00,   2.176918040E-03,  -1.640725180E-07,  -9.704198700E-11, 
+             1.682009920E-14,  -3.000429710E+04,   4.966770100E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">572.400</LJ_welldepth>
+        <LJ_diameter units="A">2.600</LJ_diameter>
+        <dipoleMoment units="Debye">1.840</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>4.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species HO2    -->
+    <species name="HO2">
+      <atomArray>H:1 O:2 </atomArray>
+      <note>L 5/89</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             4.301798010E+00,  -4.749120510E-03,   2.115828910E-05,  -2.427638940E-08, 
+             9.292251240E-12,   2.948080400E+02,   3.716662450E+00</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             4.017210900E+00,   2.239820130E-03,  -6.336581500E-07,   1.142463700E-10, 
+             -1.079085350E-14,   1.118567130E+02,   3.785102150E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">107.400</LJ_welldepth>
+        <LJ_diameter units="A">3.460</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>1.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species H2O2    -->
+    <species name="H2O2">
+      <atomArray>H:2 O:2 </atomArray>
+      <note>L 7/88</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             4.276112690E+00,  -5.428224170E-04,   1.673357010E-05,  -2.157708130E-08, 
+             8.624543630E-12,  -1.770258210E+04,   3.435050740E+00</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             4.165002850E+00,   4.908316940E-03,  -1.901392250E-06,   3.711859860E-10, 
+             -2.879083050E-14,  -1.786178770E+04,   2.916156620E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">107.400</LJ_welldepth>
+        <LJ_diameter units="A">3.460</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>3.800</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species C    -->
+    <species name="C">
+      <atomArray>C:1 </atomArray>
+      <note>L11/88</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.554239550E+00,  -3.215377240E-04,   7.337922450E-07,  -7.322348890E-10, 
+             2.665214460E-13,   8.544388320E+04,   4.531308480E+00</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.492668880E+00,   4.798892840E-05,  -7.243350200E-08,   3.742910290E-11, 
+             -4.872778930E-15,   8.545129530E+04,   4.801503730E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">atom</string>
+        <LJ_welldepth units="K">71.400</LJ_welldepth>
+        <LJ_diameter units="A">3.300</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>0.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species CH    -->
+    <species name="CH">
+      <atomArray>H:1 C:1 </atomArray>
+      <note>TPIS79</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.489816650E+00,   3.238355410E-04,  -1.688990650E-06,   3.162173270E-09, 
+             -1.406090670E-12,   7.079729340E+04,   2.084011080E+00</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.878464730E+00,   9.709136810E-04,   1.444456550E-07,  -1.306878490E-10, 
+             1.760793830E-14,   7.101243640E+04,   5.484979990E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">linear</string>
+        <LJ_welldepth units="K">80.000</LJ_welldepth>
+        <LJ_diameter units="A">2.750</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>0.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species CH2    -->
+    <species name="CH2">
+      <atomArray>H:2 C:1 </atomArray>
+      <note>L S/93</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.762678670E+00,   9.688721430E-04,   2.794898410E-06,  -3.850911530E-09, 
+             1.687417190E-12,   4.600404010E+04,   1.562531850E+00</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.874101130E+00,   3.656392920E-03,  -1.408945970E-06,   2.601795490E-10, 
+             -1.877275670E-14,   4.626360400E+04,   6.171193240E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">linear</string>
+        <LJ_welldepth units="K">144.000</LJ_welldepth>
+        <LJ_diameter units="A">3.800</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>0.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species CH2(S)    -->
+    <species name="CH2(S)">
+      <atomArray>H:2 C:1 </atomArray>
+      <note>L S/93</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             4.198604110E+00,  -2.366614190E-03,   8.232962200E-06,  -6.688159810E-09, 
+             1.943147370E-12,   5.049681630E+04,  -7.691189670E-01</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.292038420E+00,   4.655886370E-03,  -2.011919470E-06,   4.179060000E-10, 
+             -3.397163650E-14,   5.092599970E+04,   8.626501690E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">linear</string>
+        <LJ_welldepth units="K">144.000</LJ_welldepth>
+        <LJ_diameter units="A">3.800</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>0.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species CH3    -->
+    <species name="CH3">
+      <atomArray>H:3 C:1 </atomArray>
+      <note>L11/89</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.673590400E+00,   2.010951750E-03,   5.730218560E-06,  -6.871174250E-09, 
+             2.543857340E-12,   1.644499880E+04,   1.604564330E+00</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.285717720E+00,   7.239900370E-03,  -2.987143480E-06,   5.956846440E-10, 
+             -4.671543940E-14,   1.677558430E+04,   8.480071790E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">linear</string>
+        <LJ_welldepth units="K">144.000</LJ_welldepth>
+        <LJ_diameter units="A">3.800</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>0.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species CH4    -->
+    <species name="CH4">
+      <atomArray>H:4 C:1 </atomArray>
+      <note>L 8/88</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             5.149876130E+00,  -1.367097880E-02,   4.918005990E-05,  -4.847430260E-08, 
+             1.666939560E-11,  -1.024664760E+04,  -4.641303760E+00</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             7.485149500E-02,   1.339094670E-02,  -5.732858090E-06,   1.222925350E-09, 
+             -1.018152300E-13,  -9.468344590E+03,   1.843731800E+01</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">141.400</LJ_welldepth>
+        <LJ_diameter units="A">3.750</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">2.600</polarizability>
+        <rotRelax>13.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species CO    -->
+    <species name="CO">
+      <atomArray>C:1 O:1 </atomArray>
+      <note>TPIS79</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.579533470E+00,  -6.103536800E-04,   1.016814330E-06,   9.070058840E-10, 
+             -9.044244990E-13,  -1.434408600E+04,   3.508409280E+00</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.715185610E+00,   2.062527430E-03,  -9.988257710E-07,   2.300530080E-10, 
+             -2.036477160E-14,  -1.415187240E+04,   7.818687720E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">linear</string>
+        <LJ_welldepth units="K">98.100</LJ_welldepth>
+        <LJ_diameter units="A">3.650</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">1.950</polarizability>
+        <rotRelax>1.800</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species CO2    -->
+    <species name="CO2">
+      <atomArray>C:1 O:2 </atomArray>
+      <note>L 7/88</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.356773520E+00,   8.984596770E-03,  -7.123562690E-06,   2.459190220E-09, 
+             -1.436995480E-13,  -4.837196970E+04,   9.901052220E+00</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.857460290E+00,   4.414370260E-03,  -2.214814040E-06,   5.234901880E-10, 
+             -4.720841640E-14,  -4.875916600E+04,   2.271638060E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">linear</string>
+        <LJ_welldepth units="K">244.000</LJ_welldepth>
+        <LJ_diameter units="A">3.760</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">2.650</polarizability>
+        <rotRelax>2.100</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species HCO    -->
+    <species name="HCO">
+      <atomArray>H:1 C:1 O:1 </atomArray>
+      <note>L12/89</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             4.221185840E+00,  -3.243925320E-03,   1.377994460E-05,  -1.331440930E-08, 
+             4.337688650E-12,   3.839564960E+03,   3.394372430E+00</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.772174380E+00,   4.956955260E-03,  -2.484456130E-06,   5.891617780E-10, 
+             -5.335087110E-14,   4.011918150E+03,   9.798344920E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">498.000</LJ_welldepth>
+        <LJ_diameter units="A">3.590</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>0.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species CH2O    -->
+    <species name="CH2O">
+      <atomArray>H:2 C:1 O:1 </atomArray>
+      <note>L 8/88</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             4.793723150E+00,  -9.908333690E-03,   3.732200080E-05,  -3.792852610E-08, 
+             1.317726520E-11,  -1.430895670E+04,   6.028129000E-01</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             1.760690080E+00,   9.200000820E-03,  -4.422588130E-06,   1.006412120E-09, 
+             -8.838556400E-14,  -1.399583230E+04,   1.365632300E+01</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">498.000</LJ_welldepth>
+        <LJ_diameter units="A">3.590</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>2.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species CH2OH    -->
+    <species name="CH2OH">
+      <atomArray>H:3 C:1 O:1 </atomArray>
+      <note>GUNL93</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.863889180E+00,   5.596723040E-03,   5.932717910E-06,  -1.045320120E-08, 
+             4.369672780E-12,  -3.193913670E+03,   5.473022430E+00</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.692665690E+00,   8.645767970E-03,  -3.751011200E-06,   7.872346360E-10, 
+             -6.485542010E-14,  -3.242506270E+03,   5.810432150E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">417.000</LJ_welldepth>
+        <LJ_diameter units="A">3.690</LJ_diameter>
+        <dipoleMoment units="Debye">1.700</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>2.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species CH3O    -->
+    <species name="CH3O">
+      <atomArray>H:3 C:1 O:1 </atomArray>
+      <note>121686</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="300.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.106204000E+00,   7.216595000E-03,   5.338472000E-06,  -7.377636000E-09, 
+             2.075610000E-12,   9.786011000E+02,   1.315217700E+01</floatArray>
+        </NASA>
+        <NASA Tmax="3000.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.770799000E+00,   7.871497000E-03,  -2.656384000E-06,   3.944431000E-10, 
+             -2.112616000E-14,   1.278325200E+02,   2.929575000E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">417.000</LJ_welldepth>
+        <LJ_diameter units="A">3.690</LJ_diameter>
+        <dipoleMoment units="Debye">1.700</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>2.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species CH3OH    -->
+    <species name="CH3OH">
+      <atomArray>H:4 C:1 O:1 </atomArray>
+      <note>L 8/88</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             5.715395820E+00,  -1.523091290E-02,   6.524411550E-05,  -7.108068890E-08, 
+             2.613526980E-11,  -2.564276560E+04,  -1.504098230E+00</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             1.789707910E+00,   1.409382920E-02,  -6.365008350E-06,   1.381710850E-09, 
+             -1.170602200E-13,  -2.537487470E+04,   1.450236230E+01</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">481.800</LJ_welldepth>
+        <LJ_diameter units="A">3.630</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>1.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species C2H    -->
+    <species name="C2H">
+      <atomArray>H:1 C:2 </atomArray>
+      <note>L 1/91</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.889657330E+00,   1.340996110E-02,  -2.847695010E-05,   2.947910450E-08, 
+             -1.093315110E-11,   6.683939320E+04,   6.222964380E+00</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.167806520E+00,   4.752219020E-03,  -1.837870770E-06,   3.041902520E-10, 
+             -1.772327700E-14,   6.712106500E+04,   6.635894750E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">linear</string>
+        <LJ_welldepth units="K">209.000</LJ_welldepth>
+        <LJ_diameter units="A">4.100</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>2.500</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species C2H2    -->
+    <species name="C2H2">
+      <atomArray>H:2 C:2 </atomArray>
+      <note>L 1/91</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             8.086810940E-01,   2.336156290E-02,  -3.551718150E-05,   2.801524370E-08, 
+             -8.500729740E-12,   2.642898070E+04,   1.393970510E+01</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             4.147569640E+00,   5.961666640E-03,  -2.372948520E-06,   4.674121710E-10, 
+             -3.612352130E-14,   2.593599920E+04,  -1.230281210E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">linear</string>
+        <LJ_welldepth units="K">209.000</LJ_welldepth>
+        <LJ_diameter units="A">4.100</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>2.500</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species C2H3    -->
+    <species name="C2H3">
+      <atomArray>H:3 C:2 </atomArray>
+      <note>L 2/92</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.212466450E+00,   1.514791620E-03,   2.592094120E-05,  -3.576578470E-08, 
+             1.471508730E-11,   3.485984680E+04,   8.510540250E+00</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.016724000E+00,   1.033022920E-02,  -4.680823490E-06,   1.017632880E-09, 
+             -8.626070410E-14,   3.461287390E+04,   7.787323780E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">209.000</LJ_welldepth>
+        <LJ_diameter units="A">4.100</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>1.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species C2H4    -->
+    <species name="C2H4">
+      <atomArray>H:4 C:2 </atomArray>
+      <note>L 1/91</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.959201480E+00,  -7.570522470E-03,   5.709902920E-05,  -6.915887530E-08, 
+             2.698843730E-11,   5.089775930E+03,   4.097330960E+00</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.036111160E+00,   1.464541510E-02,  -6.710779150E-06,   1.472229230E-09, 
+             -1.257060610E-13,   4.939886140E+03,   1.030536930E+01</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">280.800</LJ_welldepth>
+        <LJ_diameter units="A">3.970</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>1.500</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species C2H5    -->
+    <species name="C2H5">
+      <atomArray>H:5 C:2 </atomArray>
+      <note>L12/92</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             4.306465680E+00,  -4.186588920E-03,   4.971428070E-05,  -5.991266060E-08, 
+             2.305090040E-11,   1.284162650E+04,   4.707209240E+00</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             1.954656420E+00,   1.739727220E-02,  -7.982066680E-06,   1.752176890E-09, 
+             -1.496415760E-13,   1.285752000E+04,   1.346243430E+01</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">252.300</LJ_welldepth>
+        <LJ_diameter units="A">4.300</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>1.500</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species C2H6    -->
+    <species name="C2H6">
+      <atomArray>H:6 C:2 </atomArray>
+      <note>L 8/88</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             4.291424920E+00,  -5.501542700E-03,   5.994382880E-05,  -7.084662850E-08, 
+             2.686857710E-11,  -1.152220550E+04,   2.666823160E+00</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             1.071881500E+00,   2.168526770E-02,  -1.002560670E-05,   2.214120010E-09, 
+             -1.900028900E-13,  -1.142639320E+04,   1.511561070E+01</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">252.300</LJ_welldepth>
+        <LJ_diameter units="A">4.300</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>1.500</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species HCCO    -->
+    <species name="HCCO">
+      <atomArray>H:1 C:2 O:1 </atomArray>
+      <note>SRIC91</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="300.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.251721400E+00,   1.765502100E-02,  -2.372910100E-05,   1.727575900E-08, 
+             -5.066481100E-12,   2.005944900E+04,   1.249041700E+01</floatArray>
+        </NASA>
+        <NASA Tmax="4000.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             5.628205800E+00,   4.085340100E-03,  -1.593454700E-06,   2.862605200E-10, 
+             -1.940783200E-14,   1.932721500E+04,  -3.930259500E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">150.000</LJ_welldepth>
+        <LJ_diameter units="A">2.500</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>1.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species CH2CO    -->
+    <species name="CH2CO">
+      <atomArray>H:2 C:2 O:1 </atomArray>
+      <note>L 5/90</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.135836300E+00,   1.811887210E-02,  -1.739474740E-05,   9.343975680E-09, 
+             -2.014576150E-12,  -7.042918040E+03,   1.221564800E+01</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             4.511297320E+00,   9.003597450E-03,  -4.169396350E-06,   9.233458820E-10, 
+             -7.948382010E-14,  -7.551053110E+03,   6.322472050E-01</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">436.000</LJ_welldepth>
+        <LJ_diameter units="A">3.970</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>2.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species HCCOH    -->
+    <species name="HCCOH">
+      <atomArray>H:2 C:2 O:1 </atomArray>
+      <note>SRI91</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="300.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             1.242373300E+00,   3.107220100E-02,  -5.086686400E-05,   4.313713100E-08, 
+             -1.401459400E-11,   8.031614300E+03,   1.387431900E+01</floatArray>
+        </NASA>
+        <NASA Tmax="5000.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             5.923829100E+00,   6.792360000E-03,  -2.565856400E-06,   4.498784100E-10, 
+             -2.994010100E-14,   7.264626000E+03,  -7.601774200E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">436.000</LJ_welldepth>
+        <LJ_diameter units="A">3.970</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>2.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species N    -->
+    <species name="N">
+      <atomArray>N:1 </atomArray>
+      <note>L 6/88</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.500000000E+00,   0.000000000E+00,   0.000000000E+00,   0.000000000E+00, 
+             0.000000000E+00,   5.610463700E+04,   4.193908700E+00</floatArray>
+        </NASA>
+        <NASA Tmax="6000.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.415942900E+00,   1.748906500E-04,  -1.190236900E-07,   3.022624500E-11, 
+             -2.036098200E-15,   5.613377300E+04,   4.649609600E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">atom</string>
+        <LJ_welldepth units="K">71.400</LJ_welldepth>
+        <LJ_diameter units="A">3.300</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>0.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species NH    -->
+    <species name="NH">
+      <atomArray>H:1 N:1 </atomArray>
+      <note>And94</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.492908500E+00,   3.117919800E-04,  -1.489048400E-06,   2.481644200E-09, 
+             -1.035696700E-12,   4.188062900E+04,   1.848327800E+00</floatArray>
+        </NASA>
+        <NASA Tmax="6000.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.783692800E+00,   1.329843000E-03,  -4.247804700E-07,   7.834850100E-11, 
+             -5.504447000E-15,   4.212084800E+04,   5.740779900E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">linear</string>
+        <LJ_welldepth units="K">80.000</LJ_welldepth>
+        <LJ_diameter units="A">2.650</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>4.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species NH2    -->
+    <species name="NH2">
+      <atomArray>H:2 N:1 </atomArray>
+      <note>And89</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             4.204002900E+00,  -2.106138500E-03,   7.106834800E-06,  -5.611519700E-09, 
+             1.644071700E-12,   2.188591000E+04,  -1.418424800E-01</floatArray>
+        </NASA>
+        <NASA Tmax="6000.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.834742100E+00,   3.207308200E-03,  -9.339080400E-07,   1.370295300E-10, 
+             -7.920614400E-15,   2.217195700E+04,   6.520416300E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">80.000</LJ_welldepth>
+        <LJ_diameter units="A">2.650</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">2.260</polarizability>
+        <rotRelax>4.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species NH3    -->
+    <species name="NH3">
+      <atomArray>H:3 N:1 </atomArray>
+      <note>J 6/77</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             4.286027400E+00,  -4.660523000E-03,   2.171851300E-05,  -2.280888700E-08, 
+             8.263804600E-12,  -6.741728500E+03,  -6.253727700E-01</floatArray>
+        </NASA>
+        <NASA Tmax="6000.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.634452100E+00,   5.666256000E-03,  -1.727867600E-06,   2.386716100E-10, 
+             -1.257878600E-14,  -6.544695800E+03,   6.566292800E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">481.000</LJ_welldepth>
+        <LJ_diameter units="A">2.920</LJ_diameter>
+        <dipoleMoment units="Debye">1.470</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>10.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species NNH    -->
+    <species name="NNH">
+      <atomArray>H:1 N:2 </atomArray>
+      <note>T07/93</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             4.344692700E+00,  -4.849707200E-03,   2.005945900E-05,  -2.172646400E-08, 
+             7.946953900E-12,   2.879197300E+04,   2.977941000E+00</floatArray>
+        </NASA>
+        <NASA Tmax="6000.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.766754400E+00,   2.891508200E-03,  -1.041662000E-06,   1.684259400E-10, 
+             -1.009189600E-14,   2.865069700E+04,   4.470506700E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">71.400</LJ_welldepth>
+        <LJ_diameter units="A">3.800</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>1.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species NO    -->
+    <species name="NO">
+      <atomArray>O:1 N:1 </atomArray>
+      <note>RUS 78</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             4.218476300E+00,  -4.638976000E-03,   1.104102200E-05,  -9.336135400E-09, 
+             2.803577000E-12,   9.844623000E+03,   2.280846400E+00</floatArray>
+        </NASA>
+        <NASA Tmax="6000.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.260605600E+00,   1.191104300E-03,  -4.291704800E-07,   6.945766900E-11, 
+             -4.033609900E-15,   9.920974600E+03,   6.369302700E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">linear</string>
+        <LJ_welldepth units="K">97.530</LJ_welldepth>
+        <LJ_diameter units="A">3.620</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">1.760</polarizability>
+        <rotRelax>4.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species NO2    -->
+    <species name="NO2">
+      <atomArray>O:2 N:1 </atomArray>
+      <note>L 7/88</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.944031200E+00,  -1.585429000E-03,   1.665781200E-05,  -2.047542600E-08, 
+             7.835056400E-12,   2.896617900E+03,   6.311991700E+00</floatArray>
+        </NASA>
+        <NASA Tmax="6000.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             4.884754200E+00,   2.172395600E-03,  -8.280690600E-07,   1.574751000E-10, 
+             -1.051089500E-14,   2.316498300E+03,  -1.174169500E-01</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">200.000</LJ_welldepth>
+        <LJ_diameter units="A">3.500</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>1.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species N2O    -->
+    <species name="N2O">
+      <atomArray>O:1 N:2 </atomArray>
+      <note>L 7/88</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.257150200E+00,   1.130472800E-02,  -1.367131900E-05,   9.681980600E-09, 
+             -2.930718200E-12,   8.741774400E+03,   1.075799200E+01</floatArray>
+        </NASA>
+        <NASA Tmax="6000.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             4.823072900E+00,   2.627025100E-03,  -9.585087400E-07,   1.600071200E-10, 
+             -9.775230300E-15,   8.073404800E+03,  -2.201720700E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">linear</string>
+        <LJ_welldepth units="K">232.400</LJ_welldepth>
+        <LJ_diameter units="A">3.830</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>1.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species HNO    -->
+    <species name="HNO">
+      <atomArray>H:1 O:1 N:1 </atomArray>
+      <note>And93</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             4.533491600E+00,  -5.669617100E-03,   1.847320700E-05,  -1.713709400E-08, 
+             5.545457300E-12,   1.154829700E+04,   1.749841700E+00</floatArray>
+        </NASA>
+        <NASA Tmax="6000.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.979250900E+00,   3.494405900E-03,  -7.854977800E-07,   5.747959400E-11, 
+             -1.933591600E-16,   1.175058200E+04,   8.606372800E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">116.700</LJ_welldepth>
+        <LJ_diameter units="A">3.490</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>1.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species CN    -->
+    <species name="CN">
+      <atomArray>C:1 N:1 </atomArray>
+      <note>HBH92</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.612935100E+00,  -9.555132700E-04,   2.144297700E-06,  -3.151632300E-10, 
+             -4.643035600E-13,   5.170834000E+04,   3.980499500E+00</floatArray>
+        </NASA>
+        <NASA Tmax="6000.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.745980500E+00,   4.345077500E-05,   2.970598400E-07,  -6.865180600E-11, 
+             4.413417300E-15,   5.153618800E+04,   2.786760100E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">linear</string>
+        <LJ_welldepth units="K">75.000</LJ_welldepth>
+        <LJ_diameter units="A">3.860</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>1.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species HCN    -->
+    <species name="HCN">
+      <atomArray>H:1 C:1 N:1 </atomArray>
+      <note>GRI/98</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.258988600E+00,   1.005117000E-02,  -1.335176300E-05,   1.009234900E-08, 
+             -3.008902800E-12,   1.471263300E+04,   8.916441900E+00</floatArray>
+        </NASA>
+        <NASA Tmax="6000.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.802239200E+00,   3.146422800E-03,  -1.063218500E-06,   1.661975700E-10, 
+             -9.799757000E-15,   1.440729200E+04,   1.575460100E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">linear</string>
+        <LJ_welldepth units="K">569.000</LJ_welldepth>
+        <LJ_diameter units="A">3.630</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>1.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species H2CN    -->
+    <species name="H2CN">
+      <atomArray>H:2 C:1 N:1 </atomArray>
+      <note>41687</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="300.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.851661000E+00,   5.695233100E-03,   1.071140000E-06,  -1.622612000E-09, 
+             -2.351108100E-13,   2.863782000E+04,   8.992751100E+00</floatArray>
+        </NASA>
+        <NASA Tmax="4000.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             5.209703000E+00,   2.969291100E-03,  -2.855589100E-07,  -1.635550000E-10, 
+             3.043258900E-14,   2.767710900E+04,  -4.444478000E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">linear</string>
+        <LJ_welldepth units="K">569.000</LJ_welldepth>
+        <LJ_diameter units="A">3.630</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>1.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species HCNN    -->
+    <species name="HCNN">
+      <atomArray>H:1 C:1 N:2 </atomArray>
+      <note>SRI/94</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="300.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.524319400E+00,   1.596061900E-02,  -1.881635400E-05,   1.212554000E-08, 
+             -3.235737800E-12,   5.426198400E+04,   1.167587000E+01</floatArray>
+        </NASA>
+        <NASA Tmax="5000.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             5.894636200E+00,   3.989595900E-03,  -1.598238000E-06,   2.924939500E-10, 
+             -2.009468600E-14,   5.345294100E+04,  -5.103050200E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">150.000</LJ_welldepth>
+        <LJ_diameter units="A">2.500</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>1.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species HCNO    -->
+    <species name="HCNO">
+      <atomArray>H:1 C:1 O:1 N:1 </atomArray>
+      <note>BDEA94</note>
+      <thermo>
+        <NASA Tmax="1382.0" Tmin="300.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.647279890E+00,   1.275053420E-02,  -1.047942360E-05,   4.414328360E-09, 
+             -7.575214660E-13,   1.929902520E+04,   1.073329720E+01</floatArray>
+        </NASA>
+        <NASA Tmax="5000.0" Tmin="1382.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             6.598604560E+00,   3.027786260E-03,  -1.077043460E-06,   1.716665280E-10, 
+             -1.014393910E-14,   1.796613390E+04,  -1.033065990E+01</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">232.400</LJ_welldepth>
+        <LJ_diameter units="A">3.830</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>1.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species HOCN    -->
+    <species name="HOCN">
+      <atomArray>H:1 C:1 O:1 N:1 </atomArray>
+      <note>BDEA94</note>
+      <thermo>
+        <NASA Tmax="1368.0" Tmin="300.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.786049520E+00,   6.886679220E-03,  -3.214878640E-06,   5.171957670E-10, 
+             1.193607880E-14,  -2.826984000E+03,   5.632921620E+00</floatArray>
+        </NASA>
+        <NASA Tmax="5000.0" Tmin="1368.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             5.897848850E+00,   3.167893930E-03,  -1.118010640E-06,   1.772431440E-10, 
+             -1.043391770E-14,  -3.706533310E+03,  -6.181678250E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">232.400</LJ_welldepth>
+        <LJ_diameter units="A">3.830</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>1.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species HNCO    -->
+    <species name="HNCO">
+      <atomArray>H:1 C:1 O:1 N:1 </atomArray>
+      <note>BDEA94</note>
+      <thermo>
+        <NASA Tmax="1478.0" Tmin="300.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.630963170E+00,   7.302823570E-03,  -2.280500030E-06,  -6.612712980E-10, 
+             3.622357520E-13,  -1.558736360E+04,   6.194577270E+00</floatArray>
+        </NASA>
+        <NASA Tmax="5000.0" Tmin="1478.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             6.223951340E+00,   3.178640040E-03,  -1.093787550E-06,   1.707351630E-10, 
+             -9.950219550E-15,  -1.665993440E+04,  -8.382247410E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">232.400</LJ_welldepth>
+        <LJ_diameter units="A">3.830</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>1.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species NCO    -->
+    <species name="NCO">
+      <atomArray>C:1 O:1 N:1 </atomArray>
+      <note>EA 93</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.826930800E+00,   8.805168800E-03,  -8.386613400E-06,   4.801696400E-09, 
+             -1.331359500E-12,   1.468247700E+04,   9.550464600E+00</floatArray>
+        </NASA>
+        <NASA Tmax="6000.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             5.152184500E+00,   2.305176100E-03,  -8.803315300E-07,   1.478909800E-10, 
+             -9.097799600E-15,   1.400412300E+04,  -2.544266000E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">linear</string>
+        <LJ_welldepth units="K">232.400</LJ_welldepth>
+        <LJ_diameter units="A">3.830</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>1.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species N2    -->
+    <species name="N2">
+      <atomArray>N:2 </atomArray>
+      <note>121286</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="300.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.298677000E+00,   1.408240400E-03,  -3.963222000E-06,   5.641515000E-09, 
+             -2.444854000E-12,  -1.020899900E+03,   3.950372000E+00</floatArray>
+        </NASA>
+        <NASA Tmax="5000.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.926640000E+00,   1.487976800E-03,  -5.684760000E-07,   1.009703800E-10, 
+             -6.753351000E-15,  -9.227977000E+02,   5.980528000E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">linear</string>
+        <LJ_welldepth units="K">97.530</LJ_welldepth>
+        <LJ_diameter units="A">3.620</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">1.760</polarizability>
+        <rotRelax>4.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species AR    -->
+    <species name="AR">
+      <atomArray>Ar:1 </atomArray>
+      <note>120186</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="300.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.500000000E+00,   0.000000000E+00,   0.000000000E+00,   0.000000000E+00, 
+             0.000000000E+00,  -7.453750000E+02,   4.366000000E+00</floatArray>
+        </NASA>
+        <NASA Tmax="5000.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.500000000E+00,   0.000000000E+00,   0.000000000E+00,   0.000000000E+00, 
+             0.000000000E+00,  -7.453750000E+02,   4.366000000E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">atom</string>
+        <LJ_welldepth units="K">136.500</LJ_welldepth>
+        <LJ_diameter units="A">3.330</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>0.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species C3H7    -->
+    <species name="C3H7">
+      <atomArray>H:7 C:3 </atomArray>
+      <note>L 9/84</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="300.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             1.051551800E+00,   2.599198000E-02,   2.380054000E-06,  -1.960956900E-08, 
+             9.373247000E-12,   1.063186300E+04,   2.112255900E+01</floatArray>
+        </NASA>
+        <NASA Tmax="5000.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             7.702698700E+00,   1.604420300E-02,  -5.283322000E-06,   7.629859000E-10, 
+             -3.939228400E-14,   8.298433600E+03,  -1.548018000E+01</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">266.800</LJ_welldepth>
+        <LJ_diameter units="A">4.980</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>1.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species C3H8    -->
+    <species name="C3H8">
+      <atomArray>H:8 C:3 </atomArray>
+      <note>L 4/85</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="300.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             9.335538100E-01,   2.642457900E-02,   6.105972700E-06,  -2.197749900E-08, 
+             9.514925300E-12,  -1.395852000E+04,   1.920169100E+01</floatArray>
+        </NASA>
+        <NASA Tmax="5000.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             7.534136800E+00,   1.887223900E-02,  -6.271849100E-06,   9.147564900E-10, 
+             -4.783806900E-14,  -1.646751600E+04,  -1.789234900E+01</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">266.800</LJ_welldepth>
+        <LJ_diameter units="A">4.980</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>1.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species CH2CHO    -->
+    <species name="CH2CHO">
+      <atomArray>H:3 C:2 O:1 </atomArray>
+      <note>SAND86</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="300.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.409062000E+00,   1.073857400E-02,   1.891492000E-06,  -7.158583000E-09, 
+             2.867385000E-12,   1.521476600E+03,   9.558290000E+00</floatArray>
+        </NASA>
+        <NASA Tmax="5000.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             5.975670000E+00,   8.130591000E-03,  -2.743624000E-06,   4.070304000E-10, 
+             -2.176017000E-14,   4.903218000E+02,  -5.045251000E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">436.000</LJ_welldepth>
+        <LJ_diameter units="A">3.970</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>2.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species CH3CHO    -->
+    <species name="CH3CHO">
+      <atomArray>H:4 C:2 O:1 </atomArray>
+      <note>L 8/88</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             4.729459500E+00,  -3.193285800E-03,   4.753492100E-05,  -5.745861100E-08, 
+             2.193111200E-11,  -2.157287800E+04,   4.103015900E+00</floatArray>
+        </NASA>
+        <NASA Tmax="6000.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             5.404110800E+00,   1.172305900E-02,  -4.226313700E-06,   6.837245100E-10, 
+             -4.098486300E-14,  -2.259312200E+04,  -3.480791700E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">436.000</LJ_welldepth>
+        <LJ_diameter units="A">3.970</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>2.000</rotRelax>
+      </transport>
+    </species>
+  </speciesData>
+  <reactionData id="reaction_data">
+
+    <!-- reaction 0001    -->
+    <reaction reversible="yes" type="threeBody" id="0001">
+      <equation>2 O + M [=] O2 + M</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.200000E+11</A>
+           <b>-1</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.83  C2H6:3  CH4:2  CO:1.75  CO2:3.6  H2:2.4  H2O:15.4 </efficiencies>
+      </rateCoeff>
+      <reactants>O:2.0</reactants>
+      <products>O2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0002    -->
+    <reaction reversible="yes" type="threeBody" id="0002">
+      <equation>O + H + M [=] OH + M</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.000000E+11</A>
+           <b>-1</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+      </rateCoeff>
+      <reactants>H:1 O:1.0</reactants>
+      <products>OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0003    -->
+    <reaction reversible="yes" id="0003">
+      <equation>O + H2 [=] H + OH</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.870000E+01</A>
+           <b>2.7</b>
+           <E units="cal/mol">6260.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H2:1 O:1.0</reactants>
+      <products>H:1.0 OH:1</products>
+    </reaction>
+
+    <!-- reaction 0004    -->
+    <reaction reversible="yes" id="0004">
+      <equation>O + HO2 [=] OH + O2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HO2:1 O:1.0</reactants>
+      <products>O2:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0005    -->
+    <reaction reversible="yes" id="0005">
+      <equation>O + H2O2 [=] OH + HO2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>9.630000E+03</A>
+           <b>2</b>
+           <E units="cal/mol">4000.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H2O2:1 O:1.0</reactants>
+      <products>HO2:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0006    -->
+    <reaction reversible="yes" id="0006">
+      <equation>O + CH [=] H + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.700000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH:1 O:1.0</reactants>
+      <products>H:1.0 CO:1</products>
+    </reaction>
+
+    <!-- reaction 0007    -->
+    <reaction reversible="yes" id="0007">
+      <equation>O + CH2 [=] H + HCO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>8.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2:1 O:1.0</reactants>
+      <products>H:1.0 HCO:1</products>
+    </reaction>
+
+    <!-- reaction 0008    -->
+    <reaction reversible="yes" id="0008">
+      <equation>O + CH2(S) [=] H2 + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.500000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2(S):1 O:1.0</reactants>
+      <products>H2:1.0 CO:1</products>
+    </reaction>
+
+    <!-- reaction 0009    -->
+    <reaction reversible="yes" id="0009">
+      <equation>O + CH2(S) [=] H + HCO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.500000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2(S):1 O:1.0</reactants>
+      <products>H:1.0 HCO:1</products>
+    </reaction>
+
+    <!-- reaction 0010    -->
+    <reaction reversible="yes" id="0010">
+      <equation>O + CH3 [=] H + CH2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.060000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3:1 O:1.0</reactants>
+      <products>CH2O:1 H:1.0</products>
+    </reaction>
+
+    <!-- reaction 0011    -->
+    <reaction reversible="yes" id="0011">
+      <equation>O + CH4 [=] OH + CH3</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.020000E+06</A>
+           <b>1.5</b>
+           <E units="cal/mol">8600.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH4:1 O:1.0</reactants>
+      <products>CH3:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0012    -->
+    <reaction reversible="yes" type="falloff" id="0012">
+      <equation>O + CO (+ M) [=] CO2 (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.800000E+07</A>
+           <b>0</b>
+           <E units="cal/mol">2385.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>6.020000E+08</A>
+           <b>0</b>
+           <E units="cal/mol">3000.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.5  C2H6:3  CH4:2  CO:1.5  CO2:3.5  H2:2  H2O:6  O2:6 </efficiencies>
+        <falloff type="Lindemann"/>
+      </rateCoeff>
+      <reactants>CO:1 O:1.0</reactants>
+      <products>CO2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0013    -->
+    <reaction reversible="yes" id="0013">
+      <equation>O + HCO [=] OH + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HCO:1 O:1.0</reactants>
+      <products>CO:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0014    -->
+    <reaction reversible="yes" id="0014">
+      <equation>O + HCO [=] H + CO2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HCO:1 O:1.0</reactants>
+      <products>H:1.0 CO2:1</products>
+    </reaction>
+
+    <!-- reaction 0015    -->
+    <reaction reversible="yes" id="0015">
+      <equation>O + CH2O [=] OH + HCO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.900000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">3540.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2O:1 O:1.0</reactants>
+      <products>HCO:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0016    -->
+    <reaction reversible="yes" id="0016">
+      <equation>O + CH2OH [=] OH + CH2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2OH:1 O:1.0</reactants>
+      <products>CH2O:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0017    -->
+    <reaction reversible="yes" id="0017">
+      <equation>O + CH3O [=] OH + CH2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3O:1 O:1.0</reactants>
+      <products>CH2O:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0018    -->
+    <reaction reversible="yes" id="0018">
+      <equation>O + CH3OH [=] OH + CH2OH</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.880000E+02</A>
+           <b>2.5</b>
+           <E units="cal/mol">3100.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3OH:1 O:1.0</reactants>
+      <products>CH2OH:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0019    -->
+    <reaction reversible="yes" id="0019">
+      <equation>O + CH3OH [=] OH + CH3O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.300000E+02</A>
+           <b>2.5</b>
+           <E units="cal/mol">5000.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3OH:1 O:1.0</reactants>
+      <products>CH3O:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0020    -->
+    <reaction reversible="yes" id="0020">
+      <equation>O + C2H [=] CH + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C2H:1 O:1.0</reactants>
+      <products>CH:1.0 CO:1</products>
+    </reaction>
+
+    <!-- reaction 0021    -->
+    <reaction reversible="yes" id="0021">
+      <equation>O + C2H2 [=] H + HCCO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.350000E+04</A>
+           <b>2</b>
+           <E units="cal/mol">1900.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C2H2:1 O:1.0</reactants>
+      <products>H:1.0 HCCO:1</products>
+    </reaction>
+
+    <!-- reaction 0022    -->
+    <reaction reversible="yes" id="0022">
+      <equation>O + C2H2 [=] OH + C2H</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>4.600000E+16</A>
+           <b>-1.41</b>
+           <E units="cal/mol">28950.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C2H2:1 O:1.0</reactants>
+      <products>C2H:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0023    -->
+    <reaction reversible="yes" id="0023">
+      <equation>O + C2H2 [=] CO + CH2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>6.940000E+03</A>
+           <b>2</b>
+           <E units="cal/mol">1900.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C2H2:1 O:1.0</reactants>
+      <products>CH2:1 CO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0024    -->
+    <reaction reversible="yes" id="0024">
+      <equation>O + C2H3 [=] H + CH2CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C2H3:1 O:1.0</reactants>
+      <products>H:1.0 CH2CO:1</products>
+    </reaction>
+
+    <!-- reaction 0025    -->
+    <reaction reversible="yes" id="0025">
+      <equation>O + C2H4 [=] CH3 + HCO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.250000E+04</A>
+           <b>1.83</b>
+           <E units="cal/mol">220.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C2H4:1 O:1.0</reactants>
+      <products>CH3:1.0 HCO:1</products>
+    </reaction>
+
+    <!-- reaction 0026    -->
+    <reaction reversible="yes" id="0026">
+      <equation>O + C2H5 [=] CH3 + CH2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.240000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C2H5:1 O:1.0</reactants>
+      <products>CH2O:1 CH3:1.0</products>
+    </reaction>
+
+    <!-- reaction 0027    -->
+    <reaction reversible="yes" id="0027">
+      <equation>O + C2H6 [=] OH + C2H5</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>8.980000E+04</A>
+           <b>1.92</b>
+           <E units="cal/mol">5690.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C2H6:1 O:1.0</reactants>
+      <products>C2H5:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0028    -->
+    <reaction reversible="yes" id="0028">
+      <equation>O + HCCO [=] H + 2 CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.000000E+11</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HCCO:1 O:1.0</reactants>
+      <products>H:1.0 CO:2.0</products>
+    </reaction>
+
+    <!-- reaction 0029    -->
+    <reaction reversible="yes" id="0029">
+      <equation>O + CH2CO [=] OH + HCCO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">8000.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2CO:1 O:1.0</reactants>
+      <products>HCCO:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0030    -->
+    <reaction reversible="yes" id="0030">
+      <equation>O + CH2CO [=] CH2 + CO2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.750000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">1350.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2CO:1 O:1.0</reactants>
+      <products>CH2:1.0 CO2:1</products>
+    </reaction>
+
+    <!-- reaction 0031    -->
+    <reaction reversible="yes" id="0031">
+      <equation>O2 + CO [=] O + CO2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.500000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">47800.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CO:1 O2:1.0</reactants>
+      <products>CO2:1 O:1.0</products>
+    </reaction>
+
+    <!-- reaction 0032    -->
+    <reaction reversible="yes" id="0032">
+      <equation>O2 + CH2O [=] HO2 + HCO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.000000E+11</A>
+           <b>0</b>
+           <E units="cal/mol">40000.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2O:1 O2:1.0</reactants>
+      <products>HO2:1.0 HCO:1</products>
+    </reaction>
+
+    <!-- reaction 0033    -->
+    <reaction reversible="yes" type="threeBody" id="0033">
+      <equation>H + O2 + M [=] HO2 + M</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.800000E+12</A>
+           <b>-0.86</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0  C2H6:1.5  CO:0.75  CO2:1.5  H2O:0  N2:0  O2:0 </efficiencies>
+      </rateCoeff>
+      <reactants>H:1.0 O2:1</reactants>
+      <products>HO2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0034    -->
+    <reaction reversible="yes" id="0034">
+      <equation>H + 2 O2 [=] HO2 + O2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.080000E+13</A>
+           <b>-1.24</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 O2:2.0</reactants>
+      <products>HO2:1.0 O2:1</products>
+    </reaction>
+
+    <!-- reaction 0035    -->
+    <reaction reversible="yes" id="0035">
+      <equation>H + O2 + H2O [=] HO2 + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.126000E+13</A>
+           <b>-0.76</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 H2O:1 O2:1</reactants>
+      <products>H2O:1 HO2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0036    -->
+    <reaction reversible="yes" id="0036">
+      <equation>H + O2 + N2 [=] HO2 + N2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.600000E+13</A>
+           <b>-1.24</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 N2:1 O2:1</reactants>
+      <products>N2:1 HO2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0037    -->
+    <reaction reversible="yes" id="0037">
+      <equation>H + O2 + AR [=] HO2 + AR</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>7.000000E+11</A>
+           <b>-0.8</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 AR:1 O2:1</reactants>
+      <products>AR:1 HO2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0038    -->
+    <reaction reversible="yes" id="0038">
+      <equation>H + O2 [=] O + OH</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.650000E+13</A>
+           <b>-0.6707</b>
+           <E units="cal/mol">17041.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 O2:1</reactants>
+      <products>O:1.0 OH:1</products>
+    </reaction>
+
+    <!-- reaction 0039    -->
+    <reaction reversible="yes" type="threeBody" id="0039">
+      <equation>2 H + M [=] H2 + M</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.000000E+12</A>
+           <b>-1</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.63  C2H6:3  CH4:2  CO2:0  H2:0  H2O:0 </efficiencies>
+      </rateCoeff>
+      <reactants>H:2.0</reactants>
+      <products>H2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0040    -->
+    <reaction reversible="yes" id="0040">
+      <equation>2 H + H2 [=] 2 H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>9.000000E+10</A>
+           <b>-0.6</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H2:1 H:2.0</reactants>
+      <products>H2:2.0</products>
+    </reaction>
+
+    <!-- reaction 0041    -->
+    <reaction reversible="yes" id="0041">
+      <equation>2 H + H2O [=] H2 + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>6.000000E+13</A>
+           <b>-1.25</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:2.0 H2O:1</reactants>
+      <products>H2:1.0 H2O:1</products>
+    </reaction>
+
+    <!-- reaction 0042    -->
+    <reaction reversible="yes" id="0042">
+      <equation>2 H + CO2 [=] H2 + CO2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.500000E+14</A>
+           <b>-2</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:2.0 CO2:1</reactants>
+      <products>H2:1.0 CO2:1</products>
+    </reaction>
+
+    <!-- reaction 0043    -->
+    <reaction reversible="yes" type="threeBody" id="0043">
+      <equation>H + OH + M [=] H2O + M</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.200000E+16</A>
+           <b>-2</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.38  C2H6:3  CH4:2  H2:0.73  H2O:3.65 </efficiencies>
+      </rateCoeff>
+      <reactants>H:1.0 OH:1</reactants>
+      <products>H2O:1.0</products>
+    </reaction>
+
+    <!-- reaction 0044    -->
+    <reaction reversible="yes" id="0044">
+      <equation>H + HO2 [=] O + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.970000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">671.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 HO2:1</reactants>
+      <products>H2O:1 O:1.0</products>
+    </reaction>
+
+    <!-- reaction 0045    -->
+    <reaction reversible="yes" id="0045">
+      <equation>H + HO2 [=] O2 + H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>4.480000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">1068.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 HO2:1</reactants>
+      <products>H2:1 O2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0046    -->
+    <reaction reversible="yes" id="0046">
+      <equation>H + HO2 [=] 2 OH</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>8.400000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">635.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 HO2:1</reactants>
+      <products>OH:2.0</products>
+    </reaction>
+
+    <!-- reaction 0047    -->
+    <reaction reversible="yes" id="0047">
+      <equation>H + H2O2 [=] HO2 + H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.210000E+04</A>
+           <b>2</b>
+           <E units="cal/mol">5200.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 H2O2:1</reactants>
+      <products>H2:1 HO2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0048    -->
+    <reaction reversible="yes" id="0048">
+      <equation>H + H2O2 [=] OH + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">3600.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 H2O2:1</reactants>
+      <products>H2O:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0049    -->
+    <reaction reversible="yes" id="0049">
+      <equation>H + CH [=] C + H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.650000E+11</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 CH:1</reactants>
+      <products>H2:1 C:1.0</products>
+    </reaction>
+
+    <!-- reaction 0050    -->
+    <reaction reversible="yes" type="falloff" id="0050">
+      <equation>H + CH2 (+ M) [=] CH3 (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>6.000000E+11</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>1.040000E+20</A>
+           <b>-2.76</b>
+           <E units="cal/mol">1600.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Troe">0.562 91 5836 8552 </falloff>
+      </rateCoeff>
+      <reactants>H:1.0 CH2:1</reactants>
+      <products>CH3:1.0</products>
+    </reaction>
+
+    <!-- reaction 0051    -->
+    <reaction reversible="yes" id="0051">
+      <equation>H + CH2(S) [=] CH + H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 CH2(S):1</reactants>
+      <products>H2:1 CH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0052    -->
+    <reaction reversible="yes" type="falloff" id="0052">
+      <equation>H + CH3 (+ M) [=] CH4 (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.390000E+13</A>
+           <b>-0.534</b>
+           <E units="cal/mol">536.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>2.620000E+27</A>
+           <b>-4.76</b>
+           <E units="cal/mol">2440.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:3  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Troe">0.783 74 2941 6964 </falloff>
+      </rateCoeff>
+      <reactants>H:1.0 CH3:1</reactants>
+      <products>CH4:1.0</products>
+    </reaction>
+
+    <!-- reaction 0053    -->
+    <reaction reversible="yes" id="0053">
+      <equation>H + CH4 [=] CH3 + H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>6.600000E+05</A>
+           <b>1.62</b>
+           <E units="cal/mol">10840.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 CH4:1</reactants>
+      <products>H2:1 CH3:1.0</products>
+    </reaction>
+
+    <!-- reaction 0054    -->
+    <reaction reversible="yes" type="falloff" id="0054">
+      <equation>H + HCO (+ M) [=] CH2O (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.090000E+09</A>
+           <b>0.48</b>
+           <E units="cal/mol">-260.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>2.470000E+18</A>
+           <b>-2.57</b>
+           <E units="cal/mol">425.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Troe">0.7824 271 2755 6570 </falloff>
+      </rateCoeff>
+      <reactants>H:1.0 HCO:1</reactants>
+      <products>CH2O:1.0</products>
+    </reaction>
+
+    <!-- reaction 0055    -->
+    <reaction reversible="yes" id="0055">
+      <equation>H + HCO [=] H2 + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>7.340000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 HCO:1</reactants>
+      <products>H2:1.0 CO:1</products>
+    </reaction>
+
+    <!-- reaction 0056    -->
+    <reaction reversible="yes" type="falloff" id="0056">
+      <equation>H + CH2O (+ M) [=] CH2OH (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.400000E+08</A>
+           <b>0.454</b>
+           <E units="cal/mol">3600.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>1.270000E+26</A>
+           <b>-4.82</b>
+           <E units="cal/mol">6530.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Troe">0.7187 103 1291 4160 </falloff>
+      </rateCoeff>
+      <reactants>CH2O:1 H:1.0</reactants>
+      <products>CH2OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0057    -->
+    <reaction reversible="yes" type="falloff" id="0057">
+      <equation>H + CH2O (+ M) [=] CH3O (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.400000E+08</A>
+           <b>0.454</b>
+           <E units="cal/mol">2600.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>2.200000E+24</A>
+           <b>-4.8</b>
+           <E units="cal/mol">5560.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Troe">0.758 94 1555 4200 </falloff>
+      </rateCoeff>
+      <reactants>CH2O:1 H:1.0</reactants>
+      <products>CH3O:1.0</products>
+    </reaction>
+
+    <!-- reaction 0058    -->
+    <reaction reversible="yes" id="0058">
+      <equation>H + CH2O [=] HCO + H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.740000E+04</A>
+           <b>1.9</b>
+           <E units="cal/mol">2742.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2O:1 H:1.0</reactants>
+      <products>H2:1 HCO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0059    -->
+    <reaction reversible="yes" type="falloff" id="0059">
+      <equation>H + CH2OH (+ M) [=] CH3OH (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.055000E+09</A>
+           <b>0.5</b>
+           <E units="cal/mol">86.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>4.360000E+25</A>
+           <b>-4.65</b>
+           <E units="cal/mol">5080.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Troe">0.6 100 90000 10000 </falloff>
+      </rateCoeff>
+      <reactants>H:1.0 CH2OH:1</reactants>
+      <products>CH3OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0060    -->
+    <reaction reversible="yes" id="0060">
+      <equation>H + CH2OH [=] H2 + CH2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 CH2OH:1</reactants>
+      <products>H2:1.0 CH2O:1</products>
+    </reaction>
+
+    <!-- reaction 0061    -->
+    <reaction reversible="yes" id="0061">
+      <equation>H + CH2OH [=] OH + CH3</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.650000E+08</A>
+           <b>0.65</b>
+           <E units="cal/mol">-284.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 CH2OH:1</reactants>
+      <products>CH3:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0062    -->
+    <reaction reversible="yes" id="0062">
+      <equation>H + CH2OH [=] CH2(S) + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.280000E+10</A>
+           <b>-0.09</b>
+           <E units="cal/mol">610.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 CH2OH:1</reactants>
+      <products>CH2(S):1.0 H2O:1</products>
+    </reaction>
+
+    <!-- reaction 0063    -->
+    <reaction reversible="yes" type="falloff" id="0063">
+      <equation>H + CH3O (+ M) [=] CH3OH (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.430000E+09</A>
+           <b>0.515</b>
+           <E units="cal/mol">50.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>4.660000E+35</A>
+           <b>-7.44</b>
+           <E units="cal/mol">14080.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Troe">0.7 100 90000 10000 </falloff>
+      </rateCoeff>
+      <reactants>H:1.0 CH3O:1</reactants>
+      <products>CH3OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0064    -->
+    <reaction reversible="yes" id="0064">
+      <equation>H + CH3O [=] H + CH2OH</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>4.150000E+04</A>
+           <b>1.63</b>
+           <E units="cal/mol">1924.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 CH3O:1</reactants>
+      <products>H:1.0 CH2OH:1</products>
+    </reaction>
+
+    <!-- reaction 0065    -->
+    <reaction reversible="yes" id="0065">
+      <equation>H + CH3O [=] H2 + CH2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 CH3O:1</reactants>
+      <products>H2:1.0 CH2O:1</products>
+    </reaction>
+
+    <!-- reaction 0066    -->
+    <reaction reversible="yes" id="0066">
+      <equation>H + CH3O [=] OH + CH3</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.500000E+09</A>
+           <b>0.5</b>
+           <E units="cal/mol">-110.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 CH3O:1</reactants>
+      <products>CH3:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0067    -->
+    <reaction reversible="yes" id="0067">
+      <equation>H + CH3O [=] CH2(S) + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.620000E+11</A>
+           <b>-0.23</b>
+           <E units="cal/mol">1070.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 CH3O:1</reactants>
+      <products>CH2(S):1.0 H2O:1</products>
+    </reaction>
+
+    <!-- reaction 0068    -->
+    <reaction reversible="yes" id="0068">
+      <equation>H + CH3OH [=] CH2OH + H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.700000E+04</A>
+           <b>2.1</b>
+           <E units="cal/mol">4870.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3OH:1 H:1.0</reactants>
+      <products>H2:1 CH2OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0069    -->
+    <reaction reversible="yes" id="0069">
+      <equation>H + CH3OH [=] CH3O + H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>4.200000E+03</A>
+           <b>2.1</b>
+           <E units="cal/mol">4870.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3OH:1 H:1.0</reactants>
+      <products>H2:1 CH3O:1.0</products>
+    </reaction>
+
+    <!-- reaction 0070    -->
+    <reaction reversible="yes" type="falloff" id="0070">
+      <equation>H + C2H (+ M) [=] C2H2 (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.000000E+14</A>
+           <b>-1</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>3.750000E+27</A>
+           <b>-4.8</b>
+           <E units="cal/mol">1900.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Troe">0.6464 132 1315 5566 </falloff>
+      </rateCoeff>
+      <reactants>H:1.0 C2H:1</reactants>
+      <products>C2H2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0071    -->
+    <reaction reversible="yes" type="falloff" id="0071">
+      <equation>H + C2H2 (+ M) [=] C2H3 (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.600000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">2400.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>3.800000E+34</A>
+           <b>-7.27</b>
+           <E units="cal/mol">7220.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Troe">0.7507 98.5 1302 4167 </falloff>
+      </rateCoeff>
+      <reactants>H:1.0 C2H2:1</reactants>
+      <products>C2H3:1.0</products>
+    </reaction>
+
+    <!-- reaction 0072    -->
+    <reaction reversible="yes" type="falloff" id="0072">
+      <equation>H + C2H3 (+ M) [=] C2H4 (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>6.080000E+09</A>
+           <b>0.27</b>
+           <E units="cal/mol">280.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>1.400000E+24</A>
+           <b>-3.86</b>
+           <E units="cal/mol">3320.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Troe">0.782 207.5 2663 6095 </falloff>
+      </rateCoeff>
+      <reactants>H:1.0 C2H3:1</reactants>
+      <products>C2H4:1.0</products>
+    </reaction>
+
+    <!-- reaction 0073    -->
+    <reaction reversible="yes" id="0073">
+      <equation>H + C2H3 [=] H2 + C2H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 C2H3:1</reactants>
+      <products>H2:1.0 C2H2:1</products>
+    </reaction>
+
+    <!-- reaction 0074    -->
+    <reaction reversible="yes" type="falloff" id="0074">
+      <equation>H + C2H4 (+ M) [=] C2H5 (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.400000E+08</A>
+           <b>0.454</b>
+           <E units="cal/mol">1820.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>6.000000E+35</A>
+           <b>-7.62</b>
+           <E units="cal/mol">6970.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Troe">0.9753 210 984 4374 </falloff>
+      </rateCoeff>
+      <reactants>H:1.0 C2H4:1</reactants>
+      <products>C2H5:1.0</products>
+    </reaction>
+
+    <!-- reaction 0075    -->
+    <reaction reversible="yes" id="0075">
+      <equation>H + C2H4 [=] C2H3 + H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.325000E+03</A>
+           <b>2.53</b>
+           <E units="cal/mol">12240.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 C2H4:1</reactants>
+      <products>H2:1 C2H3:1.0</products>
+    </reaction>
+
+    <!-- reaction 0076    -->
+    <reaction reversible="yes" type="falloff" id="0076">
+      <equation>H + C2H5 (+ M) [=] C2H6 (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.210000E+14</A>
+           <b>-0.99</b>
+           <E units="cal/mol">1580.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>1.990000E+35</A>
+           <b>-7.08</b>
+           <E units="cal/mol">6685.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Troe">0.8422 125 2219 6882 </falloff>
+      </rateCoeff>
+      <reactants>H:1.0 C2H5:1</reactants>
+      <products>C2H6:1.0</products>
+    </reaction>
+
+    <!-- reaction 0077    -->
+    <reaction reversible="yes" id="0077">
+      <equation>H + C2H5 [=] H2 + C2H4</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.000000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 C2H5:1</reactants>
+      <products>H2:1.0 C2H4:1</products>
+    </reaction>
+
+    <!-- reaction 0078    -->
+    <reaction reversible="yes" id="0078">
+      <equation>H + C2H6 [=] C2H5 + H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.150000E+05</A>
+           <b>1.9</b>
+           <E units="cal/mol">7530.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 C2H6:1</reactants>
+      <products>H2:1 C2H5:1.0</products>
+    </reaction>
+
+    <!-- reaction 0079    -->
+    <reaction reversible="yes" id="0079">
+      <equation>H + HCCO [=] CH2(S) + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.000000E+11</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 HCCO:1</reactants>
+      <products>CH2(S):1.0 CO:1</products>
+    </reaction>
+
+    <!-- reaction 0080    -->
+    <reaction reversible="yes" id="0080">
+      <equation>H + CH2CO [=] HCCO + H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">8000.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 CH2CO:1</reactants>
+      <products>H2:1 HCCO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0081    -->
+    <reaction reversible="yes" id="0081">
+      <equation>H + CH2CO [=] CH3 + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.130000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">3428.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 CH2CO:1</reactants>
+      <products>CH3:1.0 CO:1</products>
+    </reaction>
+
+    <!-- reaction 0082    -->
+    <reaction reversible="yes" id="0082">
+      <equation>H + HCCOH [=] H + CH2CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 HCCOH:1</reactants>
+      <products>H:1.0 CH2CO:1</products>
+    </reaction>
+
+    <!-- reaction 0083    -->
+    <reaction reversible="yes" type="falloff" id="0083">
+      <equation>H2 + CO (+ M) [=] CH2O (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>4.300000E+04</A>
+           <b>1.5</b>
+           <E units="cal/mol">79600.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>5.070000E+21</A>
+           <b>-3.42</b>
+           <E units="cal/mol">84350.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Troe">0.932 197 1540 10300 </falloff>
+      </rateCoeff>
+      <reactants>H2:1.0 CO:1</reactants>
+      <products>CH2O:1.0</products>
+    </reaction>
+
+    <!-- reaction 0084    -->
+    <reaction reversible="yes" id="0084">
+      <equation>OH + H2 [=] H + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.160000E+05</A>
+           <b>1.51</b>
+           <E units="cal/mol">3430.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H2:1 OH:1.0</reactants>
+      <products>H:1.0 H2O:1</products>
+    </reaction>
+
+    <!-- reaction 0085    -->
+    <reaction reversible="yes" type="falloff" id="0085">
+      <equation>2 OH (+ M) [=] H2O2 (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>7.400000E+10</A>
+           <b>-0.37</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>2.300000E+12</A>
+           <b>-0.9</b>
+           <E units="cal/mol">-1700.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Troe">0.7346 94 1756 5182 </falloff>
+      </rateCoeff>
+      <reactants>OH:2.0</reactants>
+      <products>H2O2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0086    -->
+    <reaction reversible="yes" id="0086">
+      <equation>2 OH [=] O + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.570000E+01</A>
+           <b>2.4</b>
+           <E units="cal/mol">-2110.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>OH:2.0</reactants>
+      <products>H2O:1 O:1.0</products>
+    </reaction>
+
+    <!-- reaction 0087    -->
+    <reaction duplicate="yes" reversible="yes" id="0087">
+      <equation>OH + HO2 [=] O2 + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.450000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">-500.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HO2:1 OH:1.0</reactants>
+      <products>H2O:1 O2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0088    -->
+    <reaction duplicate="yes" reversible="yes" id="0088">
+      <equation>OH + H2O2 [=] HO2 + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.000000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">427.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H2O2:1 OH:1.0</reactants>
+      <products>H2O:1 HO2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0089    -->
+    <reaction duplicate="yes" reversible="yes" id="0089">
+      <equation>OH + H2O2 [=] HO2 + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.700000E+15</A>
+           <b>0</b>
+           <E units="cal/mol">29410.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H2O2:1 OH:1.0</reactants>
+      <products>H2O:1 HO2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0090    -->
+    <reaction reversible="yes" id="0090">
+      <equation>OH + C [=] H + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C:1 OH:1.0</reactants>
+      <products>H:1.0 CO:1</products>
+    </reaction>
+
+    <!-- reaction 0091    -->
+    <reaction reversible="yes" id="0091">
+      <equation>OH + CH [=] H + HCO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH:1 OH:1.0</reactants>
+      <products>H:1.0 HCO:1</products>
+    </reaction>
+
+    <!-- reaction 0092    -->
+    <reaction reversible="yes" id="0092">
+      <equation>OH + CH2 [=] H + CH2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2:1 OH:1.0</reactants>
+      <products>CH2O:1 H:1.0</products>
+    </reaction>
+
+    <!-- reaction 0093    -->
+    <reaction reversible="yes" id="0093">
+      <equation>OH + CH2 [=] CH + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.130000E+04</A>
+           <b>2</b>
+           <E units="cal/mol">3000.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2:1 OH:1.0</reactants>
+      <products>H2O:1 CH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0094    -->
+    <reaction reversible="yes" id="0094">
+      <equation>OH + CH2(S) [=] H + CH2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2(S):1 OH:1.0</reactants>
+      <products>CH2O:1 H:1.0</products>
+    </reaction>
+
+    <!-- reaction 0095    -->
+    <reaction reversible="yes" type="falloff" id="0095">
+      <equation>OH + CH3 (+ M) [=] CH3OH (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.790000E+15</A>
+           <b>-1.43</b>
+           <E units="cal/mol">1330.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>4.000000E+30</A>
+           <b>-5.92</b>
+           <E units="cal/mol">3140.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Troe">0.412 195 5900 6394 </falloff>
+      </rateCoeff>
+      <reactants>CH3:1 OH:1.0</reactants>
+      <products>CH3OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0096    -->
+    <reaction reversible="yes" id="0096">
+      <equation>OH + CH3 [=] CH2 + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.600000E+04</A>
+           <b>1.6</b>
+           <E units="cal/mol">5420.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3:1 OH:1.0</reactants>
+      <products>CH2:1.0 H2O:1</products>
+    </reaction>
+
+    <!-- reaction 0097    -->
+    <reaction reversible="yes" id="0097">
+      <equation>OH + CH3 [=] CH2(S) + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>6.440000E+14</A>
+           <b>-1.34</b>
+           <E units="cal/mol">1417.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3:1 OH:1.0</reactants>
+      <products>CH2(S):1.0 H2O:1</products>
+    </reaction>
+
+    <!-- reaction 0098    -->
+    <reaction reversible="yes" id="0098">
+      <equation>OH + CH4 [=] CH3 + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.000000E+05</A>
+           <b>1.6</b>
+           <E units="cal/mol">3120.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH4:1 OH:1.0</reactants>
+      <products>H2O:1 CH3:1.0</products>
+    </reaction>
+
+    <!-- reaction 0099    -->
+    <reaction reversible="yes" id="0099">
+      <equation>OH + CO [=] H + CO2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>4.760000E+04</A>
+           <b>1.228</b>
+           <E units="cal/mol">70.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CO:1 OH:1.0</reactants>
+      <products>H:1.0 CO2:1</products>
+    </reaction>
+
+    <!-- reaction 0100    -->
+    <reaction reversible="yes" id="0100">
+      <equation>OH + HCO [=] H2O + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HCO:1 OH:1.0</reactants>
+      <products>H2O:1.0 CO:1</products>
+    </reaction>
+
+    <!-- reaction 0101    -->
+    <reaction reversible="yes" id="0101">
+      <equation>OH + CH2O [=] HCO + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.430000E+06</A>
+           <b>1.18</b>
+           <E units="cal/mol">-447.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2O:1 OH:1.0</reactants>
+      <products>H2O:1 HCO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0102    -->
+    <reaction reversible="yes" id="0102">
+      <equation>OH + CH2OH [=] H2O + CH2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.000000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2OH:1 OH:1.0</reactants>
+      <products>CH2O:1 H2O:1.0</products>
+    </reaction>
+
+    <!-- reaction 0103    -->
+    <reaction reversible="yes" id="0103">
+      <equation>OH + CH3O [=] H2O + CH2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.000000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3O:1 OH:1.0</reactants>
+      <products>CH2O:1 H2O:1.0</products>
+    </reaction>
+
+    <!-- reaction 0104    -->
+    <reaction reversible="yes" id="0104">
+      <equation>OH + CH3OH [=] CH2OH + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.440000E+03</A>
+           <b>2</b>
+           <E units="cal/mol">-840.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3OH:1 OH:1.0</reactants>
+      <products>CH2OH:1.0 H2O:1</products>
+    </reaction>
+
+    <!-- reaction 0105    -->
+    <reaction reversible="yes" id="0105">
+      <equation>OH + CH3OH [=] CH3O + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>6.300000E+03</A>
+           <b>2</b>
+           <E units="cal/mol">1500.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3OH:1 OH:1.0</reactants>
+      <products>H2O:1 CH3O:1.0</products>
+    </reaction>
+
+    <!-- reaction 0106    -->
+    <reaction reversible="yes" id="0106">
+      <equation>OH + C2H [=] H + HCCO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C2H:1 OH:1.0</reactants>
+      <products>H:1.0 HCCO:1</products>
+    </reaction>
+
+    <!-- reaction 0107    -->
+    <reaction reversible="yes" id="0107">
+      <equation>OH + C2H2 [=] H + CH2CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.180000E-07</A>
+           <b>4.5</b>
+           <E units="cal/mol">-1000.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C2H2:1 OH:1.0</reactants>
+      <products>H:1.0 CH2CO:1</products>
+    </reaction>
+
+    <!-- reaction 0108    -->
+    <reaction reversible="yes" id="0108">
+      <equation>OH + C2H2 [=] H + HCCOH</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.040000E+02</A>
+           <b>2.3</b>
+           <E units="cal/mol">13500.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C2H2:1 OH:1.0</reactants>
+      <products>H:1.0 HCCOH:1</products>
+    </reaction>
+
+    <!-- reaction 0109    -->
+    <reaction reversible="yes" id="0109">
+      <equation>OH + C2H2 [=] C2H + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.370000E+04</A>
+           <b>2</b>
+           <E units="cal/mol">14000.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C2H2:1 OH:1.0</reactants>
+      <products>C2H:1.0 H2O:1</products>
+    </reaction>
+
+    <!-- reaction 0110    -->
+    <reaction reversible="yes" id="0110">
+      <equation>OH + C2H2 [=] CH3 + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>4.830000E-07</A>
+           <b>4</b>
+           <E units="cal/mol">-2000.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C2H2:1 OH:1.0</reactants>
+      <products>CH3:1.0 CO:1</products>
+    </reaction>
+
+    <!-- reaction 0111    -->
+    <reaction reversible="yes" id="0111">
+      <equation>OH + C2H3 [=] H2O + C2H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.000000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C2H3:1 OH:1.0</reactants>
+      <products>H2O:1.0 C2H2:1</products>
+    </reaction>
+
+    <!-- reaction 0112    -->
+    <reaction reversible="yes" id="0112">
+      <equation>OH + C2H4 [=] C2H3 + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.600000E+03</A>
+           <b>2</b>
+           <E units="cal/mol">2500.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C2H4:1 OH:1.0</reactants>
+      <products>H2O:1 C2H3:1.0</products>
+    </reaction>
+
+    <!-- reaction 0113    -->
+    <reaction reversible="yes" id="0113">
+      <equation>OH + C2H6 [=] C2H5 + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.540000E+03</A>
+           <b>2.12</b>
+           <E units="cal/mol">870.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C2H6:1 OH:1.0</reactants>
+      <products>C2H5:1.0 H2O:1</products>
+    </reaction>
+
+    <!-- reaction 0114    -->
+    <reaction reversible="yes" id="0114">
+      <equation>OH + CH2CO [=] HCCO + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>7.500000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">2000.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2CO:1 OH:1.0</reactants>
+      <products>H2O:1 HCCO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0115    -->
+    <reaction duplicate="yes" reversible="yes" id="0115">
+      <equation>2 HO2 [=] O2 + H2O2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.300000E+08</A>
+           <b>0</b>
+           <E units="cal/mol">-1630.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HO2:2.0</reactants>
+      <products>O2:1.0 H2O2:1</products>
+    </reaction>
+
+    <!-- reaction 0116    -->
+    <reaction duplicate="yes" reversible="yes" id="0116">
+      <equation>2 HO2 [=] O2 + H2O2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>4.200000E+11</A>
+           <b>0</b>
+           <E units="cal/mol">12000.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HO2:2.0</reactants>
+      <products>O2:1.0 H2O2:1</products>
+    </reaction>
+
+    <!-- reaction 0117    -->
+    <reaction reversible="yes" id="0117">
+      <equation>HO2 + CH2 [=] OH + CH2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2:1 HO2:1.0</reactants>
+      <products>CH2O:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0118    -->
+    <reaction reversible="yes" id="0118">
+      <equation>HO2 + CH3 [=] O2 + CH4</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.000000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3:1 HO2:1.0</reactants>
+      <products>CH4:1 O2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0119    -->
+    <reaction reversible="yes" id="0119">
+      <equation>HO2 + CH3 [=] OH + CH3O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.780000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3:1 HO2:1.0</reactants>
+      <products>CH3O:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0120    -->
+    <reaction reversible="yes" id="0120">
+      <equation>HO2 + CO [=] OH + CO2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.500000E+11</A>
+           <b>0</b>
+           <E units="cal/mol">23600.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CO:1 HO2:1.0</reactants>
+      <products>CO2:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0121    -->
+    <reaction reversible="yes" id="0121">
+      <equation>HO2 + CH2O [=] HCO + H2O2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.600000E+03</A>
+           <b>2</b>
+           <E units="cal/mol">12000.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2O:1 HO2:1.0</reactants>
+      <products>HCO:1.0 H2O2:1</products>
+    </reaction>
+
+    <!-- reaction 0122    -->
+    <reaction reversible="yes" id="0122">
+      <equation>C + O2 [=] O + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.800000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">576.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C:1.0 O2:1</reactants>
+      <products>CO:1 O:1.0</products>
+    </reaction>
+
+    <!-- reaction 0123    -->
+    <reaction reversible="yes" id="0123">
+      <equation>C + CH2 [=] H + C2H</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C:1.0 CH2:1</reactants>
+      <products>H:1.0 C2H:1</products>
+    </reaction>
+
+    <!-- reaction 0124    -->
+    <reaction reversible="yes" id="0124">
+      <equation>C + CH3 [=] H + C2H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C:1.0 CH3:1</reactants>
+      <products>H:1.0 C2H2:1</products>
+    </reaction>
+
+    <!-- reaction 0125    -->
+    <reaction reversible="yes" id="0125">
+      <equation>CH + O2 [=] O + HCO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>6.710000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH:1.0 O2:1</reactants>
+      <products>HCO:1 O:1.0</products>
+    </reaction>
+
+    <!-- reaction 0126    -->
+    <reaction reversible="yes" id="0126">
+      <equation>CH + H2 [=] H + CH2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.080000E+11</A>
+           <b>0</b>
+           <E units="cal/mol">3110.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H2:1 CH:1.0</reactants>
+      <products>H:1.0 CH2:1</products>
+    </reaction>
+
+    <!-- reaction 0127    -->
+    <reaction reversible="yes" id="0127">
+      <equation>CH + H2O [=] H + CH2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.710000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">-755.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H2O:1 CH:1.0</reactants>
+      <products>CH2O:1 H:1.0</products>
+    </reaction>
+
+    <!-- reaction 0128    -->
+    <reaction reversible="yes" id="0128">
+      <equation>CH + CH2 [=] H + C2H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>4.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2:1 CH:1.0</reactants>
+      <products>H:1.0 C2H2:1</products>
+    </reaction>
+
+    <!-- reaction 0129    -->
+    <reaction reversible="yes" id="0129">
+      <equation>CH + CH3 [=] H + C2H3</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3:1 CH:1.0</reactants>
+      <products>H:1.0 C2H3:1</products>
+    </reaction>
+
+    <!-- reaction 0130    -->
+    <reaction reversible="yes" id="0130">
+      <equation>CH + CH4 [=] H + C2H4</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>6.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH:1.0 CH4:1</reactants>
+      <products>H:1.0 C2H4:1</products>
+    </reaction>
+
+    <!-- reaction 0131    -->
+    <reaction reversible="yes" type="falloff" id="0131">
+      <equation>CH + CO (+ M) [=] HCCO (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>2.690000E+22</A>
+           <b>-3.74</b>
+           <E units="cal/mol">1936.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Troe">0.5757 237 1652 5069 </falloff>
+      </rateCoeff>
+      <reactants>CH:1.0 CO:1</reactants>
+      <products>HCCO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0132    -->
+    <reaction reversible="yes" id="0132">
+      <equation>CH + CO2 [=] HCO + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.900000E+11</A>
+           <b>0</b>
+           <E units="cal/mol">15792.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH:1.0 CO2:1</reactants>
+      <products>CO:1 HCO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0133    -->
+    <reaction reversible="yes" id="0133">
+      <equation>CH + CH2O [=] H + CH2CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>9.460000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">-515.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2O:1 CH:1.0</reactants>
+      <products>H:1.0 CH2CO:1</products>
+    </reaction>
+
+    <!-- reaction 0134    -->
+    <reaction reversible="yes" id="0134">
+      <equation>CH + HCCO [=] CO + C2H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH:1.0 HCCO:1</reactants>
+      <products>CO:1.0 C2H2:1</products>
+    </reaction>
+
+    <!-- reaction 0135    -->
+    <reaction reversible="no" id="0135">
+      <equation>CH2 + O2 =] OH + H + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.000000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">1500.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2:1.0 O2:1</reactants>
+      <products>H:1 CO:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0136    -->
+    <reaction reversible="yes" id="0136">
+      <equation>CH2 + H2 [=] H + CH3</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.000000E+02</A>
+           <b>2</b>
+           <E units="cal/mol">7230.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H2:1 CH2:1.0</reactants>
+      <products>H:1.0 CH3:1</products>
+    </reaction>
+
+    <!-- reaction 0137    -->
+    <reaction reversible="yes" id="0137">
+      <equation>2 CH2 [=] H2 + C2H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.600000E+12</A>
+           <b>0</b>
+           <E units="cal/mol">11944.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2:2.0</reactants>
+      <products>H2:1.0 C2H2:1</products>
+    </reaction>
+
+    <!-- reaction 0138    -->
+    <reaction reversible="yes" id="0138">
+      <equation>CH2 + CH3 [=] H + C2H4</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>4.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2:1.0 CH3:1</reactants>
+      <products>H:1.0 C2H4:1</products>
+    </reaction>
+
+    <!-- reaction 0139    -->
+    <reaction reversible="yes" id="0139">
+      <equation>CH2 + CH4 [=] 2 CH3</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.460000E+03</A>
+           <b>2</b>
+           <E units="cal/mol">8270.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2:1.0 CH4:1</reactants>
+      <products>CH3:2.0</products>
+    </reaction>
+
+    <!-- reaction 0140    -->
+    <reaction reversible="yes" type="falloff" id="0140">
+      <equation>CH2 + CO (+ M) [=] CH2CO (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>8.100000E+08</A>
+           <b>0.5</b>
+           <E units="cal/mol">4510.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>2.690000E+27</A>
+           <b>-5.11</b>
+           <E units="cal/mol">7095.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Troe">0.5907 275 1226 5185 </falloff>
+      </rateCoeff>
+      <reactants>CH2:1.0 CO:1</reactants>
+      <products>CH2CO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0141    -->
+    <reaction reversible="yes" id="0141">
+      <equation>CH2 + HCCO [=] C2H3 + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2:1.0 HCCO:1</reactants>
+      <products>CO:1 C2H3:1.0</products>
+    </reaction>
+
+    <!-- reaction 0142    -->
+    <reaction reversible="yes" id="0142">
+      <equation>CH2(S) + N2 [=] CH2 + N2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.500000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">600.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2(S):1.0 N2:1</reactants>
+      <products>CH2:1.0 N2:1</products>
+    </reaction>
+
+    <!-- reaction 0143    -->
+    <reaction reversible="yes" id="0143">
+      <equation>CH2(S) + AR [=] CH2 + AR</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>9.000000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">600.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2(S):1.0 AR:1</reactants>
+      <products>CH2:1.0 AR:1</products>
+    </reaction>
+
+    <!-- reaction 0144    -->
+    <reaction reversible="yes" id="0144">
+      <equation>CH2(S) + O2 [=] H + OH + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.800000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2(S):1.0 O2:1</reactants>
+      <products>H:1.0 CO:1 OH:1</products>
+    </reaction>
+
+    <!-- reaction 0145    -->
+    <reaction reversible="yes" id="0145">
+      <equation>CH2(S) + O2 [=] CO + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.200000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2(S):1.0 O2:1</reactants>
+      <products>H2O:1 CO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0146    -->
+    <reaction reversible="yes" id="0146">
+      <equation>CH2(S) + H2 [=] CH3 + H</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>7.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H2:1 CH2(S):1.0</reactants>
+      <products>H:1 CH3:1.0</products>
+    </reaction>
+
+    <!-- reaction 0147    -->
+    <reaction reversible="yes" type="falloff" id="0147">
+      <equation>CH2(S) + H2O (+ M) [=] CH3OH (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>4.820000E+14</A>
+           <b>-1.16</b>
+           <E units="cal/mol">1145.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>1.880000E+32</A>
+           <b>-6.36</b>
+           <E units="cal/mol">5040.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Troe">0.6027 208 3922 10180 </falloff>
+      </rateCoeff>
+      <reactants>CH2(S):1.0 H2O:1</reactants>
+      <products>CH3OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0148    -->
+    <reaction reversible="yes" id="0148">
+      <equation>CH2(S) + H2O [=] CH2 + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2(S):1.0 H2O:1</reactants>
+      <products>CH2:1.0 H2O:1</products>
+    </reaction>
+
+    <!-- reaction 0149    -->
+    <reaction reversible="yes" id="0149">
+      <equation>CH2(S) + CH3 [=] H + C2H4</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.200000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">-570.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2(S):1.0 CH3:1</reactants>
+      <products>H:1.0 C2H4:1</products>
+    </reaction>
+
+    <!-- reaction 0150    -->
+    <reaction reversible="yes" id="0150">
+      <equation>CH2(S) + CH4 [=] 2 CH3</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.600000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">-570.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2(S):1.0 CH4:1</reactants>
+      <products>CH3:2.0</products>
+    </reaction>
+
+    <!-- reaction 0151    -->
+    <reaction reversible="yes" id="0151">
+      <equation>CH2(S) + CO [=] CH2 + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>9.000000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2(S):1.0 CO:1</reactants>
+      <products>CH2:1.0 CO:1</products>
+    </reaction>
+
+    <!-- reaction 0152    -->
+    <reaction reversible="yes" id="0152">
+      <equation>CH2(S) + CO2 [=] CH2 + CO2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>7.000000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2(S):1.0 CO2:1</reactants>
+      <products>CH2:1.0 CO2:1</products>
+    </reaction>
+
+    <!-- reaction 0153    -->
+    <reaction reversible="yes" id="0153">
+      <equation>CH2(S) + CO2 [=] CO + CH2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.400000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2(S):1.0 CO2:1</reactants>
+      <products>CH2O:1 CO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0154    -->
+    <reaction reversible="yes" id="0154">
+      <equation>CH2(S) + C2H6 [=] CH3 + C2H5</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>4.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">-550.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2(S):1.0 C2H6:1</reactants>
+      <products>C2H5:1 CH3:1.0</products>
+    </reaction>
+
+    <!-- reaction 0155    -->
+    <reaction reversible="yes" id="0155">
+      <equation>CH3 + O2 [=] O + CH3O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.560000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">30480.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3:1.0 O2:1</reactants>
+      <products>CH3O:1 O:1.0</products>
+    </reaction>
+
+    <!-- reaction 0156    -->
+    <reaction reversible="yes" id="0156">
+      <equation>CH3 + O2 [=] OH + CH2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.310000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">20315.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3:1.0 O2:1</reactants>
+      <products>CH2O:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0157    -->
+    <reaction reversible="yes" id="0157">
+      <equation>CH3 + H2O2 [=] HO2 + CH4</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.450000E+01</A>
+           <b>2.47</b>
+           <E units="cal/mol">5180.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3:1.0 H2O2:1</reactants>
+      <products>CH4:1 HO2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0158    -->
+    <reaction reversible="yes" type="falloff" id="0158">
+      <equation>2 CH3 (+ M) [=] C2H6 (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>6.770000E+13</A>
+           <b>-1.18</b>
+           <E units="cal/mol">654.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>3.400000E+35</A>
+           <b>-7.03</b>
+           <E units="cal/mol">2762.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Troe">0.619 73.2 1180 9999 </falloff>
+      </rateCoeff>
+      <reactants>CH3:2.0</reactants>
+      <products>C2H6:1.0</products>
+    </reaction>
+
+    <!-- reaction 0159    -->
+    <reaction reversible="yes" id="0159">
+      <equation>2 CH3 [=] H + C2H5</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>6.840000E+09</A>
+           <b>0.1</b>
+           <E units="cal/mol">10600.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3:2.0</reactants>
+      <products>H:1.0 C2H5:1</products>
+    </reaction>
+
+    <!-- reaction 0160    -->
+    <reaction reversible="yes" id="0160">
+      <equation>CH3 + HCO [=] CH4 + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.648000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3:1.0 HCO:1</reactants>
+      <products>CO:1 CH4:1.0</products>
+    </reaction>
+
+    <!-- reaction 0161    -->
+    <reaction reversible="yes" id="0161">
+      <equation>CH3 + CH2O [=] HCO + CH4</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.320000E+00</A>
+           <b>2.81</b>
+           <E units="cal/mol">5860.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2O:1 CH3:1.0</reactants>
+      <products>CH4:1 HCO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0162    -->
+    <reaction reversible="yes" id="0162">
+      <equation>CH3 + CH3OH [=] CH2OH + CH4</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.000000E+04</A>
+           <b>1.5</b>
+           <E units="cal/mol">9940.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3OH:1 CH3:1.0</reactants>
+      <products>CH2OH:1.0 CH4:1</products>
+    </reaction>
+
+    <!-- reaction 0163    -->
+    <reaction reversible="yes" id="0163">
+      <equation>CH3 + CH3OH [=] CH3O + CH4</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.000000E+04</A>
+           <b>1.5</b>
+           <E units="cal/mol">9940.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3OH:1 CH3:1.0</reactants>
+      <products>CH3O:1.0 CH4:1</products>
+    </reaction>
+
+    <!-- reaction 0164    -->
+    <reaction reversible="yes" id="0164">
+      <equation>CH3 + C2H4 [=] C2H3 + CH4</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.270000E+02</A>
+           <b>2</b>
+           <E units="cal/mol">9200.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3:1.0 C2H4:1</reactants>
+      <products>CH4:1 C2H3:1.0</products>
+    </reaction>
+
+    <!-- reaction 0165    -->
+    <reaction reversible="yes" id="0165">
+      <equation>CH3 + C2H6 [=] C2H5 + CH4</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>6.140000E+03</A>
+           <b>1.74</b>
+           <E units="cal/mol">10450.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C2H6:1 CH3:1.0</reactants>
+      <products>C2H5:1.0 CH4:1</products>
+    </reaction>
+
+    <!-- reaction 0166    -->
+    <reaction reversible="yes" id="0166">
+      <equation>HCO + H2O [=] H + CO + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.500000E+15</A>
+           <b>-1</b>
+           <E units="cal/mol">17000.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H2O:1 HCO:1.0</reactants>
+      <products>H:1.0 H2O:1 CO:1</products>
+    </reaction>
+
+    <!-- reaction 0167    -->
+    <reaction reversible="yes" type="threeBody" id="0167">
+      <equation>HCO + M [=] H + CO + M</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.870000E+14</A>
+           <b>-1</b>
+           <E units="cal/mol">17000.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:0 </efficiencies>
+      </rateCoeff>
+      <reactants>HCO:1.0</reactants>
+      <products>H:1.0 CO:1</products>
+    </reaction>
+
+    <!-- reaction 0168    -->
+    <reaction reversible="yes" id="0168">
+      <equation>HCO + O2 [=] HO2 + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.345000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">400.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HCO:1.0 O2:1</reactants>
+      <products>CO:1 HO2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0169    -->
+    <reaction reversible="yes" id="0169">
+      <equation>CH2OH + O2 [=] HO2 + CH2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.800000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">900.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2OH:1.0 O2:1</reactants>
+      <products>CH2O:1 HO2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0170    -->
+    <reaction reversible="yes" id="0170">
+      <equation>CH3O + O2 [=] HO2 + CH2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>4.280000E-16</A>
+           <b>7.6</b>
+           <E units="cal/mol">-3530.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3O:1.0 O2:1</reactants>
+      <products>CH2O:1 HO2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0171    -->
+    <reaction reversible="yes" id="0171">
+      <equation>C2H + O2 [=] HCO + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">-755.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C2H:1.0 O2:1</reactants>
+      <products>CO:1 HCO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0172    -->
+    <reaction reversible="yes" id="0172">
+      <equation>C2H + H2 [=] H + C2H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.680000E+07</A>
+           <b>0.9</b>
+           <E units="cal/mol">1993.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H2:1 C2H:1.0</reactants>
+      <products>H:1.0 C2H2:1</products>
+    </reaction>
+
+    <!-- reaction 0173    -->
+    <reaction reversible="yes" id="0173">
+      <equation>C2H3 + O2 [=] HCO + CH2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>4.580000E+13</A>
+           <b>-1.39</b>
+           <E units="cal/mol">1015.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C2H3:1.0 O2:1</reactants>
+      <products>CH2O:1 HCO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0174    -->
+    <reaction reversible="yes" type="falloff" id="0174">
+      <equation>C2H4 (+ M) [=] H2 + C2H2 (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>8.000000E+12</A>
+           <b>0.44</b>
+           <E units="cal/mol">86770.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>1.580000E+48</A>
+           <b>-9.3</b>
+           <E units="cal/mol">97800.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Troe">0.7345 180 1035 5417 </falloff>
+      </rateCoeff>
+      <reactants>C2H4:1.0</reactants>
+      <products>H2:1.0 C2H2:1</products>
+    </reaction>
+
+    <!-- reaction 0175    -->
+    <reaction reversible="yes" id="0175">
+      <equation>C2H5 + O2 [=] HO2 + C2H4</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>8.400000E+08</A>
+           <b>0</b>
+           <E units="cal/mol">3875.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C2H5:1.0 O2:1</reactants>
+      <products>C2H4:1 HO2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0176    -->
+    <reaction reversible="yes" id="0176">
+      <equation>HCCO + O2 [=] OH + 2 CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.200000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">854.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HCCO:1.0 O2:1</reactants>
+      <products>CO:2.0 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0177    -->
+    <reaction reversible="yes" id="0177">
+      <equation>2 HCCO [=] 2 CO + C2H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HCCO:2.0</reactants>
+      <products>CO:2.0 C2H2:1</products>
+    </reaction>
+
+    <!-- reaction 0178    -->
+    <reaction reversible="yes" id="0178">
+      <equation>N + NO [=] N2 + O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.700000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">355.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>NO:1 N:1.0</reactants>
+      <products>N2:1.0 O:1</products>
+    </reaction>
+
+    <!-- reaction 0179    -->
+    <reaction reversible="yes" id="0179">
+      <equation>N + O2 [=] NO + O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>9.000000E+06</A>
+           <b>1</b>
+           <E units="cal/mol">6500.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>O2:1 N:1.0</reactants>
+      <products>O:1 NO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0180    -->
+    <reaction reversible="yes" id="0180">
+      <equation>N + OH [=] NO + H</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.360000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">385.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>OH:1 N:1.0</reactants>
+      <products>H:1 NO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0181    -->
+    <reaction reversible="yes" id="0181">
+      <equation>N2O + O [=] N2 + O2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.400000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">10810.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>N2O:1.0 O:1</reactants>
+      <products>N2:1.0 O2:1</products>
+    </reaction>
+
+    <!-- reaction 0182    -->
+    <reaction reversible="yes" id="0182">
+      <equation>N2O + O [=] 2 NO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.900000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">23150.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>N2O:1.0 O:1</reactants>
+      <products>NO:2.0</products>
+    </reaction>
+
+    <!-- reaction 0183    -->
+    <reaction reversible="yes" id="0183">
+      <equation>N2O + H [=] N2 + OH</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.870000E+11</A>
+           <b>0</b>
+           <E units="cal/mol">18880.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1 N2O:1.0</reactants>
+      <products>N2:1.0 OH:1</products>
+    </reaction>
+
+    <!-- reaction 0184    -->
+    <reaction reversible="yes" id="0184">
+      <equation>N2O + OH [=] N2 + HO2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.000000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">21060.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>N2O:1.0 OH:1</reactants>
+      <products>N2:1.0 HO2:1</products>
+    </reaction>
+
+    <!-- reaction 0185    -->
+    <reaction reversible="yes" type="falloff" id="0185">
+      <equation>N2O (+ M) [=] N2 + O (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>7.910000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">56020.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>6.370000E+11</A>
+           <b>0</b>
+           <E units="cal/mol">56640.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.625  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Lindemann"/>
+      </rateCoeff>
+      <reactants>N2O:1.0</reactants>
+      <products>N2:1.0 O:1</products>
+    </reaction>
+
+    <!-- reaction 0186    -->
+    <reaction reversible="yes" id="0186">
+      <equation>HO2 + NO [=] NO2 + OH</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.110000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">-480.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HO2:1.0 NO:1</reactants>
+      <products>NO2:1.0 OH:1</products>
+    </reaction>
+
+    <!-- reaction 0187    -->
+    <reaction reversible="yes" type="threeBody" id="0187">
+      <equation>NO + O + M [=] NO2 + M</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.060000E+14</A>
+           <b>-1.41</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+      </rateCoeff>
+      <reactants>O:1 NO:1.0</reactants>
+      <products>NO2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0188    -->
+    <reaction reversible="yes" id="0188">
+      <equation>NO2 + O [=] NO + O2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.900000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">-240.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>O:1 NO2:1.0</reactants>
+      <products>O2:1 NO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0189    -->
+    <reaction reversible="yes" id="0189">
+      <equation>NO2 + H [=] NO + OH</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.320000E+11</A>
+           <b>0</b>
+           <E units="cal/mol">360.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1 NO2:1.0</reactants>
+      <products>OH:1 NO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0190    -->
+    <reaction reversible="yes" id="0190">
+      <equation>NH + O [=] NO + H</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>4.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>NH:1.0 O:1</reactants>
+      <products>H:1 NO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0191    -->
+    <reaction reversible="yes" id="0191">
+      <equation>NH + H [=] N + H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.200000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">330.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>NH:1.0 H:1</reactants>
+      <products>H2:1 N:1.0</products>
+    </reaction>
+
+    <!-- reaction 0192    -->
+    <reaction reversible="yes" id="0192">
+      <equation>NH + OH [=] HNO + H</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>NH:1.0 OH:1</reactants>
+      <products>H:1 HNO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0193    -->
+    <reaction reversible="yes" id="0193">
+      <equation>NH + OH [=] N + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.000000E+06</A>
+           <b>1.2</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>NH:1.0 OH:1</reactants>
+      <products>H2O:1 N:1.0</products>
+    </reaction>
+
+    <!-- reaction 0194    -->
+    <reaction reversible="yes" id="0194">
+      <equation>NH + O2 [=] HNO + O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>4.610000E+02</A>
+           <b>2</b>
+           <E units="cal/mol">6500.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>NH:1.0 O2:1</reactants>
+      <products>O:1 HNO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0195    -->
+    <reaction reversible="yes" id="0195">
+      <equation>NH + O2 [=] NO + OH</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.280000E+03</A>
+           <b>1.5</b>
+           <E units="cal/mol">100.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>NH:1.0 O2:1</reactants>
+      <products>OH:1 NO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0196    -->
+    <reaction reversible="yes" id="0196">
+      <equation>NH + N [=] N2 + H</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.500000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>NH:1.0 N:1</reactants>
+      <products>H:1 N2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0197    -->
+    <reaction reversible="yes" id="0197">
+      <equation>NH + H2O [=] HNO + H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">13850.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>NH:1.0 H2O:1</reactants>
+      <products>H2:1 HNO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0198    -->
+    <reaction reversible="yes" id="0198">
+      <equation>NH + NO [=] N2 + OH</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.160000E+10</A>
+           <b>-0.23</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>NH:1.0 NO:1</reactants>
+      <products>N2:1.0 OH:1</products>
+    </reaction>
+
+    <!-- reaction 0199    -->
+    <reaction reversible="yes" id="0199">
+      <equation>NH + NO [=] N2O + H</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.650000E+11</A>
+           <b>-0.45</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>NH:1.0 NO:1</reactants>
+      <products>H:1 N2O:1.0</products>
+    </reaction>
+
+    <!-- reaction 0200    -->
+    <reaction reversible="yes" id="0200">
+      <equation>NH2 + O [=] OH + NH</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.000000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>O:1 NH2:1.0</reactants>
+      <products>NH:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0201    -->
+    <reaction reversible="yes" id="0201">
+      <equation>NH2 + O [=] H + HNO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.900000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>O:1 NH2:1.0</reactants>
+      <products>H:1.0 HNO:1</products>
+    </reaction>
+
+    <!-- reaction 0202    -->
+    <reaction reversible="yes" id="0202">
+      <equation>NH2 + H [=] NH + H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>4.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">3650.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1 NH2:1.0</reactants>
+      <products>NH:1.0 H2:1</products>
+    </reaction>
+
+    <!-- reaction 0203    -->
+    <reaction reversible="yes" id="0203">
+      <equation>NH2 + OH [=] NH + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>9.000000E+04</A>
+           <b>1.5</b>
+           <E units="cal/mol">-460.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>OH:1 NH2:1.0</reactants>
+      <products>NH:1.0 H2O:1</products>
+    </reaction>
+
+    <!-- reaction 0204    -->
+    <reaction reversible="yes" id="0204">
+      <equation>NNH [=] N2 + H</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.300000E+08</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>NNH:1.0</reactants>
+      <products>H:1 N2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0205    -->
+    <reaction reversible="yes" type="threeBody" id="0205">
+      <equation>NNH + M [=] N2 + H + M</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.300000E+11</A>
+           <b>-0.11</b>
+           <E units="cal/mol">4980.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+      </rateCoeff>
+      <reactants>NNH:1.0</reactants>
+      <products>H:1 N2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0206    -->
+    <reaction reversible="yes" id="0206">
+      <equation>NNH + O2 [=] HO2 + N2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.000000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>O2:1 NNH:1.0</reactants>
+      <products>N2:1 HO2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0207    -->
+    <reaction reversible="yes" id="0207">
+      <equation>NNH + O [=] OH + N2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.500000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>O:1 NNH:1.0</reactants>
+      <products>N2:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0208    -->
+    <reaction reversible="yes" id="0208">
+      <equation>NNH + O [=] NH + NO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>7.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>O:1 NNH:1.0</reactants>
+      <products>NH:1.0 NO:1</products>
+    </reaction>
+
+    <!-- reaction 0209    -->
+    <reaction reversible="yes" id="0209">
+      <equation>NNH + H [=] H2 + N2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1 NNH:1.0</reactants>
+      <products>H2:1.0 N2:1</products>
+    </reaction>
+
+    <!-- reaction 0210    -->
+    <reaction reversible="yes" id="0210">
+      <equation>NNH + OH [=] H2O + N2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>OH:1 NNH:1.0</reactants>
+      <products>H2O:1.0 N2:1</products>
+    </reaction>
+
+    <!-- reaction 0211    -->
+    <reaction reversible="yes" id="0211">
+      <equation>NNH + CH3 [=] CH4 + N2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.500000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3:1 NNH:1.0</reactants>
+      <products>N2:1 CH4:1.0</products>
+    </reaction>
+
+    <!-- reaction 0212    -->
+    <reaction reversible="yes" type="threeBody" id="0212">
+      <equation>H + NO + M [=] HNO + M</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>4.480000E+13</A>
+           <b>-1.32</b>
+           <E units="cal/mol">740.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+      </rateCoeff>
+      <reactants>H:1.0 NO:1</reactants>
+      <products>HNO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0213    -->
+    <reaction reversible="yes" id="0213">
+      <equation>HNO + O [=] NO + OH</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.500000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>O:1 HNO:1.0</reactants>
+      <products>OH:1 NO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0214    -->
+    <reaction reversible="yes" id="0214">
+      <equation>HNO + H [=] H2 + NO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>9.000000E+08</A>
+           <b>0.72</b>
+           <E units="cal/mol">660.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1 HNO:1.0</reactants>
+      <products>H2:1.0 NO:1</products>
+    </reaction>
+
+    <!-- reaction 0215    -->
+    <reaction reversible="yes" id="0215">
+      <equation>HNO + OH [=] NO + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.300000E+04</A>
+           <b>1.9</b>
+           <E units="cal/mol">-950.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HNO:1.0 OH:1</reactants>
+      <products>H2O:1 NO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0216    -->
+    <reaction reversible="yes" id="0216">
+      <equation>HNO + O2 [=] HO2 + NO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">13000.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>O2:1 HNO:1.0</reactants>
+      <products>HO2:1.0 NO:1</products>
+    </reaction>
+
+    <!-- reaction 0217    -->
+    <reaction reversible="yes" id="0217">
+      <equation>CN + O [=] CO + N</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>7.700000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CN:1.0 O:1</reactants>
+      <products>CO:1.0 N:1</products>
+    </reaction>
+
+    <!-- reaction 0218    -->
+    <reaction reversible="yes" id="0218">
+      <equation>CN + OH [=] NCO + H</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>4.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CN:1.0 OH:1</reactants>
+      <products>H:1 NCO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0219    -->
+    <reaction reversible="yes" id="0219">
+      <equation>CN + H2O [=] HCN + OH</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>8.000000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">7460.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H2O:1 CN:1.0</reactants>
+      <products>HCN:1.0 OH:1</products>
+    </reaction>
+
+    <!-- reaction 0220    -->
+    <reaction reversible="yes" id="0220">
+      <equation>CN + O2 [=] NCO + O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>6.140000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">-440.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CN:1.0 O2:1</reactants>
+      <products>O:1 NCO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0221    -->
+    <reaction reversible="yes" id="0221">
+      <equation>CN + H2 [=] HCN + H</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.950000E+02</A>
+           <b>2.45</b>
+           <E units="cal/mol">2240.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H2:1 CN:1.0</reactants>
+      <products>H:1 HCN:1.0</products>
+    </reaction>
+
+    <!-- reaction 0222    -->
+    <reaction reversible="yes" id="0222">
+      <equation>NCO + O [=] NO + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.350000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>O:1 NCO:1.0</reactants>
+      <products>CO:1 NO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0223    -->
+    <reaction reversible="yes" id="0223">
+      <equation>NCO + H [=] NH + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.400000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1 NCO:1.0</reactants>
+      <products>NH:1.0 CO:1</products>
+    </reaction>
+
+    <!-- reaction 0224    -->
+    <reaction reversible="yes" id="0224">
+      <equation>NCO + OH [=] NO + H + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.500000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>OH:1 NCO:1.0</reactants>
+      <products>H:1 CO:1 NO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0225    -->
+    <reaction reversible="yes" id="0225">
+      <equation>NCO + N [=] N2 + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>N:1 NCO:1.0</reactants>
+      <products>N2:1.0 CO:1</products>
+    </reaction>
+
+    <!-- reaction 0226    -->
+    <reaction reversible="yes" id="0226">
+      <equation>NCO + O2 [=] NO + CO2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.000000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">20000.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>O2:1 NCO:1.0</reactants>
+      <products>CO2:1 NO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0227    -->
+    <reaction reversible="yes" type="threeBody" id="0227">
+      <equation>NCO + M [=] N + CO + M</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.100000E+11</A>
+           <b>0</b>
+           <E units="cal/mol">54050.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+      </rateCoeff>
+      <reactants>NCO:1.0</reactants>
+      <products>CO:1 N:1.0</products>
+    </reaction>
+
+    <!-- reaction 0228    -->
+    <reaction reversible="yes" id="0228">
+      <equation>NCO + NO [=] N2O + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.900000E+14</A>
+           <b>-1.52</b>
+           <E units="cal/mol">740.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>NO:1 NCO:1.0</reactants>
+      <products>CO:1 N2O:1.0</products>
+    </reaction>
+
+    <!-- reaction 0229    -->
+    <reaction reversible="yes" id="0229">
+      <equation>NCO + NO [=] N2 + CO2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.800000E+15</A>
+           <b>-2</b>
+           <E units="cal/mol">800.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>NO:1 NCO:1.0</reactants>
+      <products>N2:1.0 CO2:1</products>
+    </reaction>
+
+    <!-- reaction 0230    -->
+    <reaction reversible="yes" type="threeBody" id="0230">
+      <equation>HCN + M [=] H + CN + M</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.040000E+26</A>
+           <b>-3.3</b>
+           <E units="cal/mol">126600.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+      </rateCoeff>
+      <reactants>HCN:1.0</reactants>
+      <products>H:1.0 CN:1</products>
+    </reaction>
+
+    <!-- reaction 0231    -->
+    <reaction reversible="yes" id="0231">
+      <equation>HCN + O [=] NCO + H</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.030000E+01</A>
+           <b>2.64</b>
+           <E units="cal/mol">4980.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HCN:1.0 O:1</reactants>
+      <products>H:1 NCO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0232    -->
+    <reaction reversible="yes" id="0232">
+      <equation>HCN + O [=] NH + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.070000E+00</A>
+           <b>2.64</b>
+           <E units="cal/mol">4980.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HCN:1.0 O:1</reactants>
+      <products>NH:1.0 CO:1</products>
+    </reaction>
+
+    <!-- reaction 0233    -->
+    <reaction reversible="yes" id="0233">
+      <equation>HCN + O [=] CN + OH</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.910000E+06</A>
+           <b>1.58</b>
+           <E units="cal/mol">26600.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HCN:1.0 O:1</reactants>
+      <products>CN:1.0 OH:1</products>
+    </reaction>
+
+    <!-- reaction 0234    -->
+    <reaction reversible="yes" id="0234">
+      <equation>HCN + OH [=] HOCN + H</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.100000E+03</A>
+           <b>2.03</b>
+           <E units="cal/mol">13370.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HCN:1.0 OH:1</reactants>
+      <products>HOCN:1.0 H:1</products>
+    </reaction>
+
+    <!-- reaction 0235    -->
+    <reaction reversible="yes" id="0235">
+      <equation>HCN + OH [=] HNCO + H</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>4.400000E+00</A>
+           <b>2.26</b>
+           <E units="cal/mol">6400.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HCN:1.0 OH:1</reactants>
+      <products>HNCO:1.0 H:1</products>
+    </reaction>
+
+    <!-- reaction 0236    -->
+    <reaction reversible="yes" id="0236">
+      <equation>HCN + OH [=] NH2 + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.600000E-01</A>
+           <b>2.56</b>
+           <E units="cal/mol">9000.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HCN:1.0 OH:1</reactants>
+      <products>CO:1 NH2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0237    -->
+    <reaction reversible="yes" type="falloff" id="0237">
+      <equation>H + HCN (+ M) [=] H2CN (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.300000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>1.400000E+20</A>
+           <b>-3.4</b>
+           <E units="cal/mol">1900.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Lindemann"/>
+      </rateCoeff>
+      <reactants>H:1.0 HCN:1</reactants>
+      <products>H2CN:1.0</products>
+    </reaction>
+
+    <!-- reaction 0238    -->
+    <reaction reversible="yes" id="0238">
+      <equation>H2CN + N [=] N2 + CH2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>6.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">400.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H2CN:1.0 N:1</reactants>
+      <products>N2:1.0 CH2:1</products>
+    </reaction>
+
+    <!-- reaction 0239    -->
+    <reaction reversible="yes" id="0239">
+      <equation>C + N2 [=] CN + N</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>6.300000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">46020.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C:1.0 N2:1</reactants>
+      <products>CN:1.0 N:1</products>
+    </reaction>
+
+    <!-- reaction 0240    -->
+    <reaction reversible="yes" id="0240">
+      <equation>CH + N2 [=] HCN + N</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.120000E+06</A>
+           <b>0.88</b>
+           <E units="cal/mol">20130.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>N2:1 CH:1.0</reactants>
+      <products>HCN:1.0 N:1</products>
+    </reaction>
+
+    <!-- reaction 0241    -->
+    <reaction reversible="yes" type="falloff" id="0241">
+      <equation>CH + N2 (+ M) [=] HCNN (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.100000E+09</A>
+           <b>0.15</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>1.300000E+19</A>
+           <b>-3.16</b>
+           <E units="cal/mol">740.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:1  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Troe">0.667 235 2117 4536 </falloff>
+      </rateCoeff>
+      <reactants>N2:1 CH:1.0</reactants>
+      <products>HCNN:1.0</products>
+    </reaction>
+
+    <!-- reaction 0242    -->
+    <reaction reversible="yes" id="0242">
+      <equation>CH2 + N2 [=] HCN + NH</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">74000.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2:1.0 N2:1</reactants>
+      <products>NH:1 HCN:1.0</products>
+    </reaction>
+
+    <!-- reaction 0243    -->
+    <reaction reversible="yes" id="0243">
+      <equation>CH2(S) + N2 [=] NH + HCN</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.000000E+08</A>
+           <b>0</b>
+           <E units="cal/mol">65000.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2(S):1.0 N2:1</reactants>
+      <products>NH:1.0 HCN:1</products>
+    </reaction>
+
+    <!-- reaction 0244    -->
+    <reaction reversible="yes" id="0244">
+      <equation>C + NO [=] CN + O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.900000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C:1.0 NO:1</reactants>
+      <products>CN:1.0 O:1</products>
+    </reaction>
+
+    <!-- reaction 0245    -->
+    <reaction reversible="yes" id="0245">
+      <equation>C + NO [=] CO + N</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.900000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C:1.0 NO:1</reactants>
+      <products>CO:1.0 N:1</products>
+    </reaction>
+
+    <!-- reaction 0246    -->
+    <reaction reversible="yes" id="0246">
+      <equation>CH + NO [=] HCN + O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>4.100000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH:1.0 NO:1</reactants>
+      <products>HCN:1.0 O:1</products>
+    </reaction>
+
+    <!-- reaction 0247    -->
+    <reaction reversible="yes" id="0247">
+      <equation>CH + NO [=] H + NCO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.620000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH:1.0 NO:1</reactants>
+      <products>H:1.0 NCO:1</products>
+    </reaction>
+
+    <!-- reaction 0248    -->
+    <reaction reversible="yes" id="0248">
+      <equation>CH + NO [=] N + HCO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.460000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH:1.0 NO:1</reactants>
+      <products>HCO:1 N:1.0</products>
+    </reaction>
+
+    <!-- reaction 0249    -->
+    <reaction reversible="yes" id="0249">
+      <equation>CH2 + NO [=] H + HNCO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.100000E+14</A>
+           <b>-1.38</b>
+           <E units="cal/mol">1270.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2:1.0 NO:1</reactants>
+      <products>HNCO:1 H:1.0</products>
+    </reaction>
+
+    <!-- reaction 0250    -->
+    <reaction reversible="yes" id="0250">
+      <equation>CH2 + NO [=] OH + HCN</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.900000E+11</A>
+           <b>-0.69</b>
+           <E units="cal/mol">760.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2:1.0 NO:1</reactants>
+      <products>HCN:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0251    -->
+    <reaction reversible="yes" id="0251">
+      <equation>CH2 + NO [=] H + HCNO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.800000E+10</A>
+           <b>-0.36</b>
+           <E units="cal/mol">580.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2:1.0 NO:1</reactants>
+      <products>H:1.0 HCNO:1</products>
+    </reaction>
+
+    <!-- reaction 0252    -->
+    <reaction reversible="yes" id="0252">
+      <equation>CH2(S) + NO [=] H + HNCO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.100000E+14</A>
+           <b>-1.38</b>
+           <E units="cal/mol">1270.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2(S):1.0 NO:1</reactants>
+      <products>HNCO:1 H:1.0</products>
+    </reaction>
+
+    <!-- reaction 0253    -->
+    <reaction reversible="yes" id="0253">
+      <equation>CH2(S) + NO [=] OH + HCN</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.900000E+11</A>
+           <b>-0.69</b>
+           <E units="cal/mol">760.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2(S):1.0 NO:1</reactants>
+      <products>HCN:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0254    -->
+    <reaction reversible="yes" id="0254">
+      <equation>CH2(S) + NO [=] H + HCNO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.800000E+10</A>
+           <b>-0.36</b>
+           <E units="cal/mol">580.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2(S):1.0 NO:1</reactants>
+      <products>H:1.0 HCNO:1</products>
+    </reaction>
+
+    <!-- reaction 0255    -->
+    <reaction reversible="yes" id="0255">
+      <equation>CH3 + NO [=] HCN + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>9.600000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">28800.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3:1.0 NO:1</reactants>
+      <products>H2O:1 HCN:1.0</products>
+    </reaction>
+
+    <!-- reaction 0256    -->
+    <reaction reversible="yes" id="0256">
+      <equation>CH3 + NO [=] H2CN + OH</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.000000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">21750.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3:1.0 NO:1</reactants>
+      <products>H2CN:1.0 OH:1</products>
+    </reaction>
+
+    <!-- reaction 0257    -->
+    <reaction reversible="yes" id="0257">
+      <equation>HCNN + O [=] CO + H + N2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.200000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>O:1 HCNN:1.0</reactants>
+      <products>H:1 N2:1 CO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0258    -->
+    <reaction reversible="yes" id="0258">
+      <equation>HCNN + O [=] HCN + NO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.000000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>O:1 HCNN:1.0</reactants>
+      <products>HCN:1.0 NO:1</products>
+    </reaction>
+
+    <!-- reaction 0259    -->
+    <reaction reversible="yes" id="0259">
+      <equation>HCNN + O2 [=] O + HCO + N2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.200000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>O2:1 HCNN:1.0</reactants>
+      <products>N2:1 HCO:1 O:1.0</products>
+    </reaction>
+
+    <!-- reaction 0260    -->
+    <reaction reversible="yes" id="0260">
+      <equation>HCNN + OH [=] H + HCO + N2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.200000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>OH:1 HCNN:1.0</reactants>
+      <products>H:1.0 N2:1 HCO:1</products>
+    </reaction>
+
+    <!-- reaction 0261    -->
+    <reaction reversible="yes" id="0261">
+      <equation>HCNN + H [=] CH2 + N2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.000000E+11</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1 HCNN:1.0</reactants>
+      <products>CH2:1.0 N2:1</products>
+    </reaction>
+
+    <!-- reaction 0262    -->
+    <reaction reversible="yes" id="0262">
+      <equation>HNCO + O [=] NH + CO2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>9.800000E+04</A>
+           <b>1.41</b>
+           <E units="cal/mol">8500.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HNCO:1.0 O:1</reactants>
+      <products>NH:1.0 CO2:1</products>
+    </reaction>
+
+    <!-- reaction 0263    -->
+    <reaction reversible="yes" id="0263">
+      <equation>HNCO + O [=] HNO + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.500000E+05</A>
+           <b>1.57</b>
+           <E units="cal/mol">44000.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HNCO:1.0 O:1</reactants>
+      <products>CO:1 HNO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0264    -->
+    <reaction reversible="yes" id="0264">
+      <equation>HNCO + O [=] NCO + OH</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.200000E+03</A>
+           <b>2.11</b>
+           <E units="cal/mol">11400.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HNCO:1.0 O:1</reactants>
+      <products>OH:1 NCO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0265    -->
+    <reaction reversible="yes" id="0265">
+      <equation>HNCO + H [=] NH2 + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.250000E+04</A>
+           <b>1.7</b>
+           <E units="cal/mol">3800.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HNCO:1.0 H:1</reactants>
+      <products>CO:1 NH2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0266    -->
+    <reaction reversible="yes" id="0266">
+      <equation>HNCO + H [=] H2 + NCO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.050000E+02</A>
+           <b>2.5</b>
+           <E units="cal/mol">13300.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HNCO:1.0 H:1</reactants>
+      <products>H2:1.0 NCO:1</products>
+    </reaction>
+
+    <!-- reaction 0267    -->
+    <reaction reversible="yes" id="0267">
+      <equation>HNCO + OH [=] NCO + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.300000E+04</A>
+           <b>1.5</b>
+           <E units="cal/mol">3600.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HNCO:1.0 OH:1</reactants>
+      <products>H2O:1 NCO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0268    -->
+    <reaction reversible="yes" id="0268">
+      <equation>HNCO + OH [=] NH2 + CO2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.300000E+03</A>
+           <b>1.5</b>
+           <E units="cal/mol">3600.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HNCO:1.0 OH:1</reactants>
+      <products>CO2:1 NH2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0269    -->
+    <reaction reversible="yes" type="threeBody" id="0269">
+      <equation>HNCO + M [=] NH + CO + M</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.180000E+13</A>
+           <b>0</b>
+           <E units="cal/mol">84720.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+      </rateCoeff>
+      <reactants>HNCO:1.0</reactants>
+      <products>NH:1.0 CO:1</products>
+    </reaction>
+
+    <!-- reaction 0270    -->
+    <reaction reversible="yes" id="0270">
+      <equation>HCNO + H [=] H + HNCO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.100000E+12</A>
+           <b>-0.69</b>
+           <E units="cal/mol">2850.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1 HCNO:1.0</reactants>
+      <products>HNCO:1 H:1.0</products>
+    </reaction>
+
+    <!-- reaction 0271    -->
+    <reaction reversible="yes" id="0271">
+      <equation>HCNO + H [=] OH + HCN</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.700000E+08</A>
+           <b>0.18</b>
+           <E units="cal/mol">2120.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1 HCNO:1.0</reactants>
+      <products>HCN:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0272    -->
+    <reaction reversible="yes" id="0272">
+      <equation>HCNO + H [=] NH2 + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.700000E+11</A>
+           <b>-0.75</b>
+           <E units="cal/mol">2890.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1 HCNO:1.0</reactants>
+      <products>CO:1 NH2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0273    -->
+    <reaction reversible="yes" id="0273">
+      <equation>HOCN + H [=] H + HNCO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.000000E+04</A>
+           <b>2</b>
+           <E units="cal/mol">2000.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HOCN:1.0 H:1</reactants>
+      <products>HNCO:1 H:1.0</products>
+    </reaction>
+
+    <!-- reaction 0274    -->
+    <reaction reversible="yes" id="0274">
+      <equation>HCCO + NO [=] HCNO + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>9.000000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HCCO:1.0 NO:1</reactants>
+      <products>CO:1 HCNO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0275    -->
+    <reaction reversible="yes" id="0275">
+      <equation>CH3 + N [=] H2CN + H</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>6.100000E+11</A>
+           <b>-0.31</b>
+           <E units="cal/mol">290.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3:1.0 N:1</reactants>
+      <products>H:1 H2CN:1.0</products>
+    </reaction>
+
+    <!-- reaction 0276    -->
+    <reaction reversible="yes" id="0276">
+      <equation>CH3 + N [=] HCN + H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.700000E+09</A>
+           <b>0.15</b>
+           <E units="cal/mol">-90.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3:1.0 N:1</reactants>
+      <products>H2:1 HCN:1.0</products>
+    </reaction>
+
+    <!-- reaction 0277    -->
+    <reaction reversible="yes" id="0277">
+      <equation>NH3 + H [=] NH2 + H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.400000E+02</A>
+           <b>2.4</b>
+           <E units="cal/mol">9915.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1 NH3:1.0</reactants>
+      <products>H2:1 NH2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0278    -->
+    <reaction reversible="yes" id="0278">
+      <equation>NH3 + OH [=] NH2 + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.000000E+04</A>
+           <b>1.6</b>
+           <E units="cal/mol">955.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>NH3:1.0 OH:1</reactants>
+      <products>H2O:1 NH2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0279    -->
+    <reaction reversible="yes" id="0279">
+      <equation>NH3 + O [=] NH2 + OH</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>9.400000E+03</A>
+           <b>1.94</b>
+           <E units="cal/mol">6460.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>O:1 NH3:1.0</reactants>
+      <products>OH:1 NH2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0280    -->
+    <reaction reversible="yes" id="0280">
+      <equation>NH + CO2 [=] HNO + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">14350.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>NH:1.0 CO2:1</reactants>
+      <products>CO:1 HNO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0281    -->
+    <reaction reversible="yes" id="0281">
+      <equation>CN + NO2 [=] NCO + NO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>6.160000E+12</A>
+           <b>-0.752</b>
+           <E units="cal/mol">345.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CN:1.0 NO2:1</reactants>
+      <products>NO:1 NCO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0282    -->
+    <reaction reversible="yes" id="0282">
+      <equation>NCO + NO2 [=] N2O + CO2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.250000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">-705.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>NO2:1 NCO:1.0</reactants>
+      <products>CO2:1 N2O:1.0</products>
+    </reaction>
+
+    <!-- reaction 0283    -->
+    <reaction reversible="yes" id="0283">
+      <equation>N + CO2 [=] NO + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.000000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">11300.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CO2:1 N:1.0</reactants>
+      <products>CO:1 NO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0284    -->
+    <reaction reversible="no" id="0284">
+      <equation>O + CH3 =] H + H2 + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.370000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3:1 O:1.0</reactants>
+      <products>H2:1 H:1.0 CO:1</products>
+    </reaction>
+
+    <!-- reaction 0285    -->
+    <reaction reversible="yes" id="0285">
+      <equation>O + C2H4 [=] H + CH2CHO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>6.700000E+03</A>
+           <b>1.83</b>
+           <E units="cal/mol">220.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C2H4:1 O:1.0</reactants>
+      <products>H:1.0 CH2CHO:1</products>
+    </reaction>
+
+    <!-- reaction 0286    -->
+    <reaction reversible="yes" id="0286">
+      <equation>O + C2H5 [=] H + CH3CHO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.096000E+11</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C2H5:1 O:1.0</reactants>
+      <products>H:1.0 CH3CHO:1</products>
+    </reaction>
+
+    <!-- reaction 0287    -->
+    <reaction duplicate="yes" reversible="yes" id="0287">
+      <equation>OH + HO2 [=] O2 + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.000000E+12</A>
+           <b>0</b>
+           <E units="cal/mol">17330.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HO2:1 OH:1.0</reactants>
+      <products>H2O:1 O2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0288    -->
+    <reaction reversible="no" id="0288">
+      <equation>OH + CH3 =] H2 + CH2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>8.000000E+06</A>
+           <b>0.5</b>
+           <E units="cal/mol">-1755.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3:1 OH:1.0</reactants>
+      <products>H2:1.0 CH2O:1</products>
+    </reaction>
+
+    <!-- reaction 0289    -->
+    <reaction reversible="yes" type="falloff" id="0289">
+      <equation>CH + H2 (+ M) [=] CH3 (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.970000E+09</A>
+           <b>0.43</b>
+           <E units="cal/mol">-370.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>4.820000E+19</A>
+           <b>-2.8</b>
+           <E units="cal/mol">590.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Troe">0.578 122 2535 9365 </falloff>
+      </rateCoeff>
+      <reactants>H2:1 CH:1.0</reactants>
+      <products>CH3:1.0</products>
+    </reaction>
+
+    <!-- reaction 0290    -->
+    <reaction reversible="no" id="0290">
+      <equation>CH2 + O2 =] 2 H + CO2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.800000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">1500.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2:1.0 O2:1</reactants>
+      <products>H:2.0 CO2:1</products>
+    </reaction>
+
+    <!-- reaction 0291    -->
+    <reaction reversible="yes" id="0291">
+      <equation>CH2 + O2 [=] O + CH2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.400000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">1500.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2:1.0 O2:1</reactants>
+      <products>CH2O:1 O:1.0</products>
+    </reaction>
+
+    <!-- reaction 0292    -->
+    <reaction reversible="no" id="0292">
+      <equation>CH2 + CH2 =] 2 H + C2H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.000000E+11</A>
+           <b>0</b>
+           <E units="cal/mol">10989.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2:2.0</reactants>
+      <products>H:2.0 C2H2:1</products>
+    </reaction>
+
+    <!-- reaction 0293    -->
+    <reaction reversible="no" id="0293">
+      <equation>CH2(S) + H2O =] H2 + CH2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>6.820000E+07</A>
+           <b>0.25</b>
+           <E units="cal/mol">-935.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2(S):1.0 H2O:1</reactants>
+      <products>H2:1.0 CH2O:1</products>
+    </reaction>
+
+    <!-- reaction 0294    -->
+    <reaction reversible="yes" id="0294">
+      <equation>C2H3 + O2 [=] O + CH2CHO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.030000E+08</A>
+           <b>0.29</b>
+           <E units="cal/mol">11.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C2H3:1.0 O2:1</reactants>
+      <products>CH2CHO:1 O:1.0</products>
+    </reaction>
+
+    <!-- reaction 0295    -->
+    <reaction reversible="yes" id="0295">
+      <equation>C2H3 + O2 [=] HO2 + C2H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.337000E+03</A>
+           <b>1.61</b>
+           <E units="cal/mol">-384.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C2H3:1.0 O2:1</reactants>
+      <products>HO2:1.0 C2H2:1</products>
+    </reaction>
+
+    <!-- reaction 0296    -->
+    <reaction reversible="yes" id="0296">
+      <equation>O + CH3CHO [=] OH + CH2CHO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.840000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">1808.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3CHO:1 O:1.0</reactants>
+      <products>CH2CHO:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0297    -->
+    <reaction reversible="no" id="0297">
+      <equation>O + CH3CHO =] OH + CH3 + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.840000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">1808.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3CHO:1 O:1.0</reactants>
+      <products>CH3:1 CO:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0298    -->
+    <reaction reversible="no" id="0298">
+      <equation>O2 + CH3CHO =] HO2 + CH3 + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.010000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">39150.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3CHO:1 O2:1.0</reactants>
+      <products>CO:1 CH3:1 HO2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0299    -->
+    <reaction reversible="yes" id="0299">
+      <equation>H + CH3CHO [=] CH2CHO + H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.050000E+06</A>
+           <b>1.16</b>
+           <E units="cal/mol">2405.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 CH3CHO:1</reactants>
+      <products>H2:1 CH2CHO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0300    -->
+    <reaction reversible="no" id="0300">
+      <equation>H + CH3CHO =] CH3 + H2 + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.050000E+06</A>
+           <b>1.16</b>
+           <E units="cal/mol">2405.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 CH3CHO:1</reactants>
+      <products>H2:1 CH3:1.0 CO:1</products>
+    </reaction>
+
+    <!-- reaction 0301    -->
+    <reaction reversible="no" id="0301">
+      <equation>OH + CH3CHO =] CH3 + H2O + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.343000E+07</A>
+           <b>0.73</b>
+           <E units="cal/mol">-1113.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3CHO:1 OH:1.0</reactants>
+      <products>H2O:1 CH3:1.0 CO:1</products>
+    </reaction>
+
+    <!-- reaction 0302    -->
+    <reaction reversible="no" id="0302">
+      <equation>HO2 + CH3CHO =] CH3 + H2O2 + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.010000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">11923.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3CHO:1 HO2:1.0</reactants>
+      <products>CH3:1.0 CO:1 H2O2:1</products>
+    </reaction>
+
+    <!-- reaction 0303    -->
+    <reaction reversible="no" id="0303">
+      <equation>CH3 + CH3CHO =] CH3 + CH4 + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.720000E+03</A>
+           <b>1.77</b>
+           <E units="cal/mol">5920.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3CHO:1 CH3:1.0</reactants>
+      <products>CO:1 CH3:1.0 CH4:1</products>
+    </reaction>
+
+    <!-- reaction 0304    -->
+    <reaction reversible="yes" type="falloff" id="0304">
+      <equation>H + CH2CO (+ M) [=] CH2CHO (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>4.865000E+08</A>
+           <b>0.422</b>
+           <E units="cal/mol">-1755.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>1.012000E+36</A>
+           <b>-7.63</b>
+           <E units="cal/mol">3854.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Troe">0.465 201 1773 5333 </falloff>
+      </rateCoeff>
+      <reactants>H:1.0 CH2CO:1</reactants>
+      <products>CH2CHO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0305    -->
+    <reaction reversible="no" id="0305">
+      <equation>O + CH2CHO =] H + CH2 + CO2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.500000E+11</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2CHO:1 O:1.0</reactants>
+      <products>H:1.0 CH2:1 CO2:1</products>
+    </reaction>
+
+    <!-- reaction 0306    -->
+    <reaction reversible="no" id="0306">
+      <equation>O2 + CH2CHO =] OH + CO + CH2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.810000E+07</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2CHO:1 O2:1.0</reactants>
+      <products>CH2O:1 CO:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0307    -->
+    <reaction reversible="no" id="0307">
+      <equation>O2 + CH2CHO =] OH + 2 HCO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.350000E+07</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2CHO:1 O2:1.0</reactants>
+      <products>HCO:2.0 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0308    -->
+    <reaction reversible="yes" id="0308">
+      <equation>H + CH2CHO [=] CH3 + HCO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.200000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 CH2CHO:1</reactants>
+      <products>CH3:1.0 HCO:1</products>
+    </reaction>
+
+    <!-- reaction 0309    -->
+    <reaction reversible="yes" id="0309">
+      <equation>H + CH2CHO [=] CH2CO + H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.100000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 CH2CHO:1</reactants>
+      <products>H2:1 CH2CO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0310    -->
+    <reaction reversible="yes" id="0310">
+      <equation>OH + CH2CHO [=] H2O + CH2CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.200000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2CHO:1 OH:1.0</reactants>
+      <products>H2O:1.0 CH2CO:1</products>
+    </reaction>
+
+    <!-- reaction 0311    -->
+    <reaction reversible="yes" id="0311">
+      <equation>OH + CH2CHO [=] HCO + CH2OH</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.010000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2CHO:1 OH:1.0</reactants>
+      <products>CH2OH:1 HCO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0312    -->
+    <reaction reversible="yes" type="falloff" id="0312">
+      <equation>CH3 + C2H5 (+ M) [=] C3H8 (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>9.430000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>2.710000E+68</A>
+           <b>-16.82</b>
+           <E units="cal/mol">13065.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Troe">0.1527 291 2742 7748 </falloff>
+      </rateCoeff>
+      <reactants>C2H5:1 CH3:1.0</reactants>
+      <products>C3H8:1.0</products>
+    </reaction>
+
+    <!-- reaction 0313    -->
+    <reaction reversible="yes" id="0313">
+      <equation>O + C3H8 [=] OH + C3H7</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.930000E+02</A>
+           <b>2.68</b>
+           <E units="cal/mol">3716.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C3H8:1 O:1.0</reactants>
+      <products>C3H7:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0314    -->
+    <reaction reversible="yes" id="0314">
+      <equation>H + C3H8 [=] C3H7 + H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.320000E+03</A>
+           <b>2.54</b>
+           <E units="cal/mol">6756.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 C3H8:1</reactants>
+      <products>H2:1 C3H7:1.0</products>
+    </reaction>
+
+    <!-- reaction 0315    -->
+    <reaction reversible="yes" id="0315">
+      <equation>OH + C3H8 [=] C3H7 + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.160000E+04</A>
+           <b>1.8</b>
+           <E units="cal/mol">934.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C3H8:1 OH:1.0</reactants>
+      <products>C3H7:1.0 H2O:1</products>
+    </reaction>
+
+    <!-- reaction 0316    -->
+    <reaction reversible="yes" id="0316">
+      <equation>C3H7 + H2O2 [=] HO2 + C3H8</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.780000E-01</A>
+           <b>2.72</b>
+           <E units="cal/mol">1500.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C3H7:1.0 H2O2:1</reactants>
+      <products>HO2:1.0 C3H8:1</products>
+    </reaction>
+
+    <!-- reaction 0317    -->
+    <reaction reversible="yes" id="0317">
+      <equation>CH3 + C3H8 [=] C3H7 + CH4</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>9.030000E-04</A>
+           <b>3.65</b>
+           <E units="cal/mol">7154.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3:1.0 C3H8:1</reactants>
+      <products>C3H7:1.0 CH4:1</products>
+    </reaction>
+
+    <!-- reaction 0318    -->
+    <reaction reversible="yes" type="falloff" id="0318">
+      <equation>CH3 + C2H4 (+ M) [=] C3H7 (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.550000E+03</A>
+           <b>1.6</b>
+           <E units="cal/mol">5700.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>3.000000E+57</A>
+           <b>-14.6</b>
+           <E units="cal/mol">18170.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Troe">0.1894 277 8748 7891 </falloff>
+      </rateCoeff>
+      <reactants>CH3:1.0 C2H4:1</reactants>
+      <products>C3H7:1.0</products>
+    </reaction>
+
+    <!-- reaction 0319    -->
+    <reaction reversible="yes" id="0319">
+      <equation>O + C3H7 [=] C2H5 + CH2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>9.640000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C3H7:1 O:1.0</reactants>
+      <products>CH2O:1 C2H5:1.0</products>
+    </reaction>
+
+    <!-- reaction 0320    -->
+    <reaction reversible="yes" type="falloff" id="0320">
+      <equation>H + C3H7 (+ M) [=] C3H8 (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.613000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>4.420000E+55</A>
+           <b>-13.545</b>
+           <E units="cal/mol">11357.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Troe">0.315 369 3285 6667 </falloff>
+      </rateCoeff>
+      <reactants>H:1.0 C3H7:1</reactants>
+      <products>C3H8:1.0</products>
+    </reaction>
+
+    <!-- reaction 0321    -->
+    <reaction reversible="yes" id="0321">
+      <equation>H + C3H7 [=] CH3 + C2H5</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>4.060000E+03</A>
+           <b>2.19</b>
+           <E units="cal/mol">890.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 C3H7:1</reactants>
+      <products>C2H5:1 CH3:1.0</products>
+    </reaction>
+
+    <!-- reaction 0322    -->
+    <reaction reversible="yes" id="0322">
+      <equation>OH + C3H7 [=] C2H5 + CH2OH</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.410000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C3H7:1 OH:1.0</reactants>
+      <products>CH2OH:1 C2H5:1.0</products>
+    </reaction>
+
+    <!-- reaction 0323    -->
+    <reaction reversible="yes" id="0323">
+      <equation>HO2 + C3H7 [=] O2 + C3H8</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.550000E+07</A>
+           <b>0.255</b>
+           <E units="cal/mol">-943.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C3H7:1 HO2:1.0</reactants>
+      <products>O2:1.0 C3H8:1</products>
+    </reaction>
+
+    <!-- reaction 0324    -->
+    <reaction reversible="no" id="0324">
+      <equation>HO2 + C3H7 =] OH + C2H5 + CH2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.410000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C3H7:1 HO2:1.0</reactants>
+      <products>CH2O:1 C2H5:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0325    -->
+    <reaction reversible="yes" id="0325">
+      <equation>CH3 + C3H7 [=] 2 C2H5</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.927000E+10</A>
+           <b>-0.32</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C3H7:1 CH3:1.0</reactants>
+      <products>C2H5:2.0</products>
+    </reaction>
+  </reactionData>
+</ctml>

--- a/src/utilities/src/string_utils.C
+++ b/src/utilities/src/string_utils.C
@@ -57,17 +57,7 @@ namespace Antioch
   {
     std::string newline_str = "\n";
 
-    // First, detect any elements that are purely newlines, cache their iterator position,
-    // and them remove them.
-    std::vector<std::vector<std::string>::iterator> its_to_be_removed;
-
-    for( std::vector<std::string>::iterator it = strings.begin(); it != strings.end(); ++it )
-      if( (*it) == newline_str )
-        its_to_be_removed.push_back(it);
-
-    for(  std::vector<std::vector<std::string>::iterator>::iterator it = its_to_be_removed.begin();
-          it != its_to_be_removed.end(); ++it )
-      strings.erase( *it );
+    strings.erase( std::remove(strings.begin(),strings.end(),newline_str), strings.end() );
 
     // Now, strip any newline characters in the remaining elements
     for( std::vector<std::string>::iterator it = strings.begin(); it != strings.end(); ++it )

--- a/src/utilities/src/string_utils.C
+++ b/src/utilities/src/string_utils.C
@@ -53,19 +53,19 @@ namespace Antioch
       }
   }
 
-  void remove_newline_from_strings( std::vector<std::string>& strings )
+  void remove_newline_from_strings( std::vector<std::string> & strings )
   {
-    std::string newline_str = "\n";
+    const std::string newline_str("\n");
 
     strings.erase( std::remove(strings.begin(),strings.end(),newline_str), strings.end() );
 
     // Now, strip any newline characters in the remaining elements
     for( std::vector<std::string>::iterator it = strings.begin(); it != strings.end(); ++it )
       {
-        std::string& elem = *it;
+        std::string & elem = *it;
 
         // Compiler will not accept newline_str as the third argument to std::remove
-        elem.erase( std::remove(elem.begin(), elem.end(), '\n'), elem.end() );
+        elem.erase( std::remove(elem.begin(), elem.end(), *newline_str.c_str()), elem.end() );
       }
   }
 

--- a/test/standard_unit/nasa_mixture_xml_parsing_test.C
+++ b/test/standard_unit/nasa_mixture_xml_parsing_test.C
@@ -97,6 +97,25 @@ namespace AntiochTesting
 
   };
 
+#define DEFINE_NASA9XMLPARSING_SCALAR_TEST(Classname,BaseClass,Scalar)  \
+  class Classname : public BaseClass<Scalar>                            \
+  {                                                                     \
+  public:                                                               \
+    CPPUNIT_TEST_SUITE( Classname );                                    \
+    CPPUNIT_TEST(test_supplied_species);                                \
+    CPPUNIT_TEST_SUITE_END();                                           \
+  }
+
+  DEFINE_NASA9XMLPARSING_SCALAR_TEST(NASA9XMLParsingTestFloat,NASA9XMLParsingTest,float);
+  DEFINE_NASA9XMLPARSING_SCALAR_TEST(NASA9XMLParsingTestDouble,NASA9XMLParsingTest,double);
+  DEFINE_NASA9XMLPARSING_SCALAR_TEST(NASA9XMLParsingTestLongDouble,NASA9XMLParsingTest,long double);
+
+  CPPUNIT_TEST_SUITE_REGISTRATION( NASA9XMLParsingTestFloat );
+  CPPUNIT_TEST_SUITE_REGISTRATION( NASA9XMLParsingTestDouble );
+  CPPUNIT_TEST_SUITE_REGISTRATION( NASA9XMLParsingTestLongDouble );
+
+
+
   template<typename Scalar>
   class NASA7XMLParsingTest : public NASA7ThermoTestBase<Scalar>,
                               public CppUnit::TestCase
@@ -170,78 +189,22 @@ namespace AntiochTesting
 
   };
 
-  class NASA9XMLParsingTestFloat : public NASA9XMLParsingTest<float>
-  {
-  public:
-    CPPUNIT_TEST_SUITE( NASA9XMLParsingTestFloat );
 
-    CPPUNIT_TEST(test_supplied_species);
+#define DEFINE_NASA7XMLPARSING_SCALAR_TEST(Classname,BaseClass,Scalar)  \
+  class Classname : public BaseClass<Scalar>                            \
+  {                                                                     \
+  public:                                                               \
+    CPPUNIT_TEST_SUITE( Classname );                                    \
+    CPPUNIT_TEST(test_supplied_species);                                \
+    CPPUNIT_TEST(test_parsed_species_list);                             \
+    CPPUNIT_TEST_SUITE_END();                                           \
+  }
 
-    CPPUNIT_TEST_SUITE_END();
+  DEFINE_NASA7XMLPARSING_SCALAR_TEST(NASA7XMLParsingTestFloat,NASA7XMLParsingTest,float);
+  DEFINE_NASA7XMLPARSING_SCALAR_TEST(NASA7XMLParsingTestDouble,NASA7XMLParsingTest,double);
+  DEFINE_NASA7XMLPARSING_SCALAR_TEST(NASA7XMLParsingTestLongDouble,NASA7XMLParsingTest,long double);
 
-  };
 
-  class NASA9XMLParsingTestDouble : public NASA9XMLParsingTest<double>
-  {
-  public:
-    CPPUNIT_TEST_SUITE( NASA9XMLParsingTestDouble );
-
-    CPPUNIT_TEST(test_supplied_species);
-
-    CPPUNIT_TEST_SUITE_END();
-
-  };
-
-  class NASA9XMLParsingTestLongDouble : public NASA9XMLParsingTest<long double>
-  {
-  public:
-    CPPUNIT_TEST_SUITE( NASA9XMLParsingTestLongDouble );
-
-    CPPUNIT_TEST(test_supplied_species);
-
-    CPPUNIT_TEST_SUITE_END();
-
-  };
-
-  class NASA7XMLParsingTestFloat : public NASA7XMLParsingTest<float>
-  {
-  public:
-    CPPUNIT_TEST_SUITE( NASA7XMLParsingTestFloat );
-
-    CPPUNIT_TEST(test_supplied_species);
-    CPPUNIT_TEST(test_parsed_species_list);
-
-    CPPUNIT_TEST_SUITE_END();
-
-  };
-
-  class NASA7XMLParsingTestDouble : public NASA7XMLParsingTest<double>
-  {
-  public:
-    CPPUNIT_TEST_SUITE( NASA7XMLParsingTestDouble );
-
-    CPPUNIT_TEST(test_supplied_species);
-    CPPUNIT_TEST(test_parsed_species_list);
-
-    CPPUNIT_TEST_SUITE_END();
-
-  };
-
-  class NASA7XMLParsingTestLongDouble : public NASA7XMLParsingTest<long double>
-  {
-  public:
-    CPPUNIT_TEST_SUITE( NASA7XMLParsingTestLongDouble );
-
-    CPPUNIT_TEST(test_supplied_species);
-    CPPUNIT_TEST(test_parsed_species_list);
-
-    CPPUNIT_TEST_SUITE_END();
-
-  };
-
-  CPPUNIT_TEST_SUITE_REGISTRATION( NASA9XMLParsingTestFloat );
-  CPPUNIT_TEST_SUITE_REGISTRATION( NASA9XMLParsingTestDouble );
-  CPPUNIT_TEST_SUITE_REGISTRATION( NASA9XMLParsingTestLongDouble );
   CPPUNIT_TEST_SUITE_REGISTRATION( NASA7XMLParsingTestFloat );
   CPPUNIT_TEST_SUITE_REGISTRATION( NASA7XMLParsingTestDouble );
   CPPUNIT_TEST_SUITE_REGISTRATION( NASA7XMLParsingTestLongDouble );

--- a/test/standard_unit/nasa_mixture_xml_parsing_test.C
+++ b/test/standard_unit/nasa_mixture_xml_parsing_test.C
@@ -161,6 +161,23 @@ namespace AntiochTesting
       this->check_curve_fits(nasa_mixture);
     }
 
+    void test_gri30_xml()
+    {
+      std::vector<std::string> species_str_list(2);
+      species_str_list[0] = "H2";
+      species_str_list[1] = "N2";
+
+      Antioch::ChemicalMixture<Scalar> chem_mixture( species_str_list );
+
+      std::string thermo_filename = std::string(ANTIOCH_SHARE_XML_INPUT_FILES_SOURCE_PATH)+"gri30.xml";
+
+      Antioch::NASAThermoMixture<Scalar, Antioch::NASA7CurveFit<Scalar> > nasa_mixture( chem_mixture );
+
+      Antioch::read_nasa_mixture_data( nasa_mixture, thermo_filename, Antioch::XML );
+
+      this->check_curve_fits(nasa_mixture);
+     }
+
     void check_curve_fits( const Antioch::NASAThermoMixture<Scalar, Antioch::NASA7CurveFit<Scalar> >& nasa_mixture)
     {
       const Antioch::NASA7CurveFit<Scalar>& H2_curve_fit =  nasa_mixture.curve_fit(0);
@@ -197,6 +214,7 @@ namespace AntiochTesting
     CPPUNIT_TEST_SUITE( Classname );                                    \
     CPPUNIT_TEST(test_supplied_species);                                \
     CPPUNIT_TEST(test_parsed_species_list);                             \
+    CPPUNIT_TEST(test_gri30_xml);                                       \
     CPPUNIT_TEST_SUITE_END();                                           \
   }
 

--- a/test/standard_unit/string_utils_test.C
+++ b/test/standard_unit/string_utils_test.C
@@ -49,6 +49,7 @@ namespace AntiochTesting
     CPPUNIT_TEST(test_split_string);
     CPPUNIT_TEST(test_string_to_T);
     CPPUNIT_TEST(test_strip_newlines);
+    CPPUNIT_TEST(test_strip_newlines_gri30N2);
 
     CPPUNIT_TEST_SUITE_END();
 
@@ -164,12 +165,45 @@ namespace AntiochTesting
       strings_exact.push_back("1.1111111111e+10");
 
       Antioch::remove_newline_from_strings(strings);
+      this->compare_string_vectors(strings,strings_exact);
+    }
+
+    void test_strip_newlines_gri30N2()
+    {
+      std::vector<std::string> strings;
+      strings.push_back("\n");
+      strings.push_back("3.298677000E+00,");
+      strings.push_back("1.408240400E-03,");
+      strings.push_back("-3.963222000E-06,");
+      strings.push_back("5.641515000E-09,");
+      strings.push_back("\n");
+      strings.push_back("-2.444854000E-12,");
+      strings.push_back("-1.020899900E+03,");
+      strings.push_back("3.950372000E+00");
+
+      std::vector<std::string> strings_exact;
+      strings_exact.push_back("3.298677000E+00,");
+      strings_exact.push_back("1.408240400E-03,");
+      strings_exact.push_back("-3.963222000E-06,");
+      strings_exact.push_back("5.641515000E-09,");
+      strings_exact.push_back("-2.444854000E-12,");
+      strings_exact.push_back("-1.020899900E+03,");
+      strings_exact.push_back("3.950372000E+00");
+
+      Antioch::remove_newline_from_strings(strings);
+      this->compare_string_vectors(strings,strings_exact);
+    }
+
+  private:
+
+    void compare_string_vectors( const std::vector<std::string> & strings,
+                                 const std::vector<std::string> & strings_exact )
+    {
       CPPUNIT_ASSERT_EQUAL(strings_exact.size(), strings.size());
 
       for( unsigned int i = 0; i < strings_exact.size(); i++ )
         CPPUNIT_ASSERT_EQUAL(strings_exact[i], strings[i]);
     }
-
   };
 
   CPPUNIT_TEST_SUITE_REGISTRATION( StringUtilitiesTest );


### PR DESCRIPTION
In putting unit testing in for #240, I was hitting a snag reading NASA7 coefficients from the GRI3 XML shipped with Cantera. After a fun morning/early afternoon, boiled it down to a bug in my implementation of `Antioch::remove_newline_from_strings`; this was particularly bad since the solution was used 5 lines below for a similar problem. *sad face*

I went ahead and added GRI3 XML to the share directory and added a unit test for parsing the NASA coefficients from that XML file.