### PR TITLE
Fixed Parsing error for Reactions with species like CH2(S)

### DIFF
--- a/src/parsing/src/xml_parser.C
+++ b/src/parsing/src/xml_parser.C
@@ -317,10 +317,14 @@ namespace Antioch
                ++searchfor;
                continue;
              }
-
-           if (eq[pos] != ' ')
-             break;
-         }
+	   if(eq[pos] ==' ')
+	     continue;
+       // If not '(+M)' parenthesis, search for the next parenthesis and check
+	   searchfor = "(+M)";
+	   pos = eq.find('(',pos+1);
+       // Adjust position before iteration
+	   --pos;
+	 }
 
        // If we found everything then *searchfor is NULL
        if (!*searchfor)


### PR DESCRIPTION
While trying to parse the GRi3 XML, There was an error with Troe Reactions with CH2(S) not being recognized as three body because of the extra parenthesis. 