### PR TITLE
Query NASA Curve Fit Type from XML file

### DIFF
--- a/src/parsing/include/antioch/parser_base.h
+++ b/src/parsing/include/antioch/parser_base.h
@@ -67,7 +67,7 @@ namespace Antioch
   template <typename NumericType>
   class CEAEvaluator;
 
-// micro
+  // micro
   template <typename NumericType>
   class StatMechThermodynamics;
 
@@ -76,28 +76,28 @@ namespace Antioch
 
   /*!\class ParserBase
 
-      A parser is an instance related to a file. The parser
-      corresponds to a file type (e.g. XML or ChemKin). The
-      file HAS to be given in the constructor as the parser
-      is indissociable from the file. Set to `true' by default,
-      a verbose switch is also available.
+    A parser is an instance related to a file. The parser
+    corresponds to a file type (e.g. XML or ChemKin). The
+    file HAS to be given in the constructor as the parser
+    is indissociable from the file. Set to `true' by default,
+    a verbose switch is also available.
 
-      We define here the rule of parsing for
-      all parsers. Differences/specificities are described in the
-      corresponding files.
+    We define here the rule of parsing for
+    all parsers. Differences/specificities are described in the
+    corresponding files.
 
-      The different things to parse are:
-        - the species, name and core characteristics:
-                - list of names (std::string) `const std::vector<std::string> species_list() const;'
-                - mandatory data (molar mass, heat of formation at 0 K,
-                                  number of translational/rotational DOFs,
-                                  charge number) `void read_chemical_species(ChemicalMixture<NumericType> & chem_mixture);'
-                - vibrational data `void read_vibrational_data(ChemicalMixture<NumericType> & chem_mixture);'
-                - electronic data `void read_electronic_data(ChemicalMixture<NumericType> & chem_mixture);'
-        - the kinetics:
-                - it requires a boolean to ensure there is a reaction to parse `bool reaction();'
-                - ...
-   */
+    The different things to parse are:
+    - the species, name and core characteristics:
+    - list of names (std::string) `const std::vector<std::string> species_list() const;'
+    - mandatory data (molar mass, heat of formation at 0 K,
+    number of translational/rotational DOFs,
+    charge number) `void read_chemical_species(ChemicalMixture<NumericType> & chem_mixture);'
+    - vibrational data `void read_vibrational_data(ChemicalMixture<NumericType> & chem_mixture);'
+    - electronic data `void read_electronic_data(ChemicalMixture<NumericType> & chem_mixture);'
+    - the kinetics:
+    - it requires a boolean to ensure there is a reaction to parse `bool reaction();'
+    - ...
+  */
 
   template <typename NumericType>
   class ParserBase
@@ -110,155 +110,209 @@ namespace Antioch
 
     virtual ~ParserBase(){};
 
-        // initialize kinetics, mandatory
-        virtual bool initialize() = 0;
+    // initialize kinetics, mandatory
+    virtual bool initialize() = 0;
 
-        // to reinitialize, mandatory
-        virtual void change_file(const std::string & filename) = 0;
+    // to reinitialize, mandatory
+    virtual void change_file(const std::string & filename) = 0;
 
-/// species
-        //! reads the species set
-        virtual const std::vector<std::string> species_list() {antioch_not_implemented_msg(_not_implemented); return std::vector<std::string>();}
+    /// species
+    //! reads the species set
+    virtual const std::vector<std::string> species_list()
+    {antioch_not_implemented_msg(_not_implemented); return std::vector<std::string>();}
 
-        //! reads the mandatory data, not valid in xml && chemkin
-        virtual void read_chemical_species(ChemicalMixture<NumericType> & /*chem_mixture*/)  {antioch_not_implemented_msg(_not_implemented);}
+    //! reads the mandatory data, not valid in xml && chemkin
+    virtual void read_chemical_species(ChemicalMixture<NumericType> & /*chem_mixture*/)
+    {antioch_not_implemented_msg(_not_implemented);}
 
-        //! reads the vibrational data, not valid in xml && chemkin
-        virtual void read_vibrational_data(ChemicalMixture<NumericType> & /*chem_mixture*/)  {antioch_not_implemented_msg(_not_implemented);}
+    //! reads the vibrational data, not valid in xml && chemkin
+    virtual void read_vibrational_data(ChemicalMixture<NumericType> & /*chem_mixture*/)
+    {antioch_not_implemented_msg(_not_implemented);}
 
-        //! reads the electronic data, not valid in xml && chemkin
-        virtual void read_electronic_data(ChemicalMixture<NumericType> & /*chem_mixture*/)  {antioch_not_implemented_msg(_not_implemented);}
+    //! reads the electronic data, not valid in xml && chemkin
+    virtual void read_electronic_data(ChemicalMixture<NumericType> & /*chem_mixture*/)
+    {antioch_not_implemented_msg(_not_implemented);}
 
-// transport
+    // transport
 
-        //! reads the transport data, not valid in xml && chemkin
-        virtual void read_transport_data(TransportMixture<NumericType> & /*transport_mixture*/)  {antioch_not_implemented_msg(_not_implemented);}
+    //! reads the transport data, not valid in xml && chemkin
+    virtual void read_transport_data(TransportMixture<NumericType> & /*transport_mixture*/)
+    {antioch_not_implemented_msg(_not_implemented);}
 
-/// thermo
+    /// thermo
 
-        //! reads the thermo, NASA generalist, no templates for virtual
-        virtual void read_thermodynamic_data(NASAThermoMixture<NumericType, NASA7CurveFit<NumericType> >& /*thermo*/)  {antioch_not_implemented_msg(_not_implemented);}
+    //! reads the thermo, NASA generalist, no templates for virtual
+    virtual void read_thermodynamic_data(NASAThermoMixture<NumericType, NASA7CurveFit<NumericType> >& /*thermo*/)
+    {antioch_not_implemented_msg(_not_implemented);}
 
-        //! reads the thermo, NASA generalist, no templates for virtual
-        virtual void read_thermodynamic_data(NASAThermoMixture<NumericType, NASA9CurveFit<NumericType> >& /*thermo*/)  {antioch_not_implemented_msg(_not_implemented);}
+    //! reads the thermo, NASA generalist, no templates for virtual
+    virtual void read_thermodynamic_data(NASAThermoMixture<NumericType, NASA9CurveFit<NumericType> >& /*thermo*/)
+    {antioch_not_implemented_msg(_not_implemented);}
 
-        //! reads the thermo, NASA generalist, no templates for virtual
-        virtual void read_thermodynamic_data(NASAThermoMixture<NumericType, CEACurveFit<NumericType> >& /*thermo*/)  {antioch_not_implemented_msg(_not_implemented);}
-
-
-/// reaction
-
-// non const
-
-         /*! read & store current reaction and go to next reaction*/
-         virtual bool reaction() {antioch_not_implemented_msg(_not_implemented); return false;}
-
-         /*! go to next rate constant*/
-         virtual bool rate_constant(const std::string & /*kinetics_model*/) {antioch_not_implemented_msg(_not_implemented); return false;}
-
-// const
-
-         /*! \return true if there's a Troe block*/
-         virtual bool Troe() const {antioch_not_implemented_msg(_not_implemented); return false;}
-
-         /*! \return reaction id, 0 if not provided*/
-         virtual const std::string reaction_id() const  {antioch_not_implemented_msg(_not_implemented); return std::string();}
-
-         /*! \return reaction equation */
-         virtual const std::string reaction_equation() const {antioch_not_implemented_msg(_not_implemented); return std::string();}
-
-         /*! \return reaction chemical process*/
-         virtual const std::string reaction_chemical_process() const {antioch_not_implemented_msg(_not_implemented); return std::string();}
-
-         /*! \return reaction kinetics model*/
-         virtual const std::string reaction_kinetics_model(const std::vector<std::string> & /*kinetics_models*/) const  {antioch_not_implemented_msg(_not_implemented); return std::string();}
-
-         /*! \return reversible state*/
-         virtual bool reaction_reversible() const {antioch_not_implemented_msg(_not_implemented); return false;}
-
-         /*! \return pairs of reactants and stoichiometric coefficients*/
-         virtual bool reactants_pairs(std::vector<std::pair<std::string,int> > & /*reactants_pair*/) const  {antioch_not_implemented_msg(_not_implemented); return false;}
-
-         /*! \return pairs of products and stoichiometric coefficients*/
-         virtual bool products_pairs(std::vector<std::pair<std::string,int> > & /*products_pair*/) const {antioch_not_implemented_msg(_not_implemented); return false;}
-
-         /*! return a map between reactants' name and found partial orders */
-         virtual const std::map<std::string,NumericType> reactants_orders() const {antioch_not_implemented_msg(_not_implemented); return std::map<std::string,NumericType>();}
-
-         /*! return a map between products' name and found partial orders */
-         virtual const std::map<std::string,NumericType> products_orders() const {antioch_not_implemented_msg(_not_implemented); return std::map<std::string,NumericType>();}
-
-         /*! \return true if "name" attribute is found with value "k0"*/
-         virtual bool is_k0(unsigned int /*nrc*/, const std::string & /*kin_model*/) const {antioch_not_implemented_msg(_not_implemented); return false;}
-
-         /*! \return index of k0 (0 or 1)*/
-         virtual unsigned int where_is_k0(const std::string & /*kin_model*/) const {antioch_not_implemented_msg(_not_implemented); return -1;}
-
-         /*! \return true if pre exponentiel coefficient*/
-         virtual bool rate_constant_preexponential_parameter(NumericType & /*A*/, std::string & /*A_unit*/, std::string & /*def_unit*/) const {antioch_not_implemented_msg(_not_implemented); return false;}
-
-         /*! \return true if beta coefficient*/
-         virtual bool rate_constant_power_parameter(NumericType & /*b*/, std::string & /*b_unit*/, std::string & /*def_unit*/) const {antioch_not_implemented_msg(_not_implemented); return false;}
-
-         /*! \return true if activation energie*/
-         virtual bool rate_constant_activation_energy_parameter(NumericType & /*Ea*/, std::string & /*Ea_unit*/, std::string & /*def_unit*/) const {antioch_not_implemented_msg(_not_implemented); return false;}
-
-         /*! \return true if D coefficient*/
-         virtual bool rate_constant_Berthelot_coefficient_parameter(NumericType & /*D*/, std::string & /*D_unit*/, std::string & /*def_unit*/) const {antioch_not_implemented_msg(_not_implemented); return false;}
-
-         /*! \return true if Tref*/
-         virtual bool rate_constant_Tref_parameter( NumericType & /*Tref*/, std::string & /*Tref_unit*/, std::string & /*def_unit*/) const {antioch_not_implemented_msg(_not_implemented); return false;}
-
-         /*! \return true if lambda*/
-         virtual bool rate_constant_lambda_parameter(std::vector<NumericType> & /*lambda*/, std::string & /*lambda_unit*/, std::string & /*def_unit*/) const {antioch_not_implemented_msg(_not_implemented); return false;}
-
-         /*! \return true if sigma*/
-         virtual bool rate_constant_cross_section_parameter(std::vector<NumericType> & /*sigma*/,  std::string & /*sigma_unit*/, std::string & /*def_unit*/) const {antioch_not_implemented_msg(_not_implemented); return false;}
-
-         /*! \return true if a Kooij is called Arrhenuis*/
-         virtual bool verify_Kooij_in_place_of_Arrhenius() const {antioch_not_implemented_msg(_not_implemented); return false;}
-
-         /*! \return true if efficiencies are found*/
-         virtual bool efficiencies(std::vector<std::pair<std::string,NumericType> > & /*par_values*/) const {antioch_not_implemented_msg(_not_implemented); return false;}
-
-         /*! \return true is alpha*/
-         virtual bool Troe_alpha_parameter(NumericType & /*alpha*/, std::string & /*alpha_unit*/, std::string & /*def_unit*/) const {antioch_not_implemented_msg(_not_implemented); return false;}
-
-         /*! \return true is alpha*/
-         virtual bool Troe_T1_parameter(NumericType & /*T1*/, std::string & /*T1_unit*/, std::string & /*def_unit*/) const {antioch_not_implemented_msg(_not_implemented); return false;}
-
-         /*! \return true is alpha*/
-         virtual bool Troe_T2_parameter(NumericType & /*T2*/, std::string & /*T2_unit*/, std::string & /*def_unit*/) const {antioch_not_implemented_msg(_not_implemented); return false;}
-
-         /*! \return true is alpha*/
-         virtual bool Troe_T3_parameter(NumericType & /*T3*/, std::string & /*T3_unit*/, std::string & /*def_unit*/) const {antioch_not_implemented_msg(_not_implemented); return false;}
-
-         /*! \return name of file*/
-        const std::string file() const {return _file;}
-
-         /*! \return type of parser*/
-        const std::string type() const {return _type;}
-
-         /*! \return verbosity*/
-         bool verbose() const {return _verbose;}
-
-        /*! \return enum*/
-        ParsingType enum_type() const;
+    //! reads the thermo, NASA generalist, no templates for virtual
+    virtual void read_thermodynamic_data(NASAThermoMixture<NumericType, CEACurveFit<NumericType> >& /*thermo*/)
+    {antioch_not_implemented_msg(_not_implemented);}
 
 
-     protected:
+    /// reaction
 
-        void skip_comments(std::istream & doc);
+    // non const
 
-        std::string _type;
-        std::string _file;
-        bool        _verbose;
-        std::string _comments;
+    /*! read & store current reaction and go to next reaction*/
+    virtual bool reaction()
+    {antioch_not_implemented_msg(_not_implemented); return false;}
 
-        std::string _not_implemented;
+    /*! go to next rate constant*/
+    virtual bool rate_constant(const std::string & /*kinetics_model*/)
+    {antioch_not_implemented_msg(_not_implemented); return false;}
 
-     private:
-        ParserBase();
+    // const
+
+    /*! \return true if there's a Troe block*/
+    virtual bool Troe() const
+    {antioch_not_implemented_msg(_not_implemented); return false;}
+
+    /*! \return reaction id, 0 if not provided*/
+    virtual const std::string reaction_id() const
+    {antioch_not_implemented_msg(_not_implemented); return std::string();}
+
+    /*! \return reaction equation */
+    virtual const std::string reaction_equation() const
+    {antioch_not_implemented_msg(_not_implemented); return std::string();}
+
+    /*! \return reaction chemical process*/
+    virtual const std::string reaction_chemical_process() const
+    {antioch_not_implemented_msg(_not_implemented); return std::string();}
+
+    /*! \return reaction kinetics model*/
+    virtual const std::string reaction_kinetics_model(const std::vector<std::string> & /*kinetics_models*/) const
+    {antioch_not_implemented_msg(_not_implemented); return std::string();}
+
+    /*! \return reversible state*/
+    virtual bool reaction_reversible() const
+    {antioch_not_implemented_msg(_not_implemented); return false;}
+
+    /*! \return pairs of reactants and stoichiometric coefficients*/
+    virtual bool reactants_pairs(std::vector<std::pair<std::string,int> > & /*reactants_pair*/) const
+    {antioch_not_implemented_msg(_not_implemented); return false;}
+
+    /*! \return pairs of products and stoichiometric coefficients*/
+    virtual bool products_pairs(std::vector<std::pair<std::string,int> > & /*products_pair*/) const
+    {antioch_not_implemented_msg(_not_implemented); return false;}
+
+    /*! return a map between reactants' name and found partial orders */
+    virtual const std::map<std::string,NumericType> reactants_orders() const
+    {antioch_not_implemented_msg(_not_implemented); return std::map<std::string,NumericType>();}
+
+    /*! return a map between products' name and found partial orders */
+    virtual const std::map<std::string,NumericType> products_orders() const
+    {antioch_not_implemented_msg(_not_implemented); return std::map<std::string,NumericType>();}
+
+    /*! \return true if "name" attribute is found with value "k0"*/
+    virtual bool is_k0(unsigned int /*nrc*/, const std::string & /*kin_model*/) const
+    {antioch_not_implemented_msg(_not_implemented); return false;}
+
+    /*! \return index of k0 (0 or 1)*/
+    virtual unsigned int where_is_k0(const std::string & /*kin_model*/) const
+    {antioch_not_implemented_msg(_not_implemented); return -1;}
+
+    /*! \return true if pre exponentiel coefficient*/
+    virtual bool rate_constant_preexponential_parameter(NumericType & /*A*/,
+                                                        std::string & /*A_unit*/,
+                                                        std::string & /*def_unit*/) const
+    {antioch_not_implemented_msg(_not_implemented); return false;}
+
+    /*! \return true if beta coefficient*/
+    virtual bool rate_constant_power_parameter(NumericType & /*b*/,
+                                               std::string & /*b_unit*/,
+                                               std::string & /*def_unit*/) const
+    {antioch_not_implemented_msg(_not_implemented); return false;}
+
+    /*! \return true if activation energie*/
+    virtual bool rate_constant_activation_energy_parameter(NumericType & /*Ea*/,
+                                                           std::string & /*Ea_unit*/,
+                                                           std::string & /*def_unit*/) const
+    {antioch_not_implemented_msg(_not_implemented); return false;}
+
+    /*! \return true if D coefficient*/
+    virtual bool rate_constant_Berthelot_coefficient_parameter(NumericType & /*D*/, std::string & /*D_unit*/, std::string & /*def_unit*/) const {antioch_not_implemented_msg(_not_implemented); return false;}
+
+    /*! \return true if Tref*/
+    virtual bool rate_constant_Tref_parameter( NumericType & /*Tref*/,
+                                               std::string & /*Tref_unit*/,
+                                               std::string & /*def_unit*/) const
+    {antioch_not_implemented_msg(_not_implemented); return false;}
+
+    /*! \return true if lambda*/
+    virtual bool rate_constant_lambda_parameter(std::vector<NumericType> & /*lambda*/,
+                                                std::string & /*lambda_unit*/,
+                                                std::string & /*def_unit*/) const
+    {antioch_not_implemented_msg(_not_implemented); return false;}
+
+    /*! \return true if sigma*/
+    virtual bool rate_constant_cross_section_parameter(std::vector<NumericType> & /*sigma*/,
+                                                       std::string & /*sigma_unit*/,
+                                                       std::string & /*def_unit*/) const
+    {antioch_not_implemented_msg(_not_implemented); return false;}
+
+    /*! \return true if a Kooij is called Arrhenuis*/
+    virtual bool verify_Kooij_in_place_of_Arrhenius() const
+    {antioch_not_implemented_msg(_not_implemented); return false;}
+
+    /*! \return true if efficiencies are found*/
+    virtual bool efficiencies(std::vector<std::pair<std::string,NumericType> > & /*par_values*/) const
+    {antioch_not_implemented_msg(_not_implemented); return false;}
+
+    /*! \return true is alpha*/
+    virtual bool Troe_alpha_parameter(NumericType & /*alpha*/,
+                                      std::string & /*alpha_unit*/,
+                                      std::string & /*def_unit*/) const
+    {antioch_not_implemented_msg(_not_implemented); return false;}
+
+    /*! \return true is alpha*/
+    virtual bool Troe_T1_parameter(NumericType & /*T1*/,
+                                   std::string & /*T1_unit*/,
+                                   std::string & /*def_unit*/) const
+    {antioch_not_implemented_msg(_not_implemented); return false;}
+
+    /*! \return true is alpha*/
+    virtual bool Troe_T2_parameter(NumericType & /*T2*/,
+                                   std::string & /*T2_unit*/,
+                                   std::string & /*def_unit*/) const
+    {antioch_not_implemented_msg(_not_implemented); return false;}
+
+    /*! \return true is alpha*/
+    virtual bool Troe_T3_parameter(NumericType & /*T3*/,
+                                   std::string & /*T3_unit*/,
+                                   std::string & /*def_unit*/) const
+    {antioch_not_implemented_msg(_not_implemented); return false;}
+
+    /*! \return name of file*/
+    const std::string file() const {return _file;}
+
+    /*! \return type of parser*/
+    const std::string type() const {return _type;}
+
+    /*! \return verbosity*/
+    bool verbose() const {return _verbose;}
+
+    /*! \return enum*/
+    ParsingType enum_type() const;
+
+
+  protected:
+
+    void skip_comments(std::istream & doc);
+
+    std::string _type;
+    std::string _file;
+    bool        _verbose;
+    std::string _comments;
+
+    std::string _not_implemented;
+
+  private:
+    ParserBase();
   };
 
 } // end namespace Antioch

--- a/src/parsing/include/antioch/parsing_enum.h
+++ b/src/parsing/include/antioch/parsing_enum.h
@@ -49,6 +49,7 @@ namespace Antioch
                   REACTION,
                   REVERSIBLE,
                   ID,
+                  DATASRC,
                   EQUATION,
                   CHEMICAL_PROCESS,
                   KINETICS_MODEL,

--- a/src/parsing/include/antioch/parsing_enum.h
+++ b/src/parsing/include/antioch/parsing_enum.h
@@ -45,6 +45,7 @@ namespace Antioch
                   NASA7,
                   NASA9,
 //
+                  REACTION_SET,
                   REACTION_DATA,
                   REACTION,
                   REVERSIBLE,

--- a/src/parsing/include/antioch/xml_parser.h
+++ b/src/parsing/include/antioch/xml_parser.h
@@ -264,6 +264,8 @@ namespace Antioch{
 
     void init_name_maps();
 
+    void open_xml_file( const std::string & filename );
+
     /*! Never use default constructor*/
     XMLParser();
     std::unique_ptr<tinyxml2::XMLDocument> _doc;

--- a/src/parsing/include/antioch/xml_parser.h
+++ b/src/parsing/include/antioch/xml_parser.h
@@ -76,7 +76,15 @@ namespace Antioch{
   class XMLParser: public ParserBase<NumericType>
   {
   public:
-    XMLParser(const std::string &filename, bool verbose = true);
+
+    //! Preferred constructor
+    XMLParser(const std::string & filename, const std::string & phase_name, bool verbose = true);
+
+    //! Deprecated constructor
+    XMLParser(const std::string & filename, bool verbose = true);
+
+    XMLParser() = delete;
+
     virtual ~XMLParser() = default;
 
     void change_file(const std::string & filename);
@@ -266,8 +274,6 @@ namespace Antioch{
 
     void open_xml_file( const std::string & filename );
 
-    /*! Never use default constructor*/
-    XMLParser();
     std::unique_ptr<tinyxml2::XMLDocument> _doc;
 
     std::string _phase;

--- a/src/parsing/include/antioch/xml_parser.h
+++ b/src/parsing/include/antioch/xml_parser.h
@@ -265,6 +265,7 @@ namespace Antioch{
     std::string nasa_xml_section( NASAThermoMixture<NumericType, CEACurveFit<NumericType> >& /*thermo*/ )
     { antioch_error_msg("ERROR: Only supported for NASA7CurveFit and NASA9CurveFit!"); return "";}
 
+    void init_name_maps();
 
     /*! Never use default constructor*/
     XMLParser();

--- a/src/parsing/include/antioch/xml_parser.h
+++ b/src/parsing/include/antioch/xml_parser.h
@@ -270,7 +270,9 @@ namespace Antioch{
     XMLParser();
     std::unique_ptr<tinyxml2::XMLDocument> _doc;
 
+    std::string _phase;
     //
+    tinyxml2::XMLElement * _phase_block;
     tinyxml2::XMLElement * _species_block;
     tinyxml2::XMLElement * _thermo_block;
     tinyxml2::XMLElement * _reaction_block;

--- a/src/parsing/include/antioch/xml_parser.h
+++ b/src/parsing/include/antioch/xml_parser.h
@@ -64,163 +64,190 @@ namespace Antioch{
 
   /*!\class XMLParser
 
-     Nothing is stored, this parser is based on the tinyxml2
-     implementation. Please note that no other file should include
-     the `tinyxml2_imp.h' header.
+    Nothing is stored, this parser is based on the tinyxml2
+    implementation. Please note that no other file should include
+    the `tinyxml2_imp.h' header.
 
-     The defaults units are based and derived on Cantera:
-       -   pre-exponential parameters in (m3/kmol)^(m-1)/s
-       -   activation energy in cal/mol,
-       -   power parameter without unit
-       -   cross-section typically in cm2/nm,
-       -   lambda typically in nm,
-   */
+    The defaults units are based and derived on Cantera:
+    -   pre-exponential parameters in (m3/kmol)^(m-1)/s
+    -   activation energy in cal/mol,
+    -   power parameter without unit
+    -   cross-section typically in cm2/nm,
+    -   lambda typically in nm,
+  */
   template <typename NumericType = double>
   class XMLParser: public ParserBase<NumericType>
   {
-        public:
-          XMLParser(const std::string &filename, bool verbose = true);
-          ~XMLParser();
+  public:
+    XMLParser(const std::string &filename, bool verbose = true);
+    ~XMLParser();
 
-          void change_file(const std::string & filename);
+    void change_file(const std::string & filename);
 
-//// first local pointers
-         /*! Read header of file, go to interesting part*/
-         bool initialize();
+    //// first local pointers
+    /*! Read header of file, go to interesting part*/
+    bool initialize();
 
-/// species
-        //! reads the species set
-        const std::vector<std::string> species_list() ;
+    /// species
+    //! reads the species set
+    const std::vector<std::string> species_list() ;
 
-        //! reads the thermo, NASA generalist, no templates for virtual
-        void read_thermodynamic_data(NASAThermoMixture<NumericType, NASA7CurveFit<NumericType> >& thermo)
-                {this->read_thermodynamic_data_root(thermo);}
+    //! reads the thermo, NASA generalist, no templates for virtual
+    void read_thermodynamic_data(NASAThermoMixture<NumericType, NASA7CurveFit<NumericType> >& thermo)
+    {this->read_thermodynamic_data_root(thermo);}
 
-        //! reads the thermo, NASA generalist, no templates for virtual
-        void read_thermodynamic_data(NASAThermoMixture<NumericType, NASA9CurveFit<NumericType> >& thermo)
-                {this->read_thermodynamic_data_root(thermo);}
+    //! reads the thermo, NASA generalist, no templates for virtual
+    void read_thermodynamic_data(NASAThermoMixture<NumericType, NASA9CurveFit<NumericType> >& thermo)
+    {this->read_thermodynamic_data_root(thermo);}
 
     //! reads the thermo, NASA generalist, no templates for virtual
     void read_thermodynamic_data(NASAThermoMixture<NumericType, CEACurveFit<NumericType> >& /*thermo*/)
     {antioch_error_msg("ERROR: XML Parsing only supports parsing for NASA7CurveFit and NASA9CurveFit!");}
 
 
-/// reaction
+    /// reaction
 
-         /*! go to next reaction*/
-         bool reaction();
+    /*! go to next reaction*/
+    bool reaction();
 
-         /*! go to next rate constant*/
-         bool rate_constant(const std::string & kinetics_model);
+    /*! go to next rate constant*/
+    bool rate_constant(const std::string & kinetics_model);
 
-         /*! return true if there's a Troe block*/
-         bool Troe() const;
+    /*! return true if there's a Troe block*/
+    bool Troe() const;
 
-         /*! return reaction id, 0 if not provided*/
-         const std::string reaction_id() const;
+    /*! return reaction id, 0 if not provided*/
+    const std::string reaction_id() const;
 
-         /*! return reaction equation */
-         const std::string reaction_equation() const;
+    /*! return reaction equation */
+    const std::string reaction_equation() const;
 
-         /*! return reaction chemical process*/
-         const std::string reaction_chemical_process() const;
+    /*! return reaction chemical process*/
+    const std::string reaction_chemical_process() const;
 
-         /*! return reaction kinetics model*/
-         const std::string reaction_kinetics_model(const std::vector<std::string> &kinetics_models) const;
+    /*! return reaction kinetics model*/
+    const std::string reaction_kinetics_model(const std::vector<std::string> &kinetics_models) const;
 
-         /*! return reversible state*/
-         bool reaction_reversible() const;
+    /*! return reversible state*/
+    bool reaction_reversible() const;
 
-         /*! return pairs of reactants and stoichiometric coefficients*/
-         bool reactants_pairs(std::vector<std::pair<std::string,int> > & reactants_pair) const;
+    /*! return pairs of reactants and stoichiometric coefficients*/
+    bool reactants_pairs(std::vector<std::pair<std::string,int> > & reactants_pair) const;
 
-         /*! return pairs of products and stoichiometric coefficients*/
-         bool products_pairs(std::vector<std::pair<std::string,int> > & products_pair) const;
+    /*! return pairs of products and stoichiometric coefficients*/
+    bool products_pairs(std::vector<std::pair<std::string,int> > & products_pair) const;
 
-         /*! return a map between reactants' name and found partial orders */
-         const std::map<std::string,NumericType> reactants_orders() const;
+    /*! return a map between reactants' name and found partial orders */
+    const std::map<std::string,NumericType> reactants_orders() const;
 
-         /*! return a map between products' name and found partial orders */
-         const std::map<std::string,NumericType> products_orders() const;
+    /*! return a map between products' name and found partial orders */
+    const std::map<std::string,NumericType> products_orders() const;
 
-         /*! return true if the concerned reaction rate is the low pressure limit
-          *
-          * In the case of falloff reactions, there is the attribute "name" to
-          * specify which rate constant is the low pressure limit.  This attribute
-          * should have "k0" as value, and nothing else.
-          *
-          * If no "name" attribute is provided, the first rate constant is the low
-          * pressure limit, if two "name" attribute are provided, or if the value
-          * is not "k0", an exception is thrown.
-          */
-         bool is_k0(unsigned int nrc, const std::string & kin_model) const;
+    /*! return true if the concerned reaction rate is the low pressure limit
+     *
+     * In the case of falloff reactions, there is the attribute "name" to
+     * specify which rate constant is the low pressure limit.  This attribute
+     * should have "k0" as value, and nothing else.
+     *
+     * If no "name" attribute is provided, the first rate constant is the low
+     * pressure limit, if two "name" attribute are provided, or if the value
+     * is not "k0", an exception is thrown.
+     */
+    bool is_k0(unsigned int nrc, const std::string & kin_model) const;
 
-         /*! return index of k0 (0 or 1)*/
-         unsigned int where_is_k0(const std::string & kin_model) const;
+    /*! return index of k0 (0 or 1)*/
+    unsigned int where_is_k0(const std::string & kin_model) const;
 
-         /*! return true if pre exponentiel coefficient*/
-         bool rate_constant_preexponential_parameter(    NumericType & A,    std::string & A_unit,    std::string & def_unit) const;
+    /*! return true if pre exponentiel coefficient*/
+    bool rate_constant_preexponential_parameter( NumericType & A,
+                                                 std::string & A_unit,
+                                                 std::string & def_unit) const;
 
-         /*! return true if beta coefficient*/
-         bool rate_constant_power_parameter(             NumericType & b,    std::string & b_unit,    std::string & def_unit) const;
+    /*! return true if beta coefficient*/
+    bool rate_constant_power_parameter( NumericType & b,
+                                        std::string & b_unit,
+                                        std::string & def_unit ) const;
 
-         /*! return true if activation energie*/
-         bool rate_constant_activation_energy_parameter(NumericType & Ea,   std::string & Ea_unit,   std::string & def_unit) const;
+    /*! return true if activation energie*/
+    bool rate_constant_activation_energy_parameter( NumericType & Ea,
+                                                    std::string & Ea_unit,
+                                                    std::string & def_unit ) const;
 
-         /*! return true if D coefficient*/
-         bool rate_constant_Berthelot_coefficient_parameter(NumericType & D,    std::string & D_unit,    std::string & def_unit) const;
+    /*! return true if D coefficient*/
+    bool rate_constant_Berthelot_coefficient_parameter( NumericType & D,
+                                                        std::string & D_unit,
+                                                        std::string & def_unit ) const;
 
-         /*! return true if Tref*/
-         bool rate_constant_Tref_parameter(              NumericType & Tref, std::string & Tref_unit, std::string & def_unit) const;
+    /*! return true if Tref*/
+    bool rate_constant_Tref_parameter( NumericType & Tref,
+                                       std::string & Tref_unit,
+                                       std::string & def_unit ) const;
 
-         /*! return true if lambda*/
-         bool rate_constant_lambda_parameter(       std::vector<NumericType> & lambda, std::string & lambda_unit, std::string & def_unit) const;
+    /*! return true if lambda*/
+    bool rate_constant_lambda_parameter( std::vector<NumericType> & lambda,
+                                         std::string & lambda_unit,
+                                         std::string & def_unit ) const;
 
-         /*! return true if sigma*/
-         bool rate_constant_cross_section_parameter(std::vector<NumericType> & sigma,  std::string & sigma_unit,  std::string & def_unit) const;
+    /*! return true if sigma*/
+    bool rate_constant_cross_section_parameter( std::vector<NumericType> & sigma,
+                                                std::string & sigma_unit,
+                                                std::string & def_unit ) const;
 
-         /*! return true if a Kooij is called Arrhenuis*/
-         bool verify_Kooij_in_place_of_Arrhenius() const;
+    /*! return true if a Kooij is called Arrhenuis*/
+    bool verify_Kooij_in_place_of_Arrhenius() const;
 
-         /*! return true if efficiencies are found*/
-         bool efficiencies(std::vector<std::pair<std::string,NumericType> > & par_values) const;
+    /*! return true if efficiencies are found*/
+    bool efficiencies(std::vector<std::pair<std::string,NumericType> > & par_values) const;
 
-         /*! return true if alpha*/
-         bool Troe_alpha_parameter(NumericType & alpha, std::string & alpha_unit, std::string & def_unit) const;
+    /*! return true if alpha*/
+    bool Troe_alpha_parameter( NumericType & alpha, std::string & alpha_unit, std::string & def_unit ) const;
 
-         /*! return true if T1*/
-         bool Troe_T1_parameter(   NumericType & T1,    std::string & T1_unit,    std::string & def_unit) const;
+    /*! return true if T1*/
+    bool Troe_T1_parameter( NumericType & T1,
+                            std::string & T1_unit,
+                            std::string & def_unit ) const;
 
-         /*! return true if T2*/
-         bool Troe_T2_parameter(   NumericType & T2,    std::string & T2_unit,    std::string & def_unit) const;
+    /*! return true if T2*/
+    bool Troe_T2_parameter( NumericType & T2,
+                            std::string & T2_unit,
+                            std::string & def_unit ) const;
 
-         /*! return true if T3*/
-         bool Troe_T3_parameter(   NumericType & T3,    std::string & T3_unit,    std::string & def_unit) const;
+    /*! return true if T3*/
+    bool Troe_T3_parameter( NumericType & T3,
+                            std::string & T3_unit,
+                            std::string & def_unit ) const;
 
-         /*! return true if a Troe parameter in a GRI way*/
-         bool Troe_GRI_parameter(  NumericType & pa,    unsigned int index) const;
+    /*! return true if a Troe parameter in a GRI way*/
+    bool Troe_GRI_parameter( NumericType & pa, unsigned int index ) const;
 
-        private:
+  private:
 
-         //! reads the thermo, NASA generalist
-         template <typename ThermoType>
-         void read_thermodynamic_data_root(ThermoType & thermo);
+    //! reads the thermo, NASA generalist
+    template <typename ThermoType>
+    void read_thermodynamic_data_root(ThermoType & thermo);
 
-         /*! return pairs of molecules and stoichiometric coefficients*/
-         template <typename PairedType>
-         bool molecules_pairs(tinyxml2::XMLElement * molecules, std::vector<std::pair<std::string,PairedType> > & products_pair) const;
+    /*! return pairs of molecules and stoichiometric coefficients*/
+    template <typename PairedType>
+    bool molecules_pairs(tinyxml2::XMLElement * molecules,
+                         std::vector<std::pair<std::string,PairedType> > & products_pair) const;
 
-         /*! return a parameter's value*/
-         bool get_parameter(const tinyxml2::XMLElement * ptr, const std::string & par, NumericType & par_value, std::string & par_unit) const;
+    /*! return a parameter's value*/
+    bool get_parameter(const tinyxml2::XMLElement * ptr,
+                       const std::string & par,
+                       NumericType & par_value,
+                       std::string & par_unit) const;
 
-         /*! return a parameter's values*/
-         bool get_parameter(const tinyxml2::XMLElement * ptr, const std::string & par, std::vector<NumericType> & numpar, std::string & par_unit) const;
+    /*! return a parameter's values*/
+    bool get_parameter(const tinyxml2::XMLElement * ptr,
+                       const std::string & par,
+                       std::vector<NumericType> & numpar,
+                       std::string & par_unit) const;
 
-         /*! return the unit of current pointer*/
-         const std::string unit(tinyxml2::XMLElement * parameter) const;
+    /*! return the unit of current pointer*/
+    const std::string unit(tinyxml2::XMLElement * parameter) const;
 
-          /*! Search the siblings of the element to find the element with the
-              given value for the given attribute. Return pointer to that element. */
+    /*! Search the siblings of the element to find the element with the
+      given value for the given attribute. Return pointer to that element. */
     tinyxml2::XMLElement * find_element_with_attribute( const tinyxml2::XMLElement * element,
                                                         const std::string& elem_name,
                                                         const std::string& attribute,
@@ -239,23 +266,24 @@ namespace Antioch{
     { antioch_error_msg("ERROR: Only supported for NASA7CurveFit and NASA9CurveFit!"); return "";}
 
 
-          /*! Never use default constructor*/
-          XMLParser();
-          tinyxml2::XMLDocument * _doc;
+    /*! Never use default constructor*/
+    XMLParser();
+    tinyxml2::XMLDocument * _doc;
 
-//
-          tinyxml2::XMLElement * _species_block;
-          tinyxml2::XMLElement * _thermo_block;
-          tinyxml2::XMLElement * _reaction_block;
-          tinyxml2::XMLElement * _reaction;
+    //
+    tinyxml2::XMLElement * _species_block;
+    tinyxml2::XMLElement * _thermo_block;
+    tinyxml2::XMLElement * _reaction_block;
+    tinyxml2::XMLElement * _reaction;
 
-          tinyxml2::XMLElement * _rate_constant;
-          tinyxml2::XMLElement * _Troe;
+    tinyxml2::XMLElement * _rate_constant;
+    tinyxml2::XMLElement * _Troe;
 
-          std::map<ParsingKey,std::string> _map;
-          std::map<ParsingKey,std::string> _default_unit;
-// GRI30
-          std::map<GRI30Comp, std::string> _gri_map;
+    std::map<ParsingKey,std::string> _map;
+    std::map<ParsingKey,std::string> _default_unit;
+
+    // GRI30
+    std::map<GRI30Comp, std::string> _gri_map;
 
   };
 

--- a/src/parsing/include/antioch/xml_parser.h
+++ b/src/parsing/include/antioch/xml_parser.h
@@ -32,19 +32,16 @@
 #include "antioch/parser_base.h"
 #include "antioch/parsing_enum.h"
 
+//XML
+#include "antioch/tinyxml2.h"
+
 //C++
 #include <string>
 #include <vector>
 #include <map>
-
-namespace tinyxml2
-{
-  class XMLDocument;
-  class XMLElement;
-}
+#include <memory>
 
 namespace Antioch{
-
 
   template <typename CoeffType>
   class ChemicalMixture;
@@ -80,7 +77,7 @@ namespace Antioch{
   {
   public:
     XMLParser(const std::string &filename, bool verbose = true);
-    ~XMLParser();
+    virtual ~XMLParser() = default;
 
     void change_file(const std::string & filename);
 
@@ -269,7 +266,7 @@ namespace Antioch{
 
     /*! Never use default constructor*/
     XMLParser();
-    tinyxml2::XMLDocument * _doc;
+    std::unique_ptr<tinyxml2::XMLDocument> _doc;
 
     //
     tinyxml2::XMLElement * _species_block;

--- a/src/parsing/include/antioch/xml_parser.h
+++ b/src/parsing/include/antioch/xml_parser.h
@@ -95,7 +95,15 @@ namespace Antioch{
 
     /// species
     //! reads the species set
-    const std::vector<std::string> species_list() ;
+    const std::vector<std::string> species_list();
+
+    //! Query XML file to ascertain if we have a NASA7 or NASA9 curve fit.
+    /*! Returns true if NASA7 and false if NASA9.
+        This will then enable calling the correct version of read_thermodynamic_data.
+        This function will error if neither is found. Also, we only check the first
+        entry - if there is a mixture of NASA7 and NASA9, then read_thermodynamic_data
+        will error; that is, we assume all species use the same kind of NASA curve fit. */
+    bool is_nasa7_curve_fit_type() const;
 
     //! reads the thermo, NASA generalist, no templates for virtual
     void read_thermodynamic_data(NASAThermoMixture<NumericType, NASA7CurveFit<NumericType> >& thermo)

--- a/src/parsing/src/xml_parser.C
+++ b/src/parsing/src/xml_parser.C
@@ -66,7 +66,20 @@ namespace Antioch
 
     if(this->verbose())std::cout << "Having opened file " << filename << std::endl;
 
+    this->init_name_maps();
 
+    this->initialize();
+  }
+
+  template <typename NumericType>
+  XMLParser<NumericType>::~XMLParser()
+  {
+     delete _doc;
+  }
+
+  template <typename NumericType>
+  void XMLParser<NumericType>::init_name_maps()
+  {
     // XML block/section names
     _map[ParsingKey::PHASE_BLOCK]           = "phase";
     _map[ParsingKey::SPECIES_SET]           = "speciesArray";
@@ -135,17 +148,9 @@ namespace Antioch
     _default_unit[ParsingKey::TROE_F_TSSS]           = "K";
 
     //gri30
-     _gri_map[GRI30Comp::FALLOFF]      = "falloff";
-     _gri_map[GRI30Comp::FALLOFF_TYPE] = "type";
-     _gri_map[GRI30Comp::TROE]         = "Troe";
-
-    this->initialize();
-  }
-
-  template <typename NumericType>
-  XMLParser<NumericType>::~XMLParser()
-  {
-     delete _doc;
+    _gri_map[GRI30Comp::FALLOFF]      = "falloff";
+    _gri_map[GRI30Comp::FALLOFF_TYPE] = "type";
+    _gri_map[GRI30Comp::TROE]         = "Troe";
   }
 
   template <typename NumericType>
@@ -876,6 +881,8 @@ namespace Antioch
 
       } // end species loop
   }
+
+
 
   // Instantiate
   ANTIOCH_NUMERIC_TYPE_CLASS_INSTANTIATE(XMLParser);

--- a/src/parsing/src/xml_parser.C
+++ b/src/parsing/src/xml_parser.C
@@ -54,17 +54,7 @@ namespace Antioch
     _rate_constant(NULL),
     _Troe(NULL)
   {
-    if(_doc->LoadFile(filename.c_str()))
-      {
-        std::cerr << "ERROR: unable to load xml file " << filename << std::endl;
-        std::cerr << "Error of tinyxml2 library:\n"
-                  << "\tID = "            << _doc->ErrorID() << "\n"
-                  << "\tError String1 = " << _doc->GetErrorStr1() << "\n"
-                  << "\tError String2 = " << _doc->GetErrorStr2() << std::endl;
-        antioch_error();
-      }
-
-    if(this->verbose())std::cout << "Having opened file " << filename << std::endl;
+    this->open_xml_file(filename);
 
     this->init_name_maps();
 
@@ -148,16 +138,8 @@ namespace Antioch
   }
 
   template <typename NumericType>
-  void XMLParser<NumericType>::change_file(const std::string & filename)
+  void XMLParser<NumericType>::open_xml_file( const std::string & filename )
   {
-    ParserBase<NumericType>::_file = filename;
-    _species_block  = NULL;
-    _reaction_block = NULL;
-    _reaction       = NULL;
-    _rate_constant  = NULL;
-    _Troe           = NULL;
-
-    _doc.reset(new tinyxml2::XMLDocument);
     if(_doc->LoadFile(filename.c_str()))
       {
         std::cerr << "ERROR: unable to load xml file " << filename << std::endl;
@@ -169,6 +151,21 @@ namespace Antioch
       }
 
     if(this->verbose())std::cout << "Having opened file " << filename << std::endl;
+  }
+
+  template <typename NumericType>
+  void XMLParser<NumericType>::change_file(const std::string & filename)
+  {
+    ParserBase<NumericType>::_file = filename;
+    _species_block  = NULL;
+    _reaction_block = NULL;
+    _reaction       = NULL;
+    _rate_constant  = NULL;
+    _Troe           = NULL;
+
+    _doc.reset(new tinyxml2::XMLDocument);
+
+    this->open_xml_file(filename);
 
     this->initialize();
   }

--- a/src/parsing/src/xml_parser.C
+++ b/src/parsing/src/xml_parser.C
@@ -87,6 +87,7 @@ namespace Antioch
     _map[ParsingKey::REACTION]              = "reaction";
     _map[ParsingKey::REVERSIBLE]            = "reversible";
     _map[ParsingKey::ID]                    = "id";
+    _map[ParsingKey::DATASRC]               = "datasrc";
     _map[ParsingKey::EQUATION]              = "equation";
     _map[ParsingKey::CHEMICAL_PROCESS]      = "type";
     _map[ParsingKey::KINETICS_MODEL]        = "rateCoeff";

--- a/src/parsing/src/xml_parser.C
+++ b/src/parsing/src/xml_parser.C
@@ -47,13 +47,13 @@ namespace Antioch
   template <typename NumericType>
   XMLParser<NumericType>::XMLParser(const std::string &filename, bool verbose):
     ParserBase<NumericType>("XML",filename,verbose),
+    _doc(new tinyxml2::XMLDocument),
     _species_block(NULL),
     _reaction_block(NULL),
     _reaction(NULL),
     _rate_constant(NULL),
     _Troe(NULL)
   {
-    _doc = new tinyxml2::XMLDocument;
     if(_doc->LoadFile(filename.c_str()))
       {
         std::cerr << "ERROR: unable to load xml file " << filename << std::endl;
@@ -69,12 +69,6 @@ namespace Antioch
     this->init_name_maps();
 
     this->initialize();
-  }
-
-  template <typename NumericType>
-  XMLParser<NumericType>::~XMLParser()
-  {
-     delete _doc;
   }
 
   template <typename NumericType>
@@ -163,8 +157,7 @@ namespace Antioch
     _rate_constant  = NULL;
     _Troe           = NULL;
 
-    delete _doc;
-    _doc = new tinyxml2::XMLDocument;
+    _doc.reset(new tinyxml2::XMLDocument);
     if(_doc->LoadFile(filename.c_str()))
       {
         std::cerr << "ERROR: unable to load xml file " << filename << std::endl;

--- a/src/parsing/src/xml_parser.C
+++ b/src/parsing/src/xml_parser.C
@@ -860,6 +860,34 @@ namespace Antioch
     return antioch ? antioch : this->Troe_GRI_parameter(T3,1);
   }
 
+  template <typename NumericType>
+  bool XMLParser<NumericType>::is_nasa7_curve_fit_type() const
+  {
+    if(!_thermo_block)
+      antioch_error_msg("ERROR: No "+_map.at(ParsingKey::SPECIES_DATA)+" section found! Cannot parse thermo!");
+
+    // Step to first species block
+    tinyxml2::XMLElement * species_block =
+      _thermo_block->FirstChildElement(_map.at(ParsingKey::SPECIES).c_str());
+
+    if(!species_block)
+      antioch_error_msg("ERROR: No "+_map.at(ParsingKey::SPECIES)+" block found within "+_map.at(ParsingKey::SPECIES_DATA)+" section! Cannot parse thermo!");
+
+    tinyxml2::XMLElement * thermo_subblock = species_block->FirstChildElement(_map.at(ParsingKey::THERMO).c_str());
+    if(!thermo_subblock)
+      antioch_error_msg("ERROR: Could not find thermo block within first species block! Cannot parse thermo!");
+
+    bool is_nasa_7 = false;
+
+    if( thermo_subblock->FirstChildElement(_map.at(ParsingKey::NASA7).c_str()) )
+      is_nasa_7 = true;
+    else if( thermo_subblock->FirstChildElement(_map.at(ParsingKey::NASA9).c_str()) )
+      is_nasa_7 = false;
+    else
+      antioch_error_msg("ERROR: No value key for NASA curve it found in first species section!");
+
+    return is_nasa_7;
+  }
 
   template <typename NumericType>
   template <typename ThermoType>

--- a/src/parsing/src/xml_parser.C
+++ b/src/parsing/src/xml_parser.C
@@ -45,8 +45,27 @@
 namespace Antioch
 {
   template <typename NumericType>
-  XMLParser<NumericType>::XMLParser(const std::string &filename, bool verbose):
-    ParserBase<NumericType>("XML",filename,verbose),
+  XMLParser<NumericType>::XMLParser(const std::string & filename, const std::string & phase_name, bool verbose)
+   : ParserBase<NumericType>("XML",filename,verbose),
+    _doc(new tinyxml2::XMLDocument),
+    _phase(phase_name),
+    _phase_block(NULL),
+    _species_block(NULL),
+    _reaction_block(NULL),
+    _reaction(NULL),
+    _rate_constant(NULL),
+    _Troe(NULL)
+  {
+    this->open_xml_file(filename);
+
+    this->init_name_maps();
+
+    this->initialize();
+  }
+
+  template <typename NumericType>
+  XMLParser<NumericType>::XMLParser(const std::string & filename, bool verbose)
+  : ParserBase<NumericType>("XML",filename,verbose),
     _doc(new tinyxml2::XMLDocument),
     _phase("NONE"),
     _phase_block(NULL),

--- a/src/parsing/src/xml_parser.C
+++ b/src/parsing/src/xml_parser.C
@@ -83,6 +83,7 @@ namespace Antioch
     _map[ParsingKey::NASA9]                 = "NASA9";
 
     // Kinetics parameters
+    _map[ParsingKey::REACTION_SET]          = "reactionArray";
     _map[ParsingKey::REACTION_DATA]         = "reactionData";
     _map[ParsingKey::REACTION]              = "reaction";
     _map[ParsingKey::REVERSIBLE]            = "reversible";

--- a/src/parsing/src/xml_parser.C
+++ b/src/parsing/src/xml_parser.C
@@ -48,12 +48,16 @@ namespace Antioch
   XMLParser<NumericType>::XMLParser(const std::string &filename, bool verbose):
     ParserBase<NumericType>("XML",filename,verbose),
     _doc(new tinyxml2::XMLDocument),
+    _phase("NONE"),
+    _phase_block(NULL),
     _species_block(NULL),
     _reaction_block(NULL),
     _reaction(NULL),
     _rate_constant(NULL),
     _Troe(NULL)
   {
+    antioch_deprecated();
+
     this->open_xml_file(filename);
 
     this->init_name_maps();
@@ -157,6 +161,7 @@ namespace Antioch
   void XMLParser<NumericType>::change_file(const std::string & filename)
   {
     ParserBase<NumericType>::_file = filename;
+    _phase_block    = NULL;
     _species_block  = NULL;
     _reaction_block = NULL;
     _reaction       = NULL;

--- a/test/standard_unit/gri30_xml_parsing_test.C
+++ b/test/standard_unit/gri30_xml_parsing_test.C
@@ -73,11 +73,18 @@ namespace AntiochTesting
     //could add to check all element coefficients
     void check_curve_fits( const Antioch::NASAThermoMixture<Scalar, Antioch::NASA7CurveFit<Scalar> >& nasa_mixture)
     {
-      const Antioch::NASA7CurveFit<Scalar>& H2_curve_fit =  nasa_mixture.curve_fit(0);
-      const Antioch::NASA7CurveFit<Scalar>& N2_curve_fit =  nasa_mixture.curve_fit(47);
+      const Antioch::NASA7CurveFit<Scalar> & H2_curve_fit =
+        nasa_mixture.curve_fit(_H2_species_id);
+
+      const Antioch::NASA7CurveFit<Scalar> & N2_curve_fit =
+        nasa_mixture.curve_fit(_N2_species_id);
+
+      const Antioch::NASA7CurveFit<Scalar> & HCNO_curve_fit =
+        nasa_mixture.curve_fit(_HCNO_species_id);
 
       CPPUNIT_ASSERT_EQUAL( (unsigned int)2, H2_curve_fit.n_intervals() );
       CPPUNIT_ASSERT_EQUAL( (unsigned int)2, N2_curve_fit.n_intervals() );
+      CPPUNIT_ASSERT_EQUAL( (unsigned int)2, HCNO_curve_fit.n_intervals() );
 
       // Check H2 coefficients
       this->check_coefficients( H2_curve_fit.coefficients(0), this->_H2_coeffs_200_1000 );
@@ -86,6 +93,12 @@ namespace AntiochTesting
       // Check N2 coefficients
       this->check_coefficients( N2_curve_fit.coefficients(0), this->_N2_coeffs_300_1000 );
       this->check_coefficients( N2_curve_fit.coefficients(1), this->_N2_coeffs_1000_5000 );
+
+      // Check the bounds on HCNO curve fit since they're non-standard
+      // We don't give access to the temperature bounds, so we just check
+      // that the interval changes when T crosses the critical value
+      CPPUNIT_ASSERT_EQUAL( 0, (int)HCNO_curve_fit.interval(1381.0) );
+      CPPUNIT_ASSERT_EQUAL( 1, (int)HCNO_curve_fit.interval(1383.0) );
     }
 
     void check_coefficients( const Scalar* parsed_coeffs, std::vector<Scalar>& exact_coeffs )

--- a/test/standard_unit/gri30_xml_parsing_test.C
+++ b/test/standard_unit/gri30_xml_parsing_test.C
@@ -33,7 +33,7 @@ namespace AntiochTesting
       this->init_exact_species();
     }
 
- 
+
     void test_gri30_xml()
     {
       std::string thermo_filename = std::string(ANTIOCH_SHARE_XML_INPUT_FILES_SOURCE_PATH)+"gri30.xml";
@@ -43,6 +43,9 @@ namespace AntiochTesting
       std::vector<std::string> species_str_list = xml_parser.species_list();
 
       this->check_species_list(species_str_list);
+
+      // GRI3 is NASA7
+      CPPUNIT_ASSERT( xml_parser.is_nasa7_curve_fit_type() );
 
       Antioch::ChemicalMixture<Scalar> chem_mixture( species_str_list );
       Antioch::NASAThermoMixture<Scalar, Antioch::NASA7CurveFit<Scalar> > nasa_mixture( chem_mixture );
@@ -322,7 +325,7 @@ namespace AntiochTesting
   };
 
 
-  
+
 
 #define DEFINE_GRI30XMLPARSING_SCALAR_TEST(Classname,BaseClass,Scalar)  \
   class Classname : public BaseClass<Scalar>                            \

--- a/test/standard_unit/gri30_xml_parsing_test.C
+++ b/test/standard_unit/gri30_xml_parsing_test.C
@@ -49,11 +49,11 @@ namespace AntiochTesting
 
       //xml_parser.read_thermodynamic_data(nasa_mixture);
       Antioch::read_nasa_mixture_data( nasa_mixture, thermo_filename, Antioch::XML );
+      this->check_curve_fits(nasa_mixture);
 
       Antioch::ReactionSet<Scalar> reaction_set( chem_mixture );
       Antioch::read_reaction_set_data_xml<Scalar>(thermo_filename, true, reaction_set);
-
-      this->check_curve_fits(nasa_mixture);
+      this->check_reaction_set(reaction_set);
      }
 
     void check_species_list(const std::vector<std::string> & species_list)
@@ -109,6 +109,12 @@ namespace AntiochTesting
 
     Scalar tol()
     { return std::numeric_limits<Scalar>::epsilon() * 10; }
+
+    void check_reaction_set( const Antioch::ReactionSet<Scalar> & reaction_set )
+    {
+      CPPUNIT_ASSERT_EQUAL( (int)_species_exact.size(), (int)reaction_set.n_species() );
+      CPPUNIT_ASSERT_EQUAL( 325, (int)reaction_set.n_reactions() );
+    }
 
   protected:
 

--- a/test/standard_unit/gri30_xml_parsing_test.C
+++ b/test/standard_unit/gri30_xml_parsing_test.C
@@ -36,10 +36,14 @@ namespace AntiochTesting
  
     void test_gri30_xml()
     {
-      std::string thermo_filename = std::string(ANTIOCH_SHARE_XML_INPUT_FILES_SOURCE_PATH)+"gri30.xml";      
-      Antioch::XMLParser<Scalar> xml_parser(thermo_filename,false);
+      std::string thermo_filename = std::string(ANTIOCH_SHARE_XML_INPUT_FILES_SOURCE_PATH)+"gri30.xml";
+      const std::string phase("gri30_mix");
+
+      Antioch::XMLParser<Scalar> xml_parser(thermo_filename,phase,false);
       std::vector<std::string> species_str_list = xml_parser.species_list();
-      
+
+      this->check_species_list(species_str_list);
+
       Antioch::ChemicalMixture<Scalar> chem_mixture( species_str_list );
       Antioch::NASAThermoMixture<Scalar, Antioch::NASA7CurveFit<Scalar> > nasa_mixture( chem_mixture );
 
@@ -51,8 +55,22 @@ namespace AntiochTesting
 
       this->check_curve_fits(nasa_mixture);
      }
-    
-    //could add to check all element coefficients 
+
+    void check_species_list(const std::vector<std::string> & species_list)
+    {
+      CPPUNIT_ASSERT_EQUAL(_species_exact.size(), species_list.size());
+
+      // Check that these particular species are where they are supposed to be
+      // since we check them in the thermo part as well
+      CPPUNIT_ASSERT_EQUAL( std::string("H2"), species_list[_H2_species_id] );
+      CPPUNIT_ASSERT_EQUAL( std::string("N2"), species_list[_N2_species_id] );
+      CPPUNIT_ASSERT_EQUAL( std::string("HCNO"), species_list[_HCNO_species_id] );
+
+      for( unsigned int s = 0; s < _species_exact.size(); s++ )
+        CPPUNIT_ASSERT_EQUAL( _species_exact[s], species_list[s] );
+    }
+
+    //could add to check all element coefficients
     void check_curve_fits( const Antioch::NASAThermoMixture<Scalar, Antioch::NASA7CurveFit<Scalar> >& nasa_mixture)
     {
       const Antioch::NASA7CurveFit<Scalar>& H2_curve_fit =  nasa_mixture.curve_fit(0);

--- a/test/standard_unit/gri30_xml_parsing_test.C
+++ b/test/standard_unit/gri30_xml_parsing_test.C
@@ -30,6 +30,7 @@ namespace AntiochTesting
     virtual void setUp()
     {
       this->init();
+      this->init_exact_species();
     }
 
  
@@ -77,6 +78,75 @@ namespace AntiochTesting
 
     Scalar tol()
     { return std::numeric_limits<Scalar>::epsilon() * 10; }
+
+  protected:
+
+    std::vector<std::string> _species_exact;
+    unsigned int _H2_species_id;
+    unsigned int _N2_species_id;
+    unsigned int _HCNO_species_id;
+
+    void init_exact_species()
+    {
+      _H2_species_id = 0;
+      _N2_species_id = 47;
+      _HCNO_species_id = 43;
+
+      _species_exact.reserve(53);
+      _species_exact.push_back("H2");
+      _species_exact.push_back("H");
+      _species_exact.push_back("O");
+      _species_exact.push_back("O2");
+      _species_exact.push_back("OH");
+      _species_exact.push_back("H2O");
+      _species_exact.push_back("HO2");
+      _species_exact.push_back("H2O2");
+      _species_exact.push_back("C");
+      _species_exact.push_back("CH");
+      _species_exact.push_back("CH2");
+      _species_exact.push_back("CH2(S)");
+      _species_exact.push_back("CH3");
+      _species_exact.push_back("CH4");
+      _species_exact.push_back("CO");
+      _species_exact.push_back("CO2");
+      _species_exact.push_back("HCO");
+      _species_exact.push_back("CH2O");
+      _species_exact.push_back("CH2OH");
+      _species_exact.push_back("CH3O");
+      _species_exact.push_back("CH3OH");
+      _species_exact.push_back("C2H");
+      _species_exact.push_back("C2H2");
+      _species_exact.push_back("C2H3");
+      _species_exact.push_back("C2H4");
+      _species_exact.push_back("C2H5");
+      _species_exact.push_back("C2H6");
+      _species_exact.push_back("HCCO");
+      _species_exact.push_back("CH2CO");
+      _species_exact.push_back("HCCOH");
+      _species_exact.push_back("N");
+      _species_exact.push_back("NH");
+      _species_exact.push_back("NH2");
+      _species_exact.push_back("NH3");
+      _species_exact.push_back("NNH");
+      _species_exact.push_back("NO");
+      _species_exact.push_back("NO2");
+      _species_exact.push_back("N2O");
+      _species_exact.push_back("HNO");
+      _species_exact.push_back("CN");
+      _species_exact.push_back("HCN");
+      _species_exact.push_back("H2CN");
+      _species_exact.push_back("HCNN");
+      _species_exact.push_back("HCNO");
+      _species_exact.push_back("HOCN");
+      _species_exact.push_back("HNCO");
+      _species_exact.push_back("NCO");
+      _species_exact.push_back("N2");
+      _species_exact.push_back("AR");
+      _species_exact.push_back("C3H7");
+      _species_exact.push_back("C3H8");
+      _species_exact.push_back("CH2CHO");
+      _species_exact.push_back("CH3CHO");
+    }
 
   };
 

--- a/test/standard_unit/nasa_mixture_xml_parsing_test.C
+++ b/test/standard_unit/nasa_mixture_xml_parsing_test.C
@@ -59,12 +59,15 @@ namespace AntiochTesting
       species_str_list[0] = "N2";
       species_str_list[1] = "NO2";
 
+      std::string filename = std::string(ANTIOCH_SHARE_XML_INPUT_FILES_SOURCE_PATH)+"nasa9_thermo.xml";
+
+      Antioch::XMLParser<Scalar> xml_parser(filename,"NOPHASEINTHISFILE",false);
+      CPPUNIT_ASSERT( !xml_parser.is_nasa7_curve_fit_type() );
+
       Antioch::ChemicalMixture<Scalar> chem_mixture( species_str_list );
       Antioch::NASAThermoMixture<Scalar, Antioch::NASA9CurveFit<Scalar> > nasa_mixture( chem_mixture );
 
-      std::string filename = std::string(ANTIOCH_SHARE_XML_INPUT_FILES_SOURCE_PATH)+"nasa9_thermo.xml";
-
-      Antioch::read_nasa_mixture_data( nasa_mixture, filename, Antioch::XML );
+      xml_parser.read_thermodynamic_data(nasa_mixture);
 
       const Antioch::NASA9CurveFit<Scalar>& N2_curve_fit =  nasa_mixture.curve_fit(0);
       const Antioch::NASA9CurveFit<Scalar>& NO2_curve_fit =  nasa_mixture.curve_fit(1);


### PR DESCRIPTION
Should be merged after #254.

Closes #251.

Added function that queries the XML file. We just look at the first species and check for the key for NASA7 or NASA9 and error if it's not one of the two. We rely on the subsequent parsing of the thermo during the `read_thermodynamic_data` call to catch inconsistent/mixed use of NASA7 and NASA9. There is unit testing of both NASA7 and NASA9 cases.