### PR TITLE
XML Parsing for TransportMixture

### DIFF
--- a/src/parsing/include/antioch/parsing_enum.h
+++ b/src/parsing/include/antioch/parsing_enum.h
@@ -73,7 +73,14 @@ namespace Antioch
                   TROE_F_ALPHA,
                   TROE_F_TS,
                   TROE_F_TSS,
-                  TROE_F_TSSS
+                  TROE_F_TSSS,
+//
+                  TRANSPORT,
+                  LJ_WELLDEPTH,
+                  LJ_DIAMETER,
+                  DIPOLE_MOMENT,
+                  POLARIZABILITY,
+                  ROT_RELAX
                  };
 
 // GRI30 compatibility

--- a/src/parsing/include/antioch/xml_parser.h
+++ b/src/parsing/include/antioch/xml_parser.h
@@ -118,6 +118,8 @@ namespace Antioch{
     {antioch_error_msg("ERROR: XML Parsing only supports parsing for NASA7CurveFit and NASA9CurveFit!");}
 
 
+    virtual void read_transport_data(TransportMixture<NumericType> & transport_mixture);
+
     /// reaction
 
     /*! go to next reaction*/

--- a/src/parsing/include/antioch/xml_parser.h
+++ b/src/parsing/include/antioch/xml_parser.h
@@ -235,6 +235,14 @@ namespace Antioch{
 
   private:
 
+    //! Read the transport property given by the particular ParsingKey
+    /*! Currently, we don't support unit conversion for these properties,
+        so we just error out if the specified units aren't what we expected. */
+    NumericType read_transport_property(const std::string & species_name,
+                                        tinyxml2::XMLElement * species_elem,
+                                        ParsingKey key,
+                                        const std::string & expected_unit);
+
     //! reads the thermo, NASA generalist
     template <typename ThermoType>
     void read_thermodynamic_data_root(ThermoType & thermo);

--- a/src/parsing/src/xml_parser.C
+++ b/src/parsing/src/xml_parser.C
@@ -1002,6 +1002,46 @@ namespace Antioch
   }
 
 
+  template <typename NumericType>
+  NumericType XMLParser<NumericType>::read_transport_property(const std::string & species_name,
+                                                              tinyxml2::XMLElement * species_elem,
+                                                              ParsingKey key,
+                                                              const std::string & expected_unit)
+  {
+    antioch_assert(species_elem);
+
+    // Copy pointer so we don't muck where this is pointing
+    tinyxml2::XMLElement * data = species_elem;
+
+    data = species_elem->FirstChildElement(_map.at(key).c_str());
+
+    if(!data)
+       antioch_error_msg("ERROR: NO "+_map.at(key)+" block found for species "+species_name+"! Cannot parse transport!");
+
+    const char * unit = data->Attribute(_map.at(ParsingKey::UNIT).c_str());
+
+    // There's no unit, then either we're dimensionless (and expected_unit should be empty
+    // or it's an error because it's not supposed to be dimensionless
+    if(!unit)
+      {
+        if(!expected_unit.empty() )
+          antioch_error_msg("ERROR: No unit specified for "+_map.at(key)+" block for species "+species_name+", but expected a unit of "+expected_unit+"!\n");
+      }
+    else
+      {
+        std::string parsed_unit(data->Attribute(_map.at(ParsingKey::UNIT).c_str()));
+
+        if( expected_unit.empty() )
+          antioch_error_msg("ERROR: Unit of " " specified for "+_map.at(key)+" block for species "+species_name+", but expected a unit of "+expected_unit+"!\n");
+
+        if( parsed_unit != expected_unit )
+          antioch_error_msg("ERROR: Specified unit for "+_map.at(key)+" block for species "+species_name+" was "+parsed_unit+", but we expected units of "+expected_unit+"!\n");
+      }
+
+    NumericType value = string_to_T<NumericType>(data->GetText());
+
+    return value;
+  }
 
   // Instantiate
   ANTIOCH_NUMERIC_TYPE_CLASS_INSTANTIATE(XMLParser);

--- a/src/parsing/src/xml_parser.C
+++ b/src/parsing/src/xml_parser.C
@@ -132,6 +132,14 @@ namespace Antioch
     _map[ParsingKey::TROE_F_TSS]            = "T2";
     _map[ParsingKey::TROE_F_TSSS]           = "T3";
 
+    // Transport
+    _map[ParsingKey::TRANSPORT]             = "transport";
+    _map[ParsingKey::LJ_WELLDEPTH]          = "LJ_welldepth";
+    _map[ParsingKey::LJ_DIAMETER]           = "LJ_diameter";
+    _map[ParsingKey::DIPOLE_MOMENT]         = "dipoleMoment";
+    _map[ParsingKey::POLARIZABILITY]        = "polarizability";
+    _map[ParsingKey::ROT_RELAX]             = "rotRelax";
+
     // typically Cantera files list
     //      pre-exponential parameters in (m3/kmol)^(m-1)/s
     //      activation energy in cal/mol, but we want it in K.

--- a/src/parsing/src/xml_parser.C
+++ b/src/parsing/src/xml_parser.C
@@ -34,6 +34,7 @@
 #include "antioch/nasa_mixture.h"
 #include "antioch/cea_curve_fit.h"
 #include "antioch/nasa7_curve_fit.h"
+#include "antioch/transport_mixture.h"
 
 //XML
 #include "antioch/tinyxml2_imp.h"
@@ -1001,6 +1002,64 @@ namespace Antioch
       } // end species loop
   }
 
