### PR TITLE
Add IdealGasThermo, Deprecate IdealGasMicroThermo

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -134,6 +134,7 @@ pkginclude_HEADERS += thermo/include/antioch/cea_evaluator.h
 pkginclude_HEADERS += thermo/include/antioch/stat_mech_thermo.h
 pkginclude_HEADERS += thermo/include/antioch/ideal_gas_micro_thermo.h
 pkginclude_HEADERS += thermo/include/antioch/macro_micro_thermo_base.h
+pkginclude_HEADERS += thermo/include/antioch/ideal_gas_thermo.h
 
 # transport
 pkginclude_HEADERS += transport/include/antioch/mixture_transport_base.h

--- a/src/thermo/include/antioch/ideal_gas_micro_thermo.h
+++ b/src/thermo/include/antioch/ideal_gas_micro_thermo.h
@@ -36,6 +36,7 @@ namespace Antioch
   template <typename CoeffType>
   class TempCache;
 
+  //! Deprecated, prefer IdealGasThermo class
   template <typename MacroThermo, typename CoeffType = double>
   class IdealGasMicroThermo : public MacroMicroThermoBase<CoeffType,IdealGasMicroThermo<MacroThermo,CoeffType> >
   {
@@ -44,7 +45,7 @@ namespace Antioch
     IdealGasMicroThermo(const MacroThermo & ext_thermo, const ChemicalMixture<CoeffType> & chem_mix)
       : MacroMicroThermoBase<CoeffType,IdealGasMicroThermo<MacroThermo,CoeffType> >(chem_mix),
       _ext_therm(ext_thermo)
-    {}
+    {antioch_deprecated();}
 
     virtual ~IdealGasMicroThermo(){}
 

--- a/src/thermo/include/antioch/ideal_gas_thermo.h
+++ b/src/thermo/include/antioch/ideal_gas_thermo.h
@@ -1,0 +1,95 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// Antioch - A Gas Dynamics Thermochemistry Library
+//
+// Copyright (C) 2014-2016 Paul T. Bauman, Benjamin S. Kirk,
+//                         Sylvain Plessis, Roy H. Stonger
+//
+// Copyright (C) 2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef ANTIOCH_IDEAL_GAS_THERMO_H
+#define ANTIOCH_IDEAL_GAS_THERMO_H
+
+// Antioch
+#include "antioch/macro_micro_thermo_base.h"
+#include "antioch/nasa_mixture.h"
+
+namespace Antioch
+{
+
+  template <typename CoeffType>
+  class TempCache;
+
+  //! Statistical thermodynamics quantities for ideal gas
+  /*! In this model, we assume that vibrational states are only partially populated and
+      there's no population of electronic states. We use the provided NASAThermoMixture
+      to compute the total cv and then cv_vib = cv - cv_trans - cv_rotational; for atomic
+      species, we just return 0. This model is typically used in combustion settings,
+      for example. */
+  template <typename NASACurveFit, typename CoeffType = double>
+  class IdealGasThermo : public MacroMicroThermoBase<CoeffType,IdealGasThermo<NASACurveFit,CoeffType> >
+  {
+  public:
+
+    IdealGasThermo(const NASAThermoMixture<CoeffType,NASACurveFit> & nasa_mixture,
+                   const ChemicalMixture<CoeffType> & chem_mix)
+      : MacroMicroThermoBase<CoeffType,IdealGasThermo<NASACurveFit,CoeffType> >(chem_mix),
+      _nasa_evaluator(nasa_mixture)
+    {}
+
+    virtual ~IdealGasThermo() = default;
+
+    // Friend the base class so we can make the CRTP implementation functions
+    // private.
+    friend class  MacroMicroThermoBase<CoeffType,IdealGasThermo<NASACurveFit,CoeffType> >;
+
+  private:
+
+    NASAEvaluator<CoeffType,NASACurveFit> _nasa_evaluator;
+
+    //! Implementation of species vibrational specific heat, [J/kg-K]
+    template <typename StateType>
+    const ANTIOCH_AUTO(StateType)
+    cv_vib_impl(unsigned int s, const StateType & T) const
+    ANTIOCH_AUTOFUNC(StateType, (this->_chem_mixture.chemical_species()[s]->n_tr_dofs() < CoeffType(2.))
+                                ? zero_clone(T) : _nasa_evaluator.cv(TempCache<StateType>(T),s) - this->cv_tr(s) )
+
+    //! Implementation of normalized species vibrational specific heat.
+    template <typename StateType>
+    const ANTIOCH_AUTO(StateType)
+    cv_vib_over_R_impl(unsigned int s, const StateType & T) const
+    ANTIOCH_AUTOFUNC(StateType, (this->_chem_mixture.chemical_species()[s]->n_tr_dofs() < CoeffType(2.))
+                                ? zero_clone(T) :  _nasa_evaluator.cv_over_R(TempCache<StateType>(T),s) - this->cv_tr_over_R(s) )
+
+    //! Implementation of species electronic specific heat, [J/kg-K]
+    /*! For this class, we assume there is no population of electronic states, so cv_el is
+        just zero. */
+    template<typename StateType>
+    StateType cv_el_impl (const unsigned int /*species*/, const StateType & T) const
+    {
+      return zero_clone(T);
+    }
+
+  };
+
+} // end namespace Antioch
+
+
+#endif // ANTIOCH_IDEAL_GAS_THERMO_H

--- a/src/thermo/include/antioch/macro_micro_thermo_base.h
+++ b/src/thermo/include/antioch/macro_micro_thermo_base.h
@@ -33,6 +33,8 @@
 namespace Antioch
 {
 
+  //! Base class defining API for statistical thermodynamics quantities
+  /*! We use a CRTP pattern here to achieve static polymorphism. */
   template<typename CoeffType, typename Subclass>
   class MacroMicroThermoBase
   {

--- a/test/standard_unit/macro_micro_thermo_test.C
+++ b/test/standard_unit/macro_micro_thermo_test.C
@@ -43,7 +43,7 @@
 
 #include "antioch/chemical_mixture.h"
 #include "antioch/stat_mech_thermo.h"
-#include "antioch/ideal_gas_micro_thermo.h"
+#include "antioch/ideal_gas_thermo.h"
 #include "antioch/nasa_mixture.h"
 #include "antioch/nasa_evaluator.h"
 #include "antioch/nasa7_curve_fit.h"
@@ -678,8 +678,8 @@ namespace AntiochTesting
 
 
   template<typename Scalar, typename NASACurveFit>
-  class IdealGasMicroThermoTestBase :
-    public MacroMicroThermoTestBase<Scalar,Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<Scalar,NASACurveFit>,Scalar> >
+  class IdealGasThermoTestBase :
+    public MacroMicroThermoTestBase<Scalar,Antioch::IdealGasThermo<NASACurveFit,Scalar> >
   {
   public:
 
@@ -745,7 +745,7 @@ namespace AntiochTesting
     {
       Scalar T(1501.2);
 
-      // For IdealGasMicroThermo, none of the electronic modes are populated by assumption.
+      // For IdealGasThermo, none of the electronic modes are populated by assumption.
       Scalar cv_el_exact(0.0);
 
       for( unsigned int s = 0; s < this->_n_species; s++ )
@@ -758,7 +758,7 @@ namespace AntiochTesting
     {
       Scalar T(1501.2);
 
-      // For IdealGasMicroThermo, none of the electronic modes are populated by assumption.
+      // For IdealGasThermo, none of the electronic modes are populated by assumption.
       Scalar cv_el_exact(0.0);
 
       this->test_scalar_rel( cv_el_exact,
@@ -775,17 +775,13 @@ namespace AntiochTesting
 
       this->parse_nasa_coeffs( *(this->_nasa_mixture) );
 
-
-      _nasa_evaluator = new Antioch::NASAEvaluator<Scalar,NASACurveFit>( *(_nasa_mixture) );
-
-      this->_thermo = new Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<Scalar,NASACurveFit>,Scalar>
-        ( *(_nasa_evaluator), *(this->_chem_mixture) );
+      this->_thermo = new Antioch::IdealGasThermo<NASACurveFit,Scalar>
+        ( *(_nasa_mixture), *(this->_chem_mixture) );
     }
 
     void tearDown()
     {
       delete this->_thermo;
-      delete _nasa_evaluator;
       delete _nasa_mixture;
       this->clear();
     }
@@ -793,8 +789,6 @@ namespace AntiochTesting
   protected:
 
     Antioch::NASAThermoMixture<Scalar,NASACurveFit> * _nasa_mixture;
-
-    Antioch::NASAEvaluator<Scalar,NASACurveFit> * _nasa_evaluator;
 
     std::map<std::string,std::vector<Scalar> > _nasa_coeffs_lower_interval;
     std::map<std::string,std::vector<Scalar> > _nasa_coeffs_upper_interval;
@@ -838,8 +832,8 @@ namespace AntiochTesting
   };
 
   template<typename Scalar>
-  class IdealGasMicroThermoTestNASA7Base :
-    public IdealGasMicroThermoTestBase<Scalar,Antioch::NASA7CurveFit<Scalar> >,
+  class IdealGasThermoTestNASA7Base :
+    public IdealGasThermoTestBase<Scalar,Antioch::NASA7CurveFit<Scalar> >,
     public NASA7ThermoTestHelper<Scalar>
   {
   protected:
@@ -941,8 +935,8 @@ namespace AntiochTesting
   };
 
   template<typename Scalar>
-  class IdealGasMicroThermoTestNASA9Base :
-    public IdealGasMicroThermoTestBase<Scalar,Antioch::NASA9CurveFit<Scalar> >,
+  class IdealGasThermoTestNASA9Base :
+    public IdealGasThermoTestBase<Scalar,Antioch::NASA9CurveFit<Scalar> >,
     public NASA9ThermoTestHelper<Scalar>
   {
   protected:
@@ -1074,32 +1068,32 @@ namespace AntiochTesting
     CPPUNIT_TEST_SUITE_END();                                           \
   }
 
-  DEFINE_IDEALGASMICROTHERMO_SCALAR_TEST(IdealGasMicroThermoNASA7FloatTest,
-                                         IdealGasMicroThermoTestNASA7Base,
+  DEFINE_IDEALGASMICROTHERMO_SCALAR_TEST(IdealGasThermoNASA7FloatTest,
+                                         IdealGasThermoTestNASA7Base,
                                          float);
-  DEFINE_IDEALGASMICROTHERMO_SCALAR_TEST(IdealGasMicroThermoNASA7DoubleTest,
-                                         IdealGasMicroThermoTestNASA7Base,
+  DEFINE_IDEALGASMICROTHERMO_SCALAR_TEST(IdealGasThermoNASA7DoubleTest,
+                                         IdealGasThermoTestNASA7Base,
                                          double);
-  DEFINE_IDEALGASMICROTHERMO_SCALAR_TEST(IdealGasMicroThermoNASA7LongDoubleTest,
-                                         IdealGasMicroThermoTestNASA7Base,
+  DEFINE_IDEALGASMICROTHERMO_SCALAR_TEST(IdealGasThermoNASA7LongDoubleTest,
+                                         IdealGasThermoTestNASA7Base,
                                          long double);
 
-  DEFINE_IDEALGASMICROTHERMO_SCALAR_TEST(IdealGasMicroThermoNASA9FloatTest,
-                                         IdealGasMicroThermoTestNASA9Base,
+  DEFINE_IDEALGASMICROTHERMO_SCALAR_TEST(IdealGasThermoNASA9FloatTest,
+                                         IdealGasThermoTestNASA9Base,
                                          float);
-  DEFINE_IDEALGASMICROTHERMO_SCALAR_TEST(IdealGasMicroThermoNASA9DoubleTest,
-                                         IdealGasMicroThermoTestNASA9Base,
+  DEFINE_IDEALGASMICROTHERMO_SCALAR_TEST(IdealGasThermoNASA9DoubleTest,
+                                         IdealGasThermoTestNASA9Base,
                                          double);
-  DEFINE_IDEALGASMICROTHERMO_SCALAR_TEST(IdealGasMicroThermoNASA9LongDoubleTest,
-                                         IdealGasMicroThermoTestNASA9Base,
+  DEFINE_IDEALGASMICROTHERMO_SCALAR_TEST(IdealGasThermoNASA9LongDoubleTest,
+                                         IdealGasThermoTestNASA9Base,
                                          long double);
 
-  CPPUNIT_TEST_SUITE_REGISTRATION( IdealGasMicroThermoNASA7FloatTest );
-  CPPUNIT_TEST_SUITE_REGISTRATION( IdealGasMicroThermoNASA7DoubleTest );
-  CPPUNIT_TEST_SUITE_REGISTRATION( IdealGasMicroThermoNASA7LongDoubleTest );
-  CPPUNIT_TEST_SUITE_REGISTRATION( IdealGasMicroThermoNASA9FloatTest );
-  CPPUNIT_TEST_SUITE_REGISTRATION( IdealGasMicroThermoNASA9DoubleTest );
-  CPPUNIT_TEST_SUITE_REGISTRATION( IdealGasMicroThermoNASA9LongDoubleTest );
+  CPPUNIT_TEST_SUITE_REGISTRATION( IdealGasThermoNASA7FloatTest );
+  CPPUNIT_TEST_SUITE_REGISTRATION( IdealGasThermoNASA7DoubleTest );
+  CPPUNIT_TEST_SUITE_REGISTRATION( IdealGasThermoNASA7LongDoubleTest );
+  CPPUNIT_TEST_SUITE_REGISTRATION( IdealGasThermoNASA9FloatTest );
+  CPPUNIT_TEST_SUITE_REGISTRATION( IdealGasThermoNASA9DoubleTest );
+  CPPUNIT_TEST_SUITE_REGISTRATION( IdealGasThermoNASA9LongDoubleTest );
 
 } // end namespace AntiochTesting
 


### PR DESCRIPTION
Closes #257.

Functionally, the classes do the same computations, but construction API makes much more sense for the user in `IdealGasThermo` vs `IdealGasMicroThermo`.

I'd like to use this in grinsfem/grins ASAP, so would like to merge quickly.