### PR TITLE
Disambiguate custom_clone overloads

### DIFF
--- a/src/utilities/include/antioch/metaprogramming.h
+++ b/src/utilities/include/antioch/metaprogramming.h
@@ -74,7 +74,8 @@ T custom_clone(const T& /*example*/, const VectorScalar& values, unsigned int in
 
 template <typename T, typename VectorScalar>
 inline
-T custom_clone(const T& /*example*/, const VectorScalar& values, const typename Antioch::rebind<T,unsigned int>::type & indexes)
+typename enable_if_c<has_size<T>::value, T>::type
+custom_clone(const T& /*example*/, const VectorScalar& values, const typename Antioch::rebind<T,unsigned int>::type & indexes)
 {
   T returnval(indexes.size()); //bof bof - metaphysicl has size within type, this suppose that size_type<indexes>::type can be changed in value_type<T>::type
 

--- a/src/utilities/include/antioch/metaprogramming_decl.h
+++ b/src/utilities/include/antioch/metaprogramming_decl.h
@@ -184,7 +184,8 @@ namespace Antioch
   // custom constants stored in vector
   template <typename T, typename VectorScalar>
   inline
-  T custom_clone(const T& example, const VectorScalar& values, const typename Antioch::rebind<T,unsigned int>::type & indexes);
+  typename enable_if_c<has_size<T>::value, T>::type
+  custom_clone(const T& example, const VectorScalar& values, const typename Antioch::rebind<T,unsigned int>::type & indexes);
 
   // A function for filling already-initialized vectorized numeric
   // types with a constant.


### PR DESCRIPTION
gcc 8 (at least) realized that the supposed-to-be-for-vectors overload
actually could be applied to scalar T as well.