+  template <typename NumericType>
+  void XMLParser<NumericType>::read_transport_data(TransportMixture<NumericType> & transport_mixture)
+  {
+    // The _thermo_block points to the beginning of the relevant speciesData section
+    if(!_thermo_block)
+      antioch_error_msg("ERROR: No "+_map.at(ParsingKey::SPECIES_DATA)+" section found! Cannot parse transport!");
+
+    const ChemicalMixture<NumericType> & chem_mixture = transport_mixture.chemical_mixture();
+    const std::vector<ChemicalSpecies<NumericType>*> & chem_species = chem_mixture.chemical_species();
+
+    // Step to first species block
+    tinyxml2::XMLElement * species_block =
+      _thermo_block->FirstChildElement(_map.at(ParsingKey::SPECIES).c_str());
+
+    if(!species_block)
+      antioch_error_msg("ERROR: No "+_map.at(ParsingKey::SPECIES)+" block found within "+_map.at(ParsingKey::SPECIES_DATA)+" section! Cannot parse transport!");
+
+    // Now go through each species in our mixture, parse the transport data and add the
+    // species to our transport mixture
+    for(unsigned int s = 0; s < chem_mixture.n_species(); s++)
+      {
+        const std::string & name = chem_species[s]->species();
+
+        tinyxml2::XMLElement * species = nullptr;
+        species = this->find_element_with_attribute( species_block,
+                                                     _map.at(ParsingKey::SPECIES),
+                                                     "name",
+                                                     name );
+
+        if(!species)
+          antioch_error_msg("ERROR: Species "+name+" has not been found in the "+_map.at(ParsingKey::SPECIES_DATA)+" section! Cannot parse transport!");
+
+        species = species->FirstChildElement(_map.at(ParsingKey::TRANSPORT).c_str());
+
+        if(!species)
+          antioch_error_msg("ERROR: No "+_map.at(ParsingKey::TRANSPORT)+" block found for species "+name+"! Cannot parse transport!");
+
+        // The number of transport numbers we are reading
+        // 0 --> LJ_welldepth
+        // 1 --> LJ_diameter
+        // 2 --> dipoleMoment
+        // 3 --> polarizability
+        // 4 --> rotRelax
+        const unsigned int n_data = 5;
+        std::vector<NumericType> data(n_data);
+
+        data[0] = this->read_transport_property(name,species,ParsingKey::LJ_WELLDEPTH,"K");
+        data[1] = this->read_transport_property(name,species,ParsingKey::LJ_DIAMETER,"A");
+        data[2] = this->read_transport_property(name,species,ParsingKey::DIPOLE_MOMENT,"Debye");
+        data[3] = this->read_transport_property(name,species,ParsingKey::POLARIZABILITY,"A3");
+        data[4] = this->read_transport_property(name,species,ParsingKey::ROT_RELAX,"");
+
+        unsigned int species_idx = chem_mixture.species_name_map().at(name);
+        NumericType species_molar_mass = chem_mixture.M(species_idx);
+
+        transport_mixture.add_species(species_idx,data[0],data[1],data[2],data[3],data[4],species_molar_mass);
+      }
+  }
 
   template <typename NumericType>
   NumericType XMLParser<NumericType>::read_transport_property(const std::string & species_name,

--- a/test/standard_unit/gri30_xml_parsing_test.C
+++ b/test/standard_unit/gri30_xml_parsing_test.C
@@ -36,10 +36,10 @@ namespace AntiochTesting
 
     void test_gri30_xml()
     {
-      std::string thermo_filename = std::string(ANTIOCH_SHARE_XML_INPUT_FILES_SOURCE_PATH)+"gri30.xml";
+      std::string filename = std::string(ANTIOCH_SHARE_XML_INPUT_FILES_SOURCE_PATH)+"gri30.xml";
       const std::string phase("gri30_mix");
 
-      Antioch::XMLParser<Scalar> xml_parser(thermo_filename,phase,false);
+      Antioch::XMLParser<Scalar> xml_parser(filename,phase,false);
       std::vector<std::string> species_str_list = xml_parser.species_list();
 
       this->check_species_list(species_str_list);
@@ -51,11 +51,11 @@ namespace AntiochTesting
       Antioch::NASAThermoMixture<Scalar, Antioch::NASA7CurveFit<Scalar> > nasa_mixture( chem_mixture );
 
       //xml_parser.read_thermodynamic_data(nasa_mixture);
-      Antioch::read_nasa_mixture_data( nasa_mixture, thermo_filename, Antioch::XML );
+      Antioch::read_nasa_mixture_data( nasa_mixture, filename, Antioch::XML );
       this->check_curve_fits(nasa_mixture);
 
       Antioch::ReactionSet<Scalar> reaction_set( chem_mixture );
-      Antioch::read_reaction_set_data_xml<Scalar>(thermo_filename, true, reaction_set);
+      Antioch::read_reaction_set_data_xml<Scalar>(filename, true, reaction_set);
       this->check_reaction_set(reaction_set);
      }
 

--- a/test/standard_unit/gri30_xml_parsing_test.C
+++ b/test/standard_unit/gri30_xml_parsing_test.C
@@ -18,6 +18,7 @@
 #include "antioch/xml_parser.h"
 #include "antioch/reaction_set.h"
 #include "antioch/read_reaction_set_data.h"
+#include "antioch/transport_mixture.h"
 
 namespace AntiochTesting
 {
@@ -57,6 +58,9 @@ namespace AntiochTesting
       Antioch::ReactionSet<Scalar> reaction_set( chem_mixture );
       Antioch::read_reaction_set_data_xml<Scalar>(filename, true, reaction_set);
       this->check_reaction_set(reaction_set);
+
+      Antioch::TransportMixture<Scalar> trans_mixture( chem_mixture, &xml_parser );
+      this->check_transport_mixture(trans_mixture);
      }
 
     void check_species_list(const std::vector<std::string> & species_list)
@@ -249,6 +253,54 @@ namespace AntiochTesting
               // Default should be 1.0
               CPPUNIT_ASSERT_DOUBLES_EQUAL(1.0, efficiency, this->tol());
           }
+      }
+
+    }
+
+    void check_transport_mixture( const Antioch::TransportMixture<Scalar> & trans_mixture )
+    {
+      CPPUNIT_ASSERT_EQUAL( (int)_species_exact.size(), (int)trans_mixture.n_species() );
+
+
+      // H2
+      {
+        const Antioch::TransportSpecies<Scalar> & trans_species =
+          trans_mixture.transport_species(_H2_species_id);
+
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(38.000, trans_species.LJ_depth(), this->tol() );
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(2.920, trans_species.LJ_diameter(), this->tol() );
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(0., trans_species.dipole_moment(), this->tol() );
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(0.790, trans_species.polarizability(), this->tol() );
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(280.000, trans_species.rotational_relaxation(), this->tol() );
+
+      }
+
+      // N2
+      {
+        const Antioch::TransportSpecies<Scalar> & trans_species =
+          trans_mixture.transport_species(_N2_species_id);
+
+        // For floats, we don't get padded zeros, so we lose a little tolerance in the test
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(97.530, trans_species.LJ_depth(), this->tol()*2 );
+
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(3.620, trans_species.LJ_diameter(), this->tol() );
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(0., trans_species.dipole_moment(), this->tol() );
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(1.760, trans_species.polarizability(), this->tol() );
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(4., trans_species.rotational_relaxation(), this->tol() );
+      }
+
+      // HCNO
+      {
+        const Antioch::TransportSpecies<Scalar> & trans_species =
+          trans_mixture.transport_species(_HCNO_species_id);
+
+        // For floats, we don't get padded zeros, so we lose a little tolerance in the test
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(232.4, trans_species.LJ_depth(), this->tol()*10 );
+
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(3.83, trans_species.LJ_diameter(), this->tol() );
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(0., trans_species.dipole_moment(), this->tol() );
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(0., trans_species.polarizability(), this->tol() );
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(1., trans_species.rotational_relaxation(), this->tol() );
       }
 
     }


### PR DESCRIPTION
Closes #249.

Implements parsing for the `TransportMixture` object using our XMLParser. Unit tested on GRI 3.0 XML file. I didn't implement unit conversion here, but at least throw an error if the incorrect unit is specified so we don't get any surprises